### PR TITLE
Fixed 4 high-severity bugs in the Games folder

### DIFF
--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -503,24 +503,28 @@ void ChessWidget::input_engine_move()
     }
 
     set_override_cursor(Gfx::StandardCursor::Wait);
-    m_engine->get_best_move(board(), 4000, [this, drag_was_enabled](ErrorOr<Chess::Move> move) {
-        set_override_cursor(Gfx::StandardCursor::None);
-        if (!want_engine_move())
+    m_engine->get_best_move(board(), 4000, [weak_this = make_weak_ptr(), drag_was_enabled](ErrorOr<Chess::Move> move) {
+        auto self = weak_this.strong_ref();
+        if (!self)
             return;
-        set_drag_enabled(drag_was_enabled);
+        self->set_override_cursor(Gfx::StandardCursor::None);
+        if (!self->want_engine_move())
+            return;
+        self->set_drag_enabled(drag_was_enabled);
         if (!move.is_error()) {
-            VERIFY(board().apply_move(move.release_value()));
-            update_move_display_widget(board());
-            if (!m_unlimited_time_control) {
-                apply_increment(move.release_value());
+            auto move_value = move.release_value();
+            VERIFY(self->board().apply_move(move_value));
+            self->update_move_display_widget(self->board());
+            if (!self->m_unlimited_time_control) {
+                self->apply_increment(move_value);
             }
-            if (check_game_over(ClaimDrawBehavior::Prompt))
+            if (self->check_game_over(ClaimDrawBehavior::Prompt))
                 return;
         }
-        m_playback_move_number = m_board.moves().size();
-        m_playback = false;
-        m_board_markings.clear();
-        update();
+        self->m_playback_move_number = self->m_board.moves().size();
+        self->m_playback = false;
+        self->m_board_markings.clear();
+        self->update();
     });
 }
 
@@ -692,7 +696,7 @@ ErrorOr<void, PGNParseError> ChessWidget::import_pgn(Core::File& file)
         }
 
         if (lexer.next_is("1/2-1/2"sv)) {
-            auto value = lexer.consume(3);
+            auto value = lexer.consume(7);
             tokens.append(Token { TokenType::GameTerminator, value });
             break;
         }
@@ -770,6 +774,9 @@ ErrorOr<void, PGNParseError> ChessWidget::import_pgn(Core::File& file)
             }
             if (token.value == "0-1"sv) {
                 m_board.set_resigned(Chess::Color::White);
+            }
+            if (token.value == "1/2-1/2"sv) {
+                m_board.set_drawn();
             }
             break;
         case TokenType::Comment:

--- a/Userland/Games/Chess/Engine.cpp
+++ b/Userland/Games/Chess/Engine.cpp
@@ -43,9 +43,10 @@ void Engine::connect_to_engine_service()
     posix_spawn_file_actions_adddup2(&file_actions, wpipefds[0], STDIN_FILENO);
     posix_spawn_file_actions_adddup2(&file_actions, rpipefds[1], STDOUT_FILENO);
 
-    auto command_length = m_command.code_points().length();
+    auto command_bytes = m_command.bytes_as_string_view();
+    auto command_length = command_bytes.length();
     auto command_name = new char[command_length + 1];
-    memcpy(command_name, m_command.bytes_as_string_view().characters_without_null_termination(), command_length);
+    memcpy(command_name, command_bytes.characters_without_null_termination(), command_length);
     command_name[command_length] = '\0';
 
     char const* argv[] = { command_name, nullptr };

--- a/Userland/Games/TwentyFourtyEight/GameSizeDialog.cpp
+++ b/Userland/Games/TwentyFourtyEight/GameSizeDialog.cpp
@@ -18,7 +18,7 @@ namespace TwentyFourtyEight {
 GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t target, bool evil_ai)
     : GUI::Dialog(parent)
     , m_board_size(board_size)
