### PR TITLE
Kernel/x86: Prefer the TSC over the HPET to update the system's time

### DIFF
--- a/Kernel/Arch/x86_64/Time/TSC.cpp
+++ b/Kernel/Arch/x86_64/Time/TSC.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "TSC.h"
+#include <AK/Singleton.h>
+#include <Kernel/Arch/Processor.h>
+
+namespace Kernel {
+
+TSC& TSC::the()
+{
+    static Singleton<TSC> s_the;
+    return *s_the;
+}
+
+bool TSC::is_supported_and_invariant()
+{
+    // FIXME: This only checks the current processor and assumes that the
+    //        other have the same features.
+    bool has_sufficient_tsc = Processor::current().has_feature(CPUFeature::TSC)
+        && Processor::current().has_feature(CPUFeature::CONSTANT_TSC)
+        && Processor::current().has_feature(CPUFeature::NONSTOP_TSC);
+
+    if (!has_sufficient_tsc)
+        dmesgln("TSC: TSC is unsupported or not invariant");
+
+    return has_sufficient_tsc;
+}
+
+bool TSC::calibrate(HardwareTimerBase& calibration_source)
+{
+    VERIFY_INTERRUPTS_DISABLED();
+
+    // FIXME: Intel CPUs provide the frequency as a CPUID leaf, we could use that instead of doing the calibration.
+
+    // FIXME: Share the code with APICTimer::calibrate.
+
+    struct {
+        size_t ticks_in_100ms { 0 };
+        Atomic<size_t, AK::memory_order_relaxed> calibration_ticks { 0 };
+        u64 volatile start_tsc { 0 }, end_tsc { 0 };
+        u64 volatile start_reference { 0 }, end_reference { 0 };
+    } state;
+
+    state.ticks_in_100ms = calibration_source.ticks_per_second() / 10;
+
+    if (!calibration_source.can_query_raw())
+        return false;
+
+    auto original_source_callback = calibration_source.set_callback([&state, &calibration_source]() {
+        // FIXME: rdtsc can be executed out-of-order, use fences to get more precise results.
+        u64 current_tsc = read_tsc();
+        auto prev_tick = state.calibration_ticks.fetch_add(1);
+        if (prev_tick == 0) {
+            state.start_tsc = current_tsc;
+            state.start_reference = calibration_source.current_raw();
+        } else if (prev_tick == state.ticks_in_100ms) {
+            state.end_tsc = current_tsc;
+            state.end_reference = calibration_source.current_raw();
+        }
+    });
+
+    Processor::enable_interrupts();
+    while (state.calibration_ticks.load() <= state.ticks_in_100ms)
+        Processor::wait_check();
+    Processor::disable_interrupts();
+
+    calibration_source.set_callback(move(original_source_callback));
+
+    VERIFY(state.end_tsc > state.start_tsc);
+
+    u64 measurement_duration = calibration_source.raw_to_ns(state.end_reference - state.start_reference);
+    m_frequency = (u32)(1'000'000'000ull * (state.end_tsc - state.start_tsc) / measurement_duration);
+
+    dmesgln("TSC: Measured base frequency: {}MHz", (m_frequency + 500'000) / 1'000'000);
+
+    return true;
+}
+
+u64 TSC::update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only)
+{
+    // Should only be called by the time keeper interrupt handler!
+    u64 current_value = read_tsc();
+    u64 delta_ticks { 0 };
+    if (current_value >= m_main_counter_last_read) {
+        delta_ticks += current_value - m_main_counter_last_read;
+    } else {
+        // the counter wrapped around
+        delta_ticks += (NumericLimits<u64>::max() - m_main_counter_last_read + 1) + current_value;
+    }
+
+    u64 ticks_since_last_second = (u64)ticks_this_second + delta_ticks;
+    seconds_since_boot += ticks_since_last_second / m_frequency;
+    ticks_this_second = ticks_since_last_second % m_frequency;
+
+    if (!query_only) {
+        m_main_counter_last_read = current_value;
+    }
+
+    // Return the time passed (in ns) since last time update_time was called
+    return (delta_ticks * 1000000000ull) / m_frequency;
+}
+
+}

--- a/Kernel/Arch/x86_64/Time/TSC.h
+++ b/Kernel/Arch/x86_64/Time/TSC.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/Time/HardwareTimer.h>
+
+namespace Kernel {
+
+class TSC {
+public:
+    static bool is_supported_and_invariant();
+    static TSC& the();
+
+    bool calibrate(HardwareTimerBase& calibration_source);
+    u64 frequency() const { return m_frequency; }
+    // FIXME: Share code with HPET::update_time
+    u64 update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only);
+
+private:
+    u64 m_frequency { 0 };
+    u64 m_main_counter_last_read { 0 };
+};
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -446,6 +446,7 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Arch/x86_64/RTC.cpp
         Arch/x86_64/Shutdown.cpp
         Arch/x86_64/SmapDisabler.cpp
+        Arch/x86_64/Time/TSC.cpp
     )
 
     set(KERNEL_SOURCES

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -17,6 +17,7 @@
 #    include <Kernel/Arch/x86_64/Time/HPETComparator.h>
 #    include <Kernel/Arch/x86_64/Time/PIT.h>
 #    include <Kernel/Arch/x86_64/Time/RTC.h>
+#    include <Kernel/Arch/x86_64/Time/TSC.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/RPi/Timer.h>
 #    include <Kernel/Arch/aarch64/Time/ARMv8Timer.h>
@@ -395,6 +396,15 @@ UNMAP_AFTER_INIT bool TimeManagement::probe_and_set_x86_non_legacy_hardware_time
     // We don't need an interrupt for time keeping purposes because we
     // can query the timer.
     m_time_keeper_timer = m_system_timer;
+
+    if (TSC::is_supported_and_invariant()
+        && TSC::the().calibrate(*m_system_timer)) {
+
+        m_read_time_from_hardware = [](auto&&... args) -> u64 {
+            return TSC::the().update_time(args...);
+        };
+        m_time_ticks_per_second = TSC::the().frequency();
+    }
 
     if (periodic_timers.size() > taken_periodic_timers_count) {
         m_profile_timer = periodic_timers[taken_periodic_timers_count];

--- a/Meta/run.py
+++ b/Meta/run.py
@@ -168,7 +168,7 @@ class Configuration:
     # QEMU -m
     ram_size: str | None = "2G"
     # QEMU -cpu
-    qemu_cpu: str | None = "max"
+    qemu_cpu: str | None = "max,migratable=no"
     # QEMU -smp
     cpu_count: int | None = 2
     # QEMU -machine


### PR DESCRIPTION
As it requires MMIO access, reading the raw value of the HPET timer is
quite expensive, so doing it every time the system timer fired (~4ms)
resulted in a heavy overload over the system. As shown in [1] it is
quite known that HPET timers are slow to read. Moreover, when using QEMU
reading from MMIO causes a VM exit and makes the whole virtualized world
stop. The consequence is that reading the HPET timer would not appear in
profiles as it is not slow from the perspective of the VM.

To solve that issue, we're now using the Time Stamp Counter (TSC) as our
time-keeping source. Whenever the system interrupt fires, we read the
TSC (which is cheap, see [1], and doesn't cause a VM exit) and compute
the elapsed time based on how many cycle the CPU made during that time.

[1] https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_for_real_time/7/html/reference_guide/chap-timestamping#Reading_hardware_clock_sources


----

Before:

SFTP download @6.8 MB/s
<img width="591" height="114" alt="Screenshot From 2026-06-30 00-50-32" src="https://github.com/user-attachments/assets/0ed748f9-6a8c-4b81-a278-223232932ea0" />

After:

SFTP download @10.0 MB/s
<img width="591" height="114" alt="Screenshot From 2026-06-30 00-53-41" src="https://github.com/user-attachments/assets/8adde2de-f77f-4e4e-8f25-5acc23056226" />


---

I have a WIP branch that implements reading the PMU (Performance Monitoring Unit), and the results that I got from it indicated that the vCPU was running at a much lower frequency than expected. This, in turn made me suspect that QEMU/KVM itself was using our precious CPU time. And fortunately, KVM has some `perf` integration to show exactly this kind of bottleneck!

```
sudo perf kvm record -e kvm:kvm_page_fault -e kvm:kvm_exit
```
And then:
```
sudo perf script -i perf.data.guest | sed 's/^[^:]*: *//' | sort | uniq -c | sort -h
```

This shows all VM exits and their causes (type, but also the `rip` which allows us to trace back to the caller). The HPET counter was by far the main offender and this PR make it disappear from the samples.