### PR TITLE
AK: Include StdShim.h in NeverDestroyed.h

### DIFF
--- a/AK/NeverDestroyed.h
+++ b/AK/NeverDestroyed.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Noncopyable.h>
+#include <AK/StdShim.h>
 #include <AK/Types.h>
 
 namespace AK {


### PR DESCRIPTION
This provides the otherwise missing definition for `forward`.