-    , m_target_tile_power(AK::log2(target))
+    , m_target_tile_power(target > 0 ? AK::log2(target) : 0)
     , m_evil_ai(evil_ai)
 {
     set_rect({ 0, 0, 250, 150 });

--- a/Userland/Games/TwentyFourtyEight/main.cpp
+++ b/Userland/Games/TwentyFourtyEight/main.cpp
@@ -48,14 +48,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    size_t board_size = Config::read_i32("2048"sv, ""sv, "board_size"sv, 4);
-    u32 target_tile = Config::read_i32("2048"sv, ""sv, "target_tile"sv, 2048);
+    i32 board_size_config = Config::read_i32("2048"sv, ""sv, "board_size"sv, 4);
+    i32 target_tile_config = Config::read_i32("2048"sv, ""sv, "target_tile"sv, 2048);
     bool evil_ai = Config::read_bool("2048"sv, ""sv, "evil_ai"sv, false);
 
-    if ((target_tile & (target_tile - 1)) != 0) {
-        // If the target tile is not a power of 2, reset to its default value.
-        target_tile = 2048;
-    }
+    if (board_size_config < 2 || board_size_config > 16)
+        board_size_config = 4;
+    if (target_tile_config <= 0 || (target_tile_config & (target_tile_config - 1)) != 0)
+        target_tile_config = 2048;
+
+    size_t board_size = static_cast<size_t>(board_size_config);
+    u32 target_tile = static_cast<u32>(target_tile_config);
 
     Config::write_i32("2048"sv, ""sv, "board_size"sv, board_size);
     Config::write_i32("2048"sv, ""sv, "target_tile"sv, target_tile);

--- a/Userland/Libraries/LibChess/Chess.cpp
+++ b/Userland/Libraries/LibChess/Chess.cpp
@@ -726,6 +726,9 @@ Move Board::random_move(Color color) const
 
 Board::Result Board::game_result() const
 {
+    if (m_drawn)
+        return Result::DrawByAgreement;
+
     if (m_resigned != Color::None)
         return (m_resigned == Color::White) ? Result::WhiteResign : Result::BlackResign;
 
@@ -931,6 +934,8 @@ StringView Board::result_to_string(Result result, Color turn)
         return "Draw by fivefold repetition"sv;
     case Chess::Board::Result::InsufficientMaterial:
         return "Draw by insufficient material"sv;
+    case Chess::Board::Result::DrawByAgreement:
+        return "Draw by agreement"sv;
     case Chess::Board::Result::NotFinished:
         return "Game not finished"sv;
     default:
@@ -954,6 +959,7 @@ StringView Board::result_to_points_string(Result result, Color turn)
     case Chess::Board::Result::ThreeFoldRepetition:
     case Chess::Board::Result::FiveFoldRepetition:
     case Chess::Board::Result::InsufficientMaterial:
+    case Chess::Board::Result::DrawByAgreement:
         return "1/2-1/2"sv;
     case Chess::Board::Result::NotFinished:
         return "*"sv;

--- a/Userland/Libraries/LibChess/Chess.h
+++ b/Userland/Libraries/LibChess/Chess.h
@@ -150,6 +150,7 @@ public:
         ThreeFoldRepetition,
         FiveFoldRepetition,
         InsufficientMaterial,
+        DrawByAgreement,
         NotFinished,
     };
 
@@ -164,6 +165,7 @@ public:
     int game_score() const;
     bool game_finished() const;
     void set_resigned(Color);
+    void set_drawn() { m_drawn = true; }
     int material_imbalance() const;
 
     Color turn() const { return m_turn; }
@@ -183,6 +185,7 @@ private:
 
     Color m_turn : 2 { Color::White };
     Color m_resigned : 2 { Color::None };
+    bool m_drawn { false };
 
     bool m_white_can_castle_kingside : 1 { true };
     bool m_white_can_castle_queenside : 1 { true };


### PR DESCRIPTION
Fixed 4 high-severity bugs in the Games folder:

2048 (main.cpp) — board_size/target_tile config values are now read as i32 and validated (negative/zero/non-power-of-2 reset to defaults), preventing huge allocations and division-by-zero.

2048 (GameSizeDialog.cpp) — AK::log2(target) wrapped with target > 0 ? ... : 0 to avoid undefined behavior on log2(0).

Chess (ChessWidget.cpp) — PGN "1/2-1/2" terminator now consumed correctly (consume(7) instead of 3); added Result::DrawByAgreement + m_drawn/set_drawn() in LibChess so the draw result is actually applied.

Chess (ChessWidget.cpp) — Engine async callback switched from [this, ...] to [weak_this = make_weak_ptr(), ...] with strong_ref() guard, preventing use-after-free if the widget is destroyed before the engine responds (and fixing a double release_value() on the same Optional).