### PR TITLE
Base: Don't disable network adapter "ep1s0" by default

### DIFF
--- a/Base/etc/Network.ini
+++ b/Base/etc/Network.ini
@@ -1,2 +1,0 @@
-[ep1s0]
-Enabled=false


### PR DESCRIPTION
ddd4547e138 (#13947) added this entry without any reason. Maybe we had multiple network devices at that time?

None of our current default QEMU machines have a network adapter that gets the name "ep1s0", so this went unnoticed.
However, the RP1 chip of the Raspberry Pi 5 has PCI address 1:0.0, causing that network adapter to be disabled. (The RP1 ethernet driver itself is not yet upstream.)