### PR TITLE
Everywhere: Prefer AK::Infinity<T>, AK::NaN<T> over __builtin_huge_val{,f}, __builtin_nan{f,,l}

### DIFF
--- a/AK/FloatingPointStringConversions.cpp
+++ b/AK/FloatingPointStringConversions.cpp
@@ -8,6 +8,7 @@
 #include <AK/CharacterTypes.h>
 #include <AK/FloatingPointStringConversions.h>
 #include <AK/Format.h>
+#include <AK/Math/Constants.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringView.h>
 #include <AK/UFixedBigInt.h>
@@ -1975,7 +1976,7 @@ template<FloatingPoint T>
 constexpr FloatingPointParseResults<T> parse_result_to_full_result(BasicParseResult parse_result)
 {
     if (!parse_result.valid)
-        return { nullptr, FloatingPointError::NoOrInvalidInput, __builtin_nan("") };
+        return { nullptr, FloatingPointError::NoOrInvalidInput, AK::NaN<double> };
 
     FloatingPointParseResults<T> full_result {};
     full_result.end_ptr = parse_result.last_parsed;
@@ -2251,7 +2252,7 @@ FloatingPointParseResults<T> parse_first_hexfloat_until_zero_character(char cons
     auto parse_result = parse_hexfloat(start);
 
     if (!parse_result.valid)
-        return { nullptr, FloatingPointError::NoOrInvalidInput, __builtin_nan("") };
+        return { nullptr, FloatingPointError::NoOrInvalidInput, AK::NaN<double> };
 
     FloatingPointParseResults<T> full_result {};
     full_result.end_ptr = parse_result.last_parsed;

--- a/Tests/AK/TestFloatingPointParsing.cpp
+++ b/Tests/AK/TestFloatingPointParsing.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/FloatingPointStringConversions.h>
+#include <AK/Math/Constants.h>
 
 static double parse_complete_double(StringView view)
 {
@@ -246,13 +247,13 @@ TEST_CASE(simple_cases)
     EXPECT_TO_PARSE_TO_VALUE_EQUAL_TO(0., "+.0e10");
     EXPECT_TO_PARSE_TO_VALUE_EQUAL_TO(-0., "-.0e10");
 
-#define EXPECT_TO_PARSE_TO_INFINITY(str)                                                     \
-    EXPECT_EQ(__builtin_huge_val(), parse_complete_double(str##sv));                         \
-    EXPECT_EQ(__builtin_huge_val(), parse_complete_double("+" str##sv));                     \
-    EXPECT_EQ(-__builtin_huge_val(), parse_complete_double("-" str##sv));                    \
-    EXPECT_EQ(static_cast<float>(__builtin_huge_valf()), parse_complete_float(str##sv));     \
-    EXPECT_EQ(static_cast<float>(__builtin_huge_valf()), parse_complete_float("+" str##sv)); \
-    EXPECT_EQ(static_cast<float>(-__builtin_huge_valf()), parse_complete_float("-" str##sv))
+#define EXPECT_TO_PARSE_TO_INFINITY(str)                                  \
+    EXPECT_EQ(__builtin_huge_val(), parse_complete_double(str##sv));      \
+    EXPECT_EQ(__builtin_huge_val(), parse_complete_double("+" str##sv));  \
+    EXPECT_EQ(-__builtin_huge_val(), parse_complete_double("-" str##sv)); \
+    EXPECT_EQ(AK::Infinity<float>, parse_complete_float(str##sv));        \
+    EXPECT_EQ(AK::Infinity<float>, parse_complete_float("+" str##sv));    \
+    EXPECT_EQ(-AK::Infinity<float>, parse_complete_float("-" str##sv))
 
     EXPECT_TO_PARSE_TO_INFINITY("123.456e789");
     EXPECT_TO_PARSE_TO_INFINITY("123456.456789e789");

--- a/Tests/AK/TestFloatingPointParsing.cpp
+++ b/Tests/AK/TestFloatingPointParsing.cpp
@@ -248,9 +248,9 @@ TEST_CASE(simple_cases)
     EXPECT_TO_PARSE_TO_VALUE_EQUAL_TO(-0., "-.0e10");
 
 #define EXPECT_TO_PARSE_TO_INFINITY(str)                                  \
-    EXPECT_EQ(__builtin_huge_val(), parse_complete_double(str##sv));      \
-    EXPECT_EQ(__builtin_huge_val(), parse_complete_double("+" str##sv));  \
-    EXPECT_EQ(-__builtin_huge_val(), parse_complete_double("-" str##sv)); \
+    EXPECT_EQ(AK::Infinity<double>, parse_complete_double(str##sv));      \
+    EXPECT_EQ(AK::Infinity<double>, parse_complete_double("+" str##sv));  \
+    EXPECT_EQ(-AK::Infinity<double>, parse_complete_double("-" str##sv)); \
     EXPECT_EQ(AK::Infinity<float>, parse_complete_float(str##sv));        \
     EXPECT_EQ(AK::Infinity<float>, parse_complete_float("+" str##sv));    \
     EXPECT_EQ(-AK::Infinity<float>, parse_complete_float("-" str##sv))

--- a/Tests/AK/TestFloatingPointStringConversions.cpp
+++ b/Tests/AK/TestFloatingPointStringConversions.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/FloatingPointStringConversions.h>
+#include <AK/Math/Constants.h>
 #include <AK/UFixedBigInt.h>
 #include <LibTest/TestCase.h>
 
@@ -107,7 +108,7 @@ TEST_CASE(hex_float)
 
 TEST_CASE(out_of_range)
 {
-    floating_point_parsing_helper({ "1e309"sv, __builtin_huge_val(), FloatingPointError::OutOfRange, 5, ParserType::Regular });
+    floating_point_parsing_helper({ "1e309"sv, AK::Infinity<double>, FloatingPointError::OutOfRange, 5, ParserType::Regular });
 }
 
 TEST_CASE(rounded_down_to_zero)

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -23,7 +23,7 @@ TEST_CASE(fmod)
     EXPECT_EQ(fmod(+0.0, 1.0), 0.0);
     EXPECT_EQ(fmod(-0.0, 1.0), -0.0);
 
-    EXPECT_EQ(fmod(42.0, __builtin_huge_val()), 42.0);
+    EXPECT_EQ(fmod(42.0, AK::Infinity<double>), 42.0);
 
     // x has smaller exponent than y
     EXPECT_EQ(fmod(1.0, 3.0), 1.0);
@@ -119,7 +119,7 @@ TEST_CASE(exponents)
         EXPECT_APPROXIMATE(cosh(v.x), v.cosh);
         EXPECT_APPROXIMATE(tanh(v.x), v.tanh);
     }
-    EXPECT_EQ(exp(1000), __builtin_huge_val());
+    EXPECT_EQ(exp(1000), AK::Infinity<double>);
 }
 
 TEST_CASE(logarithms)
@@ -245,9 +245,9 @@ TEST_CASE(scalbn)
     EXPECT_EQ(scalbn(2.0, 4), 32.0);
 
     EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, 2045), 0x1.0'0000'0000'0000p1023);
-    EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, 2046), __builtin_huge_val());
+    EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, 2046), AK::Infinity<double>);
     EXPECT_EQ(scalbn(-0x1.0'0000'0000'0000p-1022, 2045), -0x1.0'0000'0000'0000p1023);
-    EXPECT_EQ(scalbn(-0x1.0'0000'0000'0000p-1022, 2046), -__builtin_huge_val());
+    EXPECT_EQ(scalbn(-0x1.0'0000'0000'0000p-1022, 2046), -AK::Infinity<double>);
 
     EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, -1), 0x0.8'0000'0000'0000p-1022); // Smallest non-denormal number on lhs.
     EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, -52), 0x0.0'0000'0000'0001p-1022);
@@ -260,9 +260,9 @@ TEST_CASE(scalbn)
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 49), 0x1.0'0000'0000'0000p-1022); // Smallest non-denormal number on rhs.
 
     EXPECT_EQ(scalbn(0x0.8'0000'0000'0000p-1022, 2046), 0x1.0'0000'0000'0000p1023);
-    EXPECT_EQ(scalbn(0x0.8'0000'0000'0000p-1022, 2047), __builtin_huge_val());
+    EXPECT_EQ(scalbn(0x0.8'0000'0000'0000p-1022, 2047), AK::Infinity<double>);
     EXPECT_EQ(scalbn(-0x0.8'0000'0000'0000p-1022, 2046), -0x1.0'0000'0000'0000p1023);
-    EXPECT_EQ(scalbn(-0x0.8'0000'0000'0000p-1022, 2047), -__builtin_huge_val());
+    EXPECT_EQ(scalbn(-0x0.8'0000'0000'0000p-1022, 2047), -AK::Infinity<double>);
 
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, -3), 0x0.00'000'0000'0001p-1022);
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, -4), 0);

--- a/Tests/LibC/TestStrtodAccuracy.cpp
+++ b/Tests/LibC/TestStrtodAccuracy.cpp
@@ -439,7 +439,7 @@ TEST_CASE(test_strtod_sets_errno)
         EXPECT_EQ(bit_cast<u64>(value), bit_cast<u64>(static_cast<double>(double_value))); \
     } while (false)
 
-    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("nan", __builtin_nan(""), ERANGE);
+    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("nan", AK::NaN<double>, ERANGE);
     EXPECT_TO_GIVE_VALUE_WITH_ERRNO("10e10000", AK::Infinity<double>, ERANGE);
     EXPECT_TO_GIVE_VALUE_WITH_ERRNO("0x1p10000", AK::Infinity<double>, ERANGE);
     EXPECT_TO_GIVE_VALUE_WITH_ERRNO("-10e10000", -AK::Infinity<double>, ERANGE);

--- a/Tests/LibC/TestStrtodAccuracy.cpp
+++ b/Tests/LibC/TestStrtodAccuracy.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/Format.h>
+#include <AK/Math/Constants.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -416,19 +417,19 @@ TEST_CASE(test_strtod_sets_errno)
     EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("10e10", 10e10);
     EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("10.10e10", 10.10e10);
 
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("inf", __builtin_huge_val());
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("infinity", __builtin_huge_val());
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("INF", __builtin_huge_val());
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("INFINITY", __builtin_huge_val());
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("inf", AK::Infinity<double>);
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("infinity", AK::Infinity<double>);
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("INF", AK::Infinity<double>);
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("INFINITY", AK::Infinity<double>);
 
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("Inf", __builtin_huge_val());
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("iNf", __builtin_huge_val());
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("inF", __builtin_huge_val());
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("Inf", AK::Infinity<double>);
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("iNf", AK::Infinity<double>);
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("inF", AK::Infinity<double>);
 
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("-inf", -__builtin_huge_val());
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("-infinity", -__builtin_huge_val());
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("-INF", -__builtin_huge_val());
-    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("-INFINITY", -__builtin_huge_val());
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("-inf", -AK::Infinity<double>);
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("-infinity", -AK::Infinity<double>);
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("-INF", -AK::Infinity<double>);
+    EXPECT_TO_GIVE_VALUE_WITH_0_ERRNO("-INFINITY", -AK::Infinity<double>);
 
 #define EXPECT_TO_GIVE_VALUE_WITH_ERRNO(str_value, double_value, errno_value)              \
     do {                                                                                   \
@@ -439,10 +440,10 @@ TEST_CASE(test_strtod_sets_errno)
     } while (false)
 
     EXPECT_TO_GIVE_VALUE_WITH_ERRNO("nan", __builtin_nan(""), ERANGE);
-    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("10e10000", __builtin_huge_val(), ERANGE);
-    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("0x1p10000", __builtin_huge_val(), ERANGE);
-    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("-10e10000", -__builtin_huge_val(), ERANGE);
-    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("-0x1p10000", -__builtin_huge_val(), ERANGE);
+    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("10e10000", AK::Infinity<double>, ERANGE);
+    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("0x1p10000", AK::Infinity<double>, ERANGE);
+    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("-10e10000", -AK::Infinity<double>, ERANGE);
+    EXPECT_TO_GIVE_VALUE_WITH_ERRNO("-0x1p10000", -AK::Infinity<double>, ERANGE);
     EXPECT_TO_GIVE_VALUE_WITH_ERRNO("10e-10000", 0, ERANGE);
     EXPECT_TO_GIVE_VALUE_WITH_ERRNO("0x1p-10000", 0, ERANGE);
     EXPECT_TO_GIVE_VALUE_WITH_ERRNO("-0x1p-10000", -0., ERANGE);

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -8,6 +8,7 @@
 #include <AK/CharacterTypes.h>
 #include <AK/FloatingPointStringConversions.h>
 #include <AK/HashMap.h>
+#include <AK/Math/Constants.h>
 #include <AK/Noncopyable.h>
 #include <AK/Random.h>
 #include <AK/StdLibExtras.h>
@@ -321,9 +322,9 @@ static T c_str_to_floating_point(char const* str, char** endptr)
         // literal infinity" and "input is not literal infinity
         // but did not fit into double".
         if (sign != Sign::Negative)
-            return static_cast<T>(__builtin_huge_val());
+            return AK::Infinity<T>;
         else
-            return static_cast<T>(-__builtin_huge_val());
+            return -AK::Infinity<T>;
     }
 
     if (is_nan_string(parse_ptr, endptr)) {

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -331,9 +331,9 @@ static T c_str_to_floating_point(char const* str, char** endptr)
         errno = ERANGE;
         // FIXME: Do we actually want to return "different" NaN bit values?
         if (sign != Sign::Negative)
-            return static_cast<T>(__builtin_nan(""));
+            return AK::NaN<T>;
         else
-            return static_cast<T>(-__builtin_nan(""));
+            return -AK::NaN<T>;
     }
 
     // If no conversion could be performed, 0 shall be returned, and errno may be set to [EINVAL].

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -9,6 +9,7 @@
 #include <AK/BuiltinWrappers.h>
 #include <AK/CharacterTypes.h>
 #include <AK/FloatingPoint.h>
+#include <AK/Math/Constants.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringHash.h>
 #include <LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h>
@@ -206,7 +207,7 @@ double UnsignedBigInteger::to_double(UnsignedBigInteger::RoundingMode rounding_m
 
     // If it uses too many bit to represent in a double return infinity
     if (highest_bit > Extractor::exponent_bias)
-        return __builtin_huge_val();
+        return AK::Infinity<double>;
 
     // Otherwise we have to take the top 53 bits, use those as the mantissa,
     // and the amount of bits as the exponent. Note that the mantissa has an implicit top bit of 1
@@ -336,7 +337,7 @@ double UnsignedBigInteger::to_double(UnsignedBigInteger::RoundingMode rounding_m
 
                 // In which case it is possible we have to round to infinity
                 if (highest_bit > Extractor::exponent_bias)
-                    return __builtin_huge_val();
+                    return AK::Infinity<double>;
             }
         }
     } else {

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -36,7 +36,7 @@ static_assert(sizeof(void*) == sizeof(double) || sizeof(void*) == sizeof(u32));
 // doubles have a lot (2^52 - 2) of NaN bit patterns. The canonical form being
 // just 0x7FF8000000000000 i.e. sign = 0 exponent is all ones and the top most
 // bit of the mantissa set.
-static constexpr u64 CANON_NAN_BITS = bit_cast<u64>(__builtin_nan(""));
+static constexpr u64 CANON_NAN_BITS = bit_cast<u64>(AK::NaN<double>);
 static_assert(CANON_NAN_BITS == 0x7FF8000000000000);
 // (Unfortunately all the other values are valid so we have to convert any
 // incoming NaNs to this pattern although in practice it seems only the negative

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -15,6 +15,7 @@
 #include <AK/Forward.h>
 #include <AK/Function.h>
 #include <AK/IntegralMath.h>
+#include <AK/Math/Constants.h>
 #include <AK/Result.h>
 #include <AK/String.h>
 #include <AK/Types.h>
@@ -42,8 +43,8 @@ static_assert(CANON_NAN_BITS == 0x7FF8000000000000);
 // version of these CANON_NAN_BITS)
 // +/- Infinity are represented by a full exponent but without any bits of the
 // mantissa set.
-static constexpr u64 POSITIVE_INFINITY_BITS = bit_cast<u64>(__builtin_huge_val());
-static constexpr u64 NEGATIVE_INFINITY_BITS = bit_cast<u64>(-__builtin_huge_val());
+static constexpr u64 POSITIVE_INFINITY_BITS = bit_cast<u64>(AK::Infinity<double>);
+static constexpr u64 NEGATIVE_INFINITY_BITS = bit_cast<u64>(-AK::Infinity<double>);
 static_assert(POSITIVE_INFINITY_BITS == 0x7FF0000000000000);
 static_assert(NEGATIVE_INFINITY_BITS == 0xFFF0000000000000);
 // However as long as any bit is set in the mantissa with the exponent of all

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -8,6 +8,7 @@
 
 #include <AK/BitCast.h>
 #include <AK/BuiltinWrappers.h>
+#include <AK/Math/Constants.h>
 #include <AK/Result.h>
 #include <AK/SIMD.h>
 #include <AK/SIMDExtras.h>
@@ -1068,7 +1069,7 @@ struct Demote {
             return nanf(""); // FIXME: Ensure canonical NaN remains canonical
 
         if (isinf(lhs))
-            return copysignf(__builtin_huge_valf(), lhs);
+            return copysignf(AK::Infinity<float>, lhs);
 
         return static_cast<float>(lhs);
     }


### PR DESCRIPTION
No behavior change.