### PR TITLE
ChessEngine: Fix unicode truncation in command name + add translated READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐 [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+Grafisches Unix-artiges Betriebssystem für 64-Bit-x86-, Arm- und RISC-V-Computer.
+
+[FAQ](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [Dokumentation](#wie-lese-ich-die-dokumentation) | [Build-Anleitung](#wie-baue-ich-dies-und-führe-es-aus)
+
+## Über
+
+SerenityOS ist ein Liebesbrief an die Benutzeroberflächen der 90er Jahre mit einem eigenen Unix-artigen Kernel. Es schmeichelt aufrichtig, indem es wunderschöne Ideen von anderen Systemen stiehlt.
+
+Grob gesagt ist das Ziel eine Verbindung zwischen der Ästhetik von Produktivitätssoftware der späten 90er Jahre und der Power-User-Zugänglichkeit des späten 2000er \*nix. Dies ist ein System von uns, für uns, basierend auf den Dingen, die wir mögen.
+
+Du kannst Videos von der Entwicklung des Systems auf YouTube ansehen:
+
+- [Andreas Klings Kanal](https://youtube.com/andreaskling)
+- [Linus Grohs Kanal](https://youtube.com/linusgroh)
+- [kleines Filmröllchens Kanal](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## Screenshot
+
+![Screenshot c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## Funktionen
+
+- Moderner 64-Bit-Kernel mit präemptivem Multithreading
+- [Browser](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser) mit JavaScript, WebAssembly und mehr (sieh dir die Spezifikationskonformität für [JS](https://serenityos.github.io/libjs-website/test262/), [CSS](https://css.tobyase.de/) und [Wasm](https://serenityos.github.io/libjs-website/wasm/) an)
+- Sicherheitsfunktionen (Hardware-Schutz, eingeschränkte Userspace-Fähigkeiten, W^X-Speicher, `pledge` und `unveil`, (K)ASLR, OOM-Resistenz, Web-Content-Isolation, modernste TLS-Algorithmen, ...)
+- [Systemdienste](https://github.com/deimo-s/serenity/blob/master/Userland/Services) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer, ...) und moderne IPC
+- Gute POSIX-Kompatibilität ([LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC), Shell, Syscalls, Signale, Pseudoterminals, Dateisystembenachrichtigungen, Standard-Unix-[Hilfsprogramme](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities), ...)
+- POSIX-artige virtuelle Dateisysteme (/proc, /dev, /sys, /tmp, ...) und ext2-Dateisystem
+- Netzwerkstack und Anwendungen mit Unterstützung für IPv4, TCP, UDP; DNS, HTTP, Gemini, IMAP, NTP
+- Profiling, Debugging und andere Entwicklungswerkzeuge (kernelunterstütztes Profiling, CrashReporter, interaktiver GUI-Spielplatz, HexEditor, HackStudio-IDE für C++ und mehr)
+- [Bibliotheken](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries) für alles, von Kryptographie bis OpenGL, Audio, JavaScript, GUI, Schach spielen, ...
+- Unterstützung für viele gängige und ungewöhnliche Dateiformate (PNG, JPEG, GIF, MP3, WAV, FLAC, ZIP, TAR, PDF, QOI, Gemini, ...)
+- Einheitliche Stil- und Designphilosophie, flexibles Themensystem, [benutzerdefinierte (Bitmap- und Vektor-)Schriften](https://fonts.serenityos.net/font-family)
+- [Spiele](https://github.com/deimo-s/serenity/blob/master/Userland/Games) (Solitaire, Minesweeper, 2048, Schach, Conways Game of Life, ...) und [Demos](https://github.com/deimo-s/serenity/blob/master/Userland/Demos) (CatDog, Starfield, Eyes, Mandelbrot-Menge, WidgetGallery, ...)
+- Alltägliche GUI-Programme und Hilfsprogramme (Tabellenkalkulation mit JavaScript, TextEditor, Terminal, PixelPaint, verschiedene Multimedia-Betrachter und -Player, Mail, Assistant, Taschenrechner, ...)
+
+... und all das oben Genannte befindet sich in diesem Repository, ohne zusätzliche Abhängigkeiten, von Grund auf von uns gebaut :^)
+
+Zusätzlich gibt es [über dreihundert Ports beliebter Open-Source-Software](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md), einschließlich Spielen, Compilern, Unix-Werkzeugen, Multimedia-Apps und mehr.
+
+## Wie lese ich die Dokumentation?
+
+Handbuchseiten sind online unter [man.serenityos.org](https://man.serenityos.org) verfügbar. Diese Seiten werden aus den Markdown-Quelldateien in [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman) generiert und automatisch aktualisiert.
+
+Beim Ausführen von SerenityOS kannst du `man` für die Terminal-Schnittstelle oder `help` für die GUI verwenden.
+
+Code-bezogene Dokumentation findest du im [Documentation](https://github.com/deimo-s/serenity/blob/master/Documentation)-Ordner.
+
+## Wie baue ich dies und führe es aus?
+
+Sieh dir die [SerenityOS-Build-Anleitung](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) oder die [Ladybird-Build-Anleitung](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md) an.
+
+Das Build-System unterstützt einen Cross-Compilation-Build von SerenityOS von Linux, macOS, Windows (mit WSL2) und vielen anderen \*Nixen aus. Die Standard-Build-System-Befehle starten eine QEMU-Instanz, die das Betriebssystem mit aktivierter Hardware- oder Software-Virtualisierung ausführt, sofern unterstützt.
+
+Ladybird läuft auf denselben Plattformen, die als Host für einen Cross-Build von SerenityOS dienen können, und auf SerenityOS selbst.
+
+## Tritt in Kontakt und mach mit!
+
+Tritt unserem Discord-Server bei: [SerenityOS Discord](https://serenityos.org/discord)
+
+Bevor du ein Issue öffnest, lies bitte die [Issue-Richtlinie](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy).
+
+Einen allgemeinen Leitfaden zum Mitwirken findest du in [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md).
+
+## Autoren
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+Und viele weitere! Die vollständige Liste der Mitwirkenden findest du [hier](https://github.com/SerenityOS/serenity/graphs/contributors). Die oben aufgeführten Personen haben mehr als 100 Commits zum Projekt beigetragen. :^)
+
+## Lizenz
+
+SerenityOS ist unter einer 2-Klausel-BSD-Lizenz lizenziert.

--- a/README.es.md
+++ b/README.es.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+Sistema operativo tipo Unix con interfaz gráfica para ordenadores x86 de 64 bits, Arm y RISC-V.
+
+[Preguntas Frecuentes](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [Documentación](#cómo-leo-la-documentación) | [Instrucciones de compilación](#cómo-compilo-y-ejecuto-esto)
+
+## Acerca de
+
+SerenityOS es una carta de amor a las interfaces de usuario de los años 90 con un núcleo tipo Unix propio. Halaga con sinceridad al robar ideas hermosas de otros sistemas.
+
+A grandes rasgos, el objetivo es un matrimonio entre la estética del software de productividad de finales de los 90 y la accesibilidad para usuarios avanzados del \*nix de finales de los 2000. Este es un sistema de nosotros, para nosotros, basado en las cosas que nos gustan.
+
+Puedes ver videos del desarrollo del sistema en YouTube:
+
+- [Canal de Andreas Kling](https://youtube.com/andreaskling)
+- [Canal de Linus Groh](https://youtube.com/linusgroh)
+- [Canal de kleines Filmröllchen](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## Captura de pantalla
+
+![Screenshot c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## Características
+
+- Núcleo moderno de 64 bits con multihilo preemptivo
+- [Navegador](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser) con JavaScript, WebAssembly y más (consulta el cumplimiento de especificaciones para [JS](https://serenityos.github.io/libjs-website/test262/), [CSS](https://css.tobyase.de/) y [Wasm](https://serenityos.github.io/libjs-website/wasm/))
+- Funciones de seguridad (protecciones de hardware, capacidades limitadas en el espacio de usuario, memoria W^X, `pledge` y `unveil`, (K)ASLR, resistencia a OOM, aislamiento de contenido web, algoritmos TLS de última generación, ...)
+- [Servicios del sistema](https://github.com/deimo-s/serenity/blob/master/Userland/Services) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer, ...) e IPC moderno
+- Buena compatibilidad POSIX ([LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC), Shell, syscalls, señales, pseudoterminales, notificaciones del sistema de archivos, [utilidades](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities) estándar de Unix, ...)
+- Sistemas de archivos virtuales tipo POSIX (/proc, /dev, /sys, /tmp, ...) y sistema de archivos ext2
+- Pila de red y aplicaciones con soporte para IPv4, TCP, UDP; DNS, HTTP, Gemini, IMAP, NTP
+- Herramientas de perfilado, depuración y otras de desarrollo (perfilado soportado por el núcleo, CrashReporter, playground GUI interactivo, HexEditor, HackStudio IDE para C++ y más)
+- [Librerías](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries) para todo, desde criptografía hasta OpenGL, audio, JavaScript, GUI, jugar al ajedrez, ...
+- Soporte para muchos formatos de archivo comunes y no comunes (PNG, JPEG, GIF, MP3, WAV, FLAC, ZIP, TAR, PDF, QOI, Gemini, ...)
+- Filosofía de estilo y diseño unificada, sistema de temas flexible, [tipografías personalizadas (bitmap y vectoriales)](https://fonts.serenityos.net/font-family)
+- [Juegos](https://github.com/deimo-s/serenity/blob/master/Userland/Games) (Solitaire, Minesweeper, 2048, ajedrez, El Juego de la Vida de Conway, ...) y [demos](https://github.com/deimo-s/serenity/blob/master/Userland/Demos) (CatDog, Starfield, Eyes, conjunto de Mandelbrot, WidgetGallery, ...)
+- Programas GUI y utilidades de uso diario (Hoja de cálculo con JavaScript, TextEditor, Terminal, PixelPaint, varios visores y reproductores multimedia, Mail, Assistant, Calculadora, ...)
+
+... y todo lo anterior está en este repositorio, sin dependencias extra, construido desde cero por nosotros :^)
+
+Adicionalmente, hay [más de trescientos ports de software de código abierto popular](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md), incluyendo juegos, compiladores, herramientas Unix, aplicaciones multimedia y más.
+
+## ¿Cómo leo la documentación?
+
+Las páginas de manual están disponibles en línea en [man.serenityos.org](https://man.serenityos.org). Estas páginas se generan a partir de los archivos fuente Markdown en [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman) y se actualizan automáticamente.
+
+Cuando ejecutes SerenityOS puedes usar `man` para la interfaz de terminal, o `help` para la GUI.
+
+La documentación relacionada con el código se puede encontrar en la carpeta [Documentation](https://github.com/deimo-s/serenity/blob/master/Documentation).
+
+## ¿Cómo compilo y ejecuto esto?
+
+Consulta las [instrucciones de compilación de SerenityOS](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) o las [instrucciones de compilación de Ladybird](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md).
+
+El sistema de compilación admite una compilación cruzada de SerenityOS desde Linux, macOS, Windows (con WSL2) y muchos otros \*Nix. Los comandos por defecto del sistema de compilación lanzarán una instancia de QEMU ejecutando el sistema operativo con virtualización por hardware o software habilitada según sea compatible.
+
+Ladybird se ejecuta en las mismas plataformas que pueden ser el host para una compilación cruzada de SerenityOS y en SerenityOS mismo.
+
+## ¡Ponte en contacto y participa!
+
+Únete a nuestro servidor de Discord: [SerenityOS Discord](https://serenityos.org/discord)
+
+Antes de abrir un issue, por favor consulta la [política de issues](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy).
+
+Una guía general para contribuir se puede encontrar en [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md).
+
+## Autores
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+¡Y muchos más! Consulta [aquí](https://github.com/SerenityOS/serenity/graphs/contributors) la lista completa de contribuidores. Las personas listadas arriba han realizado más de 100 commits en el proyecto. :^)
+
+## Licencia
+
+SerenityOS está licenciado bajo una licencia BSD de 2 cláusulas.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+Système d'exploitation graphique de type Unix pour ordinateurs x86 64 bits, Arm et RISC-V.
+
+[FAQ](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [Documentation](#comment-lis-je-la-documentation) | [Instructions de compilation](#comment-compiler-et-exécuter-ce-projet)
+
+## À propos
+
+SerenityOS est une lettre d'amour aux interfaces utilisateur des années 90 avec un noyau de type Unix personnalisé. Il flatte avec sincérité en empruntant de belles idées à d'autres systèmes.
+
+En gros, l'objectif est un mariage entre l'esthétique des logiciels de productivité de la fin des années 90 et l'accessibilité pour utilisateurs avancés du \*nix de la fin des années 2000. C'est un système par nous, pour nous, basé sur les choses que nous aimons.
+
+Vous pouvez regarder des vidéos du développement du système sur YouTube :
+
+- [Chaîne d'Andreas Kling](https://youtube.com/andreaskling)
+- [Chaîne de Linus Groh](https://youtube.com/linusgroh)
+- [Chaîne de kleines Filmröllchen](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## Capture d'écran
+
+![Screenshot c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## Fonctionnalités
+
+- Noyau 64 bits moderne avec multithreading préemptif
+- [Navigateur](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser) avec JavaScript, WebAssembly et plus (vérifiez la conformité aux spécifications pour [JS](https://serenityos.github.io/libjs-website/test262/), [CSS](https://css.tobyase.de/) et [Wasm](https://serenityos.github.io/libjs-website/wasm/))
+- Fonctionnalités de sécurité (protections matérielles, capacités limitées en espace utilisateur, mémoire W^X, `pledge` et `unveil`, (K)ASLR, résistance à l'OOM, isolation du contenu web, algorithmes TLS de pointe, ...)
+- [Services système](https://github.com/deimo-s/serenity/blob/master/Userland/Services) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer, ...) et IPC moderne
+- Bonne compatibilité POSIX ([LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC), Shell, appels système, signaux, pseudo-terminaux, notifications du système de fichiers, [utilitaires](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities) Unix standard, ...)
+- Systèmes de fichiers virtuels de type POSIX (/proc, /dev, /sys, /tmp, ...) et système de fichiers ext2
+- Pile réseau et applications avec prise en charge d'IPv4, TCP, UDP ; DNS, HTTP, Gemini, IMAP, NTP
+- Profilage, débogage et autres outils de développement (profilage supporté par le noyau, CrashReporter, terrain de jeu GUI interactif, HexEditor, IDE HackStudio pour C++ et plus)
+- [Bibliothèques](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries) pour tout, de la cryptographie à OpenGL, audio, JavaScript, GUI, jouer aux échecs, ...
+- Prise en charge de nombreux formats de fichiers courants et peu courants (PNG, JPEG, GIF, MP3, WAV, FLAC, ZIP, TAR, PDF, QOI, Gemini, ...)
+- Philosophie de style et de conception unifiée, système de thèmes flexible, [polices personnalisées (bitmap et vectorielles)](https://fonts.serenityos.net/font-family)
+- [Jeux](https://github.com/deimo-s/serenity/blob/master/Userland/Games) (Solitaire, Démineur, 2048, échecs, le Jeu de la vie de Conway, ...) et [démos](https://github.com/deimo-s/serenity/blob/master/Userland/Demos) (CatDog, Starfield, Eyes, ensemble de Mandelbrot, WidgetGallery, ...)
+- Programmes GUI et utilitaires quotidiens (Tableur avec JavaScript, TextEditor, Terminal, PixelPaint, divers lecteurs multimédias, Mail, Assistant, Calculatrice, ...)
+
+... et tout ce qui précède se trouve dans ce dépôt, sans dépendances supplémentaires, construit à partir de zéro par nous :^)
+
+De plus, il y a [plus de trois cents ports de logiciels open source populaires](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md), incluant des jeux, compilateurs, outils Unix, applications multimédias et plus.
+
+## Comment lis-je la documentation ?
+
+Les pages de manuel sont disponibles en ligne sur [man.serenityos.org](https://man.serenityos.org). Ces pages sont générées à partir des fichiers source Markdown dans [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman) et mises à jour automatiquement.
+
+Lors de l'exécution de SerenityOS, vous pouvez utiliser `man` pour l'interface terminal, ou `help` pour la GUI.
+
+La documentation relative au code se trouve dans le dossier [Documentation](https://github.com/deimo-s/serenity/blob/master/Documentation).
+
+## Comment compiler et exécuter ce projet ?
+
+Consultez les [instructions de compilation de SerenityOS](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) ou les [instructions de compilation de Ladybird](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md).
+
+Le système de compilation prend en charge une compilation croisée de SerenityOS depuis Linux, macOS, Windows (avec WSL2) et de nombreux autres \*Nix. Les commandes par défaut du système de compilation lanceront une instance QEMU exécutant l'OS avec la virtualisation matérielle ou logicielle activée selon ce qui est supporté.
+
+Ladybird s'exécute sur les mêmes plateformes qui peuvent être l'hôte d'une compilation croisée de SerenityOS et sur SerenityOS lui-même.
+
+## Prenez contact et participez !
+
+Rejoignez notre serveur Discord : [SerenityOS Discord](https://serenityos.org/discord)
+
+Avant d'ouvrir un ticket, veuillez consulter la [politique des tickets](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy).
+
+Un guide général pour contribuer se trouve dans [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md).
+
+## Auteurs
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+Et bien d'autres ! Voir [ici](https://github.com/SerenityOS/serenity/graphs/contributors) pour la liste complète des contributeurs. Les personnes listées ci-dessus ont mergé plus de 100 commits dans le projet. :^)
+
+## Licence
+
+SerenityOS est sous licence BSD à 2 clauses.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+64 ビット x86、Arm、RISC-V コンピューター向けのグラフィカルな Unix 系オペレーティングシステムです。
+
+[FAQ](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [ドキュメント](#ドキュメントの読み方) | [ビルド手順](#ビルドと実行方法)
+
+## 概要
+
+SerenityOS は、90 年代のユーザーインターフェースへのラブレターであり、Unix 系カスタムコアを備えています。さまざまな他のシステムから美しいアイデアを借りて、心からの敬意を表しています。
+
+大雑把に言えば、目標は 1990 年代後半の生産性ソフトウェアの美学と、2000 年代後半の \*nix システムのパワーユーザー向けアクセシビリティを結びつけることです。これは、私たちによる、私たちのための、私たちが好きなものに基づいたシステムです。
+
+YouTube でこのシステムの開発動画を視聴できます：
+
+- [Andreas Kling のチャンネル](https://youtube.com/andreaskling)
+- [Linus Groh のチャンネル](https://youtube.com/linusgroh)
+- [kleines Filmröllchen のチャンネル](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## スクリーンショット
+
+![Screenshot c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## 機能
+
+- プリエンプティブなマルチスレッドを備えたモダンな 64 ビットカーネル
+- JavaScript、WebAssembly などを搭載した[ブラウザ](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser)（[JS](https://serenityos.github.io/libjs-website/test262/)、[CSS](https://css.tobyase.de/)、[Wasm](https://serenityos.github.io/libjs-website/wasm/) の仕様準拠を確認してください）
+- セキュリティ機能（ハードウェア保護、限定されたユーザーランド機能、W^X メモリ、`pledge` と `unveil`、(K)ASLR、OOM 耐性、Web コンテンツ分離、最先端の TLS アルゴリズムなど）
+- [システムサービス](https://github.com/deimo-s/serenity/blob/master/Userland/Services)（WindowServer、LoginServer、AudioServer、WebServer、RequestServer、CrashServer など）とモダンな IPC
+- 優れた POSIX 互換性（[LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC)、シェル、システムコール、シグナル、擬似端末、ファイルシステム通知、標準 Unix [ユーティリティ](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities) など）
+- POSIX 風の仮想ファイルシステム（/proc、/dev、/sys、/tmp など）と ext2 ファイルシステム
+- IPv4、TCP、UDP をサポートするネットワークスタックとアプリケーション。DNS、HTTP、Gemini、IMAP、NTP に対応
+- プロファイリング、デバッグ、その他の開発ツール（カーネル対応プロファイリング、CrashReporter、インタラクティブな GUI プレイグラウンド、HexEditor、C++ 用の HackStudio IDE など）
+- 暗号化から OpenGL、オーディオ、JavaScript、GUI、チェスプレイまであらゆる[ライブラリ](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries)
+- 多くの一般的・非一般的なファイル形式をサポート（PNG、JPEG、GIF、MP3、WAV、FLAC、ZIP、TAR、PDF、QOI、Gemini など）
+- 統一されたスタイルとデザイン哲学、柔軟なテーマシステム、[カスタム（ビットマップとベクター）フォント](https://fonts.serenityos.net/font-family)
+- [ゲーム](https://github.com/deimo-s/serenity/blob/master/Userland/Games)（Solitaire、Minesweeper、2048、チェス、コンウェイのライフゲームなど）と[デモ](https://github.com/deimo-s/serenity/blob/master/Userland/Demos)（CatDog、Starfield、Eyes、マンデルブロ集合、WidgetGallery など）
+- 日常的な GUI プログラムとユーティリティ（JavaScript 搭載のスプレッドシート、TextEditor、ターミナル、PixelPaint、各種マルチメディアビューア・プレーヤー、メール、アシスタント、電卓など）
+
+…上記のすべてがこのリポジトリにあり、追加の依存関係はなく、私たちがゼロから構築しました :^)
+
+さらに、ゲーム、コンパイラ、Unix ツール、マルチメディアアプリなどを含む[300 以上の人気オープンソースソフトウェアの移植](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md)があります。
+
+## ドキュメントの読み方
+
+man ページは [man.serenityos.org](https://man.serenityos.org) でオンライン閲覧できます。これらのページは [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman) にある Markdown ソースファイルから生成され、自動的に更新されます。
+
+SerenityOS を実行しているときは、ターミナルインターフェース用に `man` を、GUI 用に `help` を使用できます。
+
+コード関連のドキュメントは [Documentation](https://github.com/deimo-s/serenity/blob/master/Documentation) フォルダにあります。
+
+## ビルドと実行方法
+
+[SerenityOS のビルド手順](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) または [Ladybird のビルド手順](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md) を参照してください。
+
+ビルドシステムは、Linux、macOS、Windows（WSL2 経由）、その他多くの \*Nix からの SerenityOS のクロスコンパイルビルドをサポートしています。デフォルトのビルドシステムコマンドは、サポートされているハードウェアまたはソフトウェア仮想化を有効にして、OS を実行する QEMU インスタンスを起動します。
+
+Ladybird は、SerenityOS のクロスビルドのホストになりうる同じプラットフォーム、および SerenityOS 自体で動作します。
+
+## 参加して交流しましょう！
+
+Discord サーバーへ参加：[SerenityOS Discord](https://serenityos.org/discord)
+
+Issue を開く前に、[Issue ポリシー](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy) を確認してください。
+
+貢献に関する一般的なガイドは [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md) にあります。
+
+## 作者
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+その他多数！完全な貢献者リストは[こちら](https://github.com/SerenityOS/serenity/graphs/contributors)をご覧ください。上記にリストされている人々は、このプロジェクトに 100 以上のコミットを貢献しています。 :^)
+
+## ライセンス
+
+SerenityOS は 2 条項 BSD ライセンスの下でライセンスされています。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+64비트 x86, Arm 및 RISC-V 컴퓨터를 위한 그래픽 Unix 계열 운영 체제입니다.
+
+[FAQ](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [문서](#문서는-어디서-읽나요) | [빌드 안내](#빌드-및-실행-방법)
+
+## 소개
+
+SerenityOS는 90년대 사용자 인터페이스에 대한 러브레터이며, Unix 계열의 자체 커널을 갖추고 있습니다. 다양한 다른 시스템들에서 아름다운 아이디어들을 차용하여 진심으로 칭찬을 보냅니다.
+
+대략적으로 말하면, 목표는 1990년대 후반 생산성 소프트웨어의 미학과 2000년대 후반 \*nix의 파워 유저 접근성을 결합하는 것입니다. 이것은 우리가, 우리를 위해, 우리가 좋아하는 것들에 기반한 시스템입니다.
+
+YouTube에서 시스템 개발 과정을 보실 수 있습니다:
+
+- [Andreas Kling의 채널](https://youtube.com/andreaskling)
+- [Linus Groh의 채널](https://youtube.com/linusgroh)
+- [kleines Filmröllchen의 채널](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## 스크린샷
+
+![Screenshot c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## 기능
+
+- 선제적 멀티스레딩을 지원하는 모던 64비트 커널
+- JavaScript, WebAssembly 등을 지원하는 [브라우저](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser) ([JS](https://serenityos.github.io/libjs-website/test262/), [CSS](https://css.tobyase.de/), [Wasm](https://serenityos.github.io/libjs-website/wasm/) 명세 준수 여부를 확인하세요)
+- 보안 기능 (하드웨어 보호, 제한된 유저랜드 권한, W^X 메모리, `pledge` 및 `unveil`, (K)ASLR, OOM 저항, 웹 콘텐츠 격리, 최첨단 TLS 알고리즘 등)
+- [시스템 서비스](https://github.com/deimo-s/serenity/blob/master/Userland/Services) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer 등) 및 모던 IPC
+- 뛰어난 POSIX 호환성 ([LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC), 셸, 시스템 콜, 시그널, 의사 터미널, 파일 시스템 알림, 표준 Unix [유틸리티](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities) 등)
+- POSIX 계열 가상 파일 시스템 (/proc, /dev, /sys, /tmp 등) 및 ext2 파일 시스템
+- IPv4, TCP, UDP; DNS, HTTP, Gemini, IMAP, NTP를 지원하는 네트워크 스택 및 애플리케이션
+- 프로파일링, 디버깅 및 기타 개발 도구 (커널 지원 프로파일링, CrashReporter, 인터랙티브 GUI 플레이그라운드, HexEditor, C++용 HackStudio IDE 등)
+- 암호학부터 OpenGL, 오디오, JavaScript, GUI, 체스 플레이에 이르기까지 모든 것을 위한 [라이브러리](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries)
+- 다양한 일반적/비일반적 파일 형식 지원 (PNG, JPEG, GIF, MP3, WAV, FLAC, ZIP, TAR, PDF, QOI, Gemini 등)
+- 통일된 스타일 및 디자인 철학, 유연한 테마 시스템, [커스텀 (비트맵 및 벡터) 폰트](https://fonts.serenityos.net/font-family)
+- [게임](https://github.com/deimo-s/serenity/blob/master/Userland/Games) (Solitaire, Minesweeper, 2048, 체스, Conway의 생명 게임 등) 및 [데모](https://github.com/deimo-s/serenity/blob/master/Userland/Demos) (CatDog, Starfield, Eyes, 만델브로 집합, WidgetGallery 등)
+- 일상적인 GUI 프로그램 및 유틸리티 (JavaScript 지원 스프레드시트, TextEditor, 터미널, PixelPaint, 다양한 멀티미디어 뷰어 및 플레이어, Mail, Assistant, 계산기 등)
+
+... 그리고 위의 모든 것이 이 저장소에 있으며, 추가 의존성 없이 우리 모두가 직접 만들었습니다 :^)
+
+추가로, 게임, 컴파일러, Unix 도구, 멀티미디어 앱 등을 포함하는 [300개 이상의 인기 오픈소스 소프트웨어 포트](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md)가 있습니다.
+
+## 문서는 어디서 읽나요?
+
+맨페이지는 [man.serenityos.org](https://man.serenityos.org)에서 온라인으로 확인하실 수 있습니다. 이 페이지들은 [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman)의 Markdown 소스 파일에서 생성되며 자동으로 업데이트됩니다.
+
+SerenityOS를 실행 중일 때 터미널 인터페이스에는 `man`을, GUI에는 `help`를 사용하실 수 있습니다.
+
+코드 관련 문서는 [Documentation](https://github.com/deimo-s/serenity/blob/master/Documentation) 폴더에서 찾으실 수 있습니다.
+
+## 빌드 및 실행 방법
+
+[SerenityOS 빌드 안내](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) 또는 [Ladybird 빌드 안내](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md)를 참조하세요.
+
+빌드 시스템은 Linux, macOS, Windows (WSL2 사용) 및 기타 다양한 \*Nix에서의 SerenityOS 크로스 컴파일을 지원합니다. 기본 빌드 시스템 명령은 지원되는 하드웨어 또는 소프트웨어 가상화를 활성화한 상태로 OS를 실행하는 QEMU 인스턴스를 시작합니다.
+
+Ladybird는 SerenityOS의 크로스 빌드 호스트가 될 수 있는 동일한 플랫폼과 SerenityOS 자체에서 실행됩니다.
+
+## 연락하고 참여하세요!
+
+Discord 서버에 참여하세요: [SerenityOS Discord](https://serenityos.org/discord)
+
+이슈를 열기 전에 [이슈 정책](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy)을 확인해 주세요.
+
+기여에 대한 일반적인 안내는 [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md)에서 찾으실 수 있습니다.
+
+## 작성자
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+그리고 더 많은 분들! 전체 기여자 목록은 [여기](https://github.com/SerenityOS/serenity/graphs/contributors)를 참조하세요. 위에 나열된 분들은 프로젝트에 100개 이상의 커밋을 기여하셨습니다. :^)
+
+## 라이선스
+
+SerenityOS는 2-clause BSD 라이선스 하에 라이선스가 부여됩니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 Graphical Unix-like operating system for 64-bit x86, Arm, and RISC-V computers.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # SerenityOS
 
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
 Graphical Unix-like operating system for 64-bit x86, Arm, and RISC-V computers.
 
-[![GitHub Actions Status](https://github.com/SerenityOS/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/SerenityOS/serenity/actions/workflows/ci.yml)
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity)
 [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+Sistema operacional gráfico do tipo Unix para computadores x86 de 64 bits, Arm e RISC-V.
+
+[FAQ](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [Documentação](#como-leio-a-documentação) | [Instruções de compilação](#como-compilo-e-exec-isto)
+
+## Sobre
+
+SerenityOS é uma carta de amor às interfaces de usuário dos anos 90 com um núcleo tipo Unix próprio. Elogia com sinceridade ao roubar belas ideias de outros sistemas.
+
+Em termos gerais, o objetivo é um casamento entre a estética do software de produtividade do final dos anos 90 e a acessibilidade para usuários avançados do \*nix do final dos anos 2000. Este é um sistema nosso, para nós, baseado nas coisas que gostamos.
+
+Você pode assistir a vídeos do desenvolvimento do sistema no YouTube:
+
+- [Canal do Andreas Kling](https://youtube.com/andreaskling)
+- [Canal do Linus Groh](https://youtube.com/linusgroh)
+- [Canal do kleines Filmröllchen](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## Captura de tela
+
+![Screenshot c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## Recursos
+
+- Kernel moderno de 64 bits com multithreading preemptivo
+- [Navegador](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser) com JavaScript, WebAssembly e mais (verifique a conformidade com as especificações para [JS](https://serenityos.github.io/libjs-website/test262/), [CSS](https://css.tobyase.de/) e [Wasm](https://serenityos.github.io/libjs-website/wasm/))
+- Recursos de segurança (proteções de hardware, capacidades limitadas no espaço de usuário, memória W^X, `pledge` e `unveil`, (K)ASLR, resistência a OOM, isolamento de conteúdo web, algoritmos TLS de última geração, ...)
+- [Serviços do sistema](https://github.com/deimo-s/serenity/blob/master/Userland/Services) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer, ...) e IPC moderno
+- Boa compatibilidade POSIX ([LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC), Shell, syscalls, sinais, pseudoterminais, notificações do sistema de arquivos, [utilitários](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities) Unix padrão, ...)
+- Sistemas de arquivos virtuais no estilo POSIX (/proc, /dev, /sys, /tmp, ...) e sistema de arquivos ext2
+- Pilha de rede e aplicações com suporte a IPv4, TCP, UDP; DNS, HTTP, Gemini, IMAP, NTP
+- Ferramentas de criação de perfil, depuração e outras de desenvolvimento (criação de perfil com suporte do kernel, CrashReporter, playground GUI interativo, HexEditor, HackStudio IDE para C++ e mais)
+- [Bibliotecas](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries) para tudo, desde criptografia até OpenGL, áudio, JavaScript, GUI, jogar xadrez, ...
+- Suporte para muitos formatos de arquivo comuns e incomuns (PNG, JPEG, GIF, MP3, WAV, FLAC, ZIP, TAR, PDF, QOI, Gemini, ...)
+- Filosofia unificada de estilo e design, sistema de temas flexível, [fontes personalizadas (bitmap e vetoriais)](https://fonts.serenityos.net/font-family)
+- [Jogos](https://github.com/deimo-s/serenity/blob/master/Userland/Games) (Solitaire, Minesweeper, 2048, xadrez, Jogo da Vida de Conway, ...) e [demos](https://github.com/deimo-s/serenity/blob/master/Userland/Demos) (CatDog, Starfield, Eyes, conjunto de Mandelbrot, WidgetGallery, ...)
+- Programas GUI e utilitários do dia a dia (Planilha com JavaScript, TextEditor, Terminal, PixelPaint, vários visualizadores e reprodutores multimídia, Mail, Assistant, Calculadora, ...)
+
+... e tudo o que está acima está neste repositório, sem dependências extras, construído do zero por nós :^)
+
+Adicionalmente, há [mais de trezentos ports de software de código aberto popular](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md), incluindo jogos, compiladores, ferramentas Unix, aplicativos multimídia e mais.
+
+## Como leio a documentação?
+
+As páginas de manual estão disponíveis online em [man.serenityos.org](https://man.serenityos.org). Essas páginas são geradas a partir dos arquivos-fonte Markdown em [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman) e atualizadas automaticamente.
+
+Ao executar o SerenityOS você pode usar `man` para a interface de terminal, ou `help` para a GUI.
+
+A documentação relacionada ao código pode ser encontrada na pasta [Documentation](https://github.com/deimo-s/serenity/blob/master/Documentation).
+
+## Como compilo e executo isto?
+
+Veja as [instruções de compilação do SerenityOS](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) ou as [instruções de compilação do Ladybird](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md).
+
+O sistema de compilação suporta uma compilação cruzada do SerenityOS a partir de Linux, macOS, Windows (com WSL2) e muitos outros \*Nix. Os comandos padrão do sistema de compilação iniciarão uma instância do QEMU executando o SO com virtualização por hardware ou software habilitada conforme suportado.
+
+O Ladybird roda nas mesmas plataformas que podem ser o host para uma compilação cruzada do SerenityOS e no próprio SerenityOS.
+
+## Entre em contato e participe!
+
+Junte-se ao nosso servidor do Discord: [SerenityOS Discord](https://serenityos.org/discord)
+
+Antes de abrir uma issue, por favor veja a [política de issues](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy).
+
+Um guia geral para contribuir pode ser encontrado em [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md).
+
+## Autores
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+E muitos mais! Veja [aqui](https://github.com/SerenityOS/serenity/graphs/contributors) a lista completa de contribuidores. As pessoas listadas acima realizaram mais de 100 commits no projeto. :^)
+
+## Licença
+
+SerenityOS é licenciado sob uma licença BSD de 2 cláusulas.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+Графическая Unix-подобная операционная система для 64-битных компьютеров на x86, Arm и RISC-V.
+
+[FAQ](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [Документация](#как-читать-документацию) | [Инструкции по сборке](#как-собрать-и-запустить)
+
+## О проекте
+
+SerenityOS — это письмо любви пользовательским интерфейсам 90-х с собственным Unix-подобным ядром. Оно льстит искренне, заимствуя красивые идеи из других систем.
+
+Грубо говоря, цель — брак между эстетикой программ для продуктивности конца 90-х и доступностью для опытных пользователей \*nix конца 2000-х. Это система от нас, для нас, основанная на том, что нам нравится.
+
+Вы можете смотреть видео разработки системы на YouTube:
+
+- [Канал Andreas Kling](https://youtube.com/andreaskling)
+- [Канал Linus Groh](https://youtube.com/linusgroh)
+- [Канал kleines Filmröllchen](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## Скриншот
+
+![Screenshot c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## Возможности
+
+- Современное 64-битное ядро с вытесняющей многопоточностью
+- [Браузер](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser) с JavaScript, WebAssembly и многим другим (проверьте соответствие спецификациям для [JS](https://serenityos.github.io/libjs-website/test262/), [CSS](https://css.tobyase.de/) и [Wasm](https://serenityos.github.io/libjs-website/wasm/))
+- Функции безопасности (аппаратные защиты, ограниченные возможности пользовательского пространства, память W^X, `pledge` и `unveil`, (K)ASLR, устойчивость к OOM, изоляция веб-контента, современные алгоритмы TLS, ...)
+- [Системные службы](https://github.com/deimo-s/serenity/blob/master/Userland/Services) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer, ...) и современный IPC
+- Хорошая совместимость с POSIX ([LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC), Shell, системные вызовы, сигналы, псевдотерминалы, уведомления файловой системы, стандартные Unix-[утилиты](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities), ...)
+- POSIX-подобные виртуальные файловые системы (/proc, /dev, /sys, /tmp, ...) и файловая система ext2
+- Сетевой стек и приложения с поддержкой IPv4, TCP, UDP; DNS, HTTP, Gemini, IMAP, NTP
+- Профилирование, отладка и другие инструменты разработки (профилирование с поддержкой ядра, CrashReporter, интерактивная GUI-площадка, HexEditor, IDE HackStudio для C++ и другое)
+- [Библиотеки](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries) для всего: от криптографии до OpenGL, аудио, JavaScript, GUI, игры в шахматы, ...
+- Поддержка многих распространённых и редких форматов файлов (PNG, JPEG, GIF, MP3, WAV, FLAC, ZIP, TAR, PDF, QOI, Gemini, ...)
+- Единая философия стиля и дизайна, гибкая система тем, [пользовательские (растровые и векторные) шрифты](https://fonts.serenityos.net/font-family)
+- [Игры](https://github.com/deimo-s/serenity/blob/master/Userland/Games) (Solitaire, Minesweeper, 2048, шахматы, «Жизнь» Конвея, ...) и [демо](https://github.com/deimo-s/serenity/blob/master/Userland/Demos) (CatDog, Starfield, Eyes, множество Мандельброта, WidgetGallery, ...)
+- Повседневные GUI-программы и утилиты (электронная таблица с JavaScript, TextEditor, Terminal, PixelPaint, различные мультимедийные просмотрщики и плееры, Mail, Assistant, Калькулятор, ...)
+
+... и всё вышеперечисленное находится прямо в этом репозитории, без дополнительных зависимостей, создано нами с нуля :^)
+
+Дополнительно, существует [более трёхсот портов популярного ПО с открытым исходным кодом](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md), включая игры, компиляторы, Unix-инструменты, мультимедийные приложения и многое другое.
+
+## Как читать документацию?
+
+Man-страницы доступны онлайн на [man.serenityos.org](https://man.serenityos.org). Эти страницы генерируются из Markdown-исходников в [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman) и обновляются автоматически.
+
+При работе в SerenityOS вы можете использовать `man` для терминального интерфейса или `help` для GUI.
+
+Документация, связанная с кодом, находится в папке [Documentation](https://github.com/deimo-s/serenity/blob/master/Documentation).
+
+## Как собрать и запустить?
+
+Смотрите [инструкции по сборке SerenityOS](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) или [инструкции по сборке Ladybird](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md).
+
+Система сборки поддерживает кросс-компиляцию SerenityOS из Linux, macOS, Windows (с WSL2) и многих других \*Nix. Команды системы сборки по умолчанию запустят экземпляр QEMU с ОС и включённой аппаратной или программной виртуализацией (если поддерживается).
+
+Ladybird работает на тех же платформах, которые могут быть хостом для кросс-сборки SerenityOS, а также на самой SerenityOS.
+
+## Связывайтесь и участвуйте!
+
+Присоединяйтесь к нашему Discord-серверу: [SerenityOS Discord](https://serenityos.org/discord)
+
+Прежде чем открыть issue, пожалуйста, ознакомьтесь с [политикой issue](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy).
+
+Общее руководство по участию можно найти в [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md).
+
+## Авторы
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+И многие другие! Полный список участников смотрите [здесь](https://github.com/SerenityOS/serenity/graphs/contributors). Люди, перечисленные выше, внесли более 100 коммитов в проект. :^)
+
+## Лицензия
+
+SerenityOS лицензирован под лицензией BSD с 2 пунктами.

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+64-bit x86, Arm ve RISC-V bilgisayarlar için grafiksel Unix-benzeri işletim sistemi.
+
+[Sıkça Sorulan Sorular](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [Belgeler](#belgeleri-nasıl-okurum) | [Derleme Talimatları](#derleyip-çalıştırmak)
+
+## Hakkında
+
+SerenityOS, '90'ların kullanıcı arayüzlerine yazılmış bir aşk mektubudur ve özel bir Unix-benzeri çekirdeğe sahiptir. Çeşitli diğer sistemlerden güzel fikirleri ödünç alarak içtenlikle pohpohlar.
+
+Kabaca söylemek gerekirse, hedef 1990'ların sonlarındaki üretkenlik yazılımlarının estetiği ile 2000'lerin sonlarındaki \*nix sistemlerinin güçlü kullanıcı erişilebilirliğinin evliliğidir. Bu, bizim için, bizim tarafımızdan, sevdiğimiz şeylere dayalı bir sistemdir.
+
+Sistemin geliştirilmesini YouTube'da izleyebilirsiniz:
+
+- [Andreas Kling'in kanalı](https://youtube.com/andreaskling)
+- [Linus Groh'un kanalı](https://youtube.com/linusgroh)
+- [kleines Filmröllchen'in kanalı](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## Ekran Görüntüsü
+
+![Ekran Görüntüsü c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## Özellikler
+
+- Önleyici çoklu iş parçacığı desteği ile modern 64-bit çekirdek
+- JavaScript, WebAssembly ve daha fazlasıyla [Tarayıcı](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser) ([JS](https://serenityos.github.io/libjs-website/test262/), [CSS](https://css.tobyase.de/) ve [Wasm](https://serenityos.github.io/libjs-website/wasm/) uyumluluğunu kontrol edin)
+- Güvenlik özellikleri (donanım korumaları, sınırlı kullanıcı alanı yetenekleri, W^X bellek, `pledge` ve `unveil`, (K)ASLR, OOM direnci, web içeriği izolasyonu, son teknoloji TLS algoritmaları, ...)
+- [Sistem servisleri](https://github.com/deimo-s/serenity/blob/master/Userland/Services) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer, ...) ve modern IPC
+- İyi POSIX uyumluluğu ([LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC), Shell, sistem çağrıları, sinyaller, sözde terminaller, dosya sistemi bildirimleri, standart Unix [yardımcı programları](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities), ...)
+- POSIX-benzeri sanal dosya sistemleri (/proc, /dev, /sys, /tmp, ...) ve ext2 dosya sistemi
+- IPv4, TCP, UDP; DNS, HTTP, Gemini, IMAP, NTP destekli ağ yığını ve uygulamaları
+- Profil oluşturma, hata ayıklama ve diğer geliştirme araçları (Çekirdek destekli profil oluşturma, CrashReporter, etkileşimli GUI oyun alanı, HexEditor, C++ için HackStudio IDE ve daha fazlası)
+- Kriptografiden OpenGL'e, ses, JavaScript, GUI, satranç oynamaya kadar her şey için [kütüphaneler](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries)
+- Birçok yaygın ve yaygın olmayan dosya biçimi desteği (PNG, JPEG, GIF, MP3, WAV, FLAC, ZIP, TAR, PDF, QOI, Gemini, ...)
+- Birleşik stil ve tasarım felsefesi, esnek tema sistemi, [özel (bit eşlem ve vektör) yazı tipleri](https://fonts.serenityos.net/font-family)
+- [Oyunlar](https://github.com/deimo-s/serenity/blob/master/Userland/Games) (Solitaire, Minesweeper, 2048, satranç, Conway'in Hayat Oyunu, ...) ve [demolar](https://github.com/deimo-s/serenity/blob/master/Userland/Demos) (CatDog, Starfield, Eyes, Mandelbrot kümesi, WidgetGallery, ...)
+- Günlük GUI programları ve yardımcı programlar (JavaScript destekli Hesap Tablosu, TextEditor, Terminal, PixelPaint, çeşitli multimedya görüntüleyiciler ve oynatıcılar, Mail, Assistant, Hesap Makinesi, ...)
+
+... ve yukarıdakilerin hepsi bu depoda, ekstra bağımlılık yok, tarafımızca sıfırdan geliştirildi :^)
+
+Ek olarak, oyunlar, derleyiciler, Unix araçları, multimedya uygulamaları ve daha fazlasını içeren [üç yüzden fazla popüler açık kaynaklı yazılım portu](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md) bulunmaktadır.
+
+## Belgeleri nasıl okurum?
+
+Man sayfaları çevrimiçi olarak [man.serenityos.org](https://man.serenityos.org) adresinde mevcuttur. Bu sayfalar [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman) içindeki Markdown kaynak dosyalarından oluşturulur ve otomatik olarak güncellenir.
+
+SerenityOS çalıştırırken terminal arayüzü için `man`, GUI için `help` kullanabilirsiniz.
+
+Kodla ilgili belgeler [belgeler](https://github.com/deimo-s/serenity/blob/master/Documentation) klasöründe bulunabilir.
+
+## Derleyip çalıştırmak
+
+[SerenityOS derleme talimatlarına](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) veya [Ladybird derleme talimatlarına](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md) bakın.
+
+Derleme sistemi, Linux, macOS, Windows (WSL2 ile) ve diğer birçok \*Nix'ten SerenityOS'un çapraz derlemesini destekler. Varsayılan derleme sistemi komutları, desteklendiği şekilde donanım veya yazılım sanallaştırma etkinken OS çalıştıran bir QEMU örneğini başlatır.
+
+Ladybird, SerenityOS'un çapraz derlemesi için ana makine olabilen aynı platformlarda ve SerenityOS'un kendisinde çalışır.
+
+## İletişime geçin ve katılın!
+
+Discord sunucumuza katılın: [SerenityOS Discord](https://serenityos.org/discord)
+
+Bir sorun açmadan önce, lütfen [sorun politikasına](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy) bakın.
+
+Katkıda bulunmak için genel bir kılavuz [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md) dosyasında bulunabilir.
+
+## Yazarlar
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+Ve daha pek çok kişi! Tam katkıda bulunanlar listesi için [buraya bakın](https://github.com/SerenityOS/serenity/graphs/contributors). Yukarıda listelenen kişiler projede 100'den fazla commit gerçekleştirmiştir. :^)
+
+## Lisans
+
+SerenityOS, 2 maddeli BSD lisansı altında lisanslanmıştır.

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,145 @@
+# SerenityOS
+
+> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+
+[![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
+
+64 位 x86、Arm 和 RISC-V 计算机的图形化类 Unix 操作系统。
+
+[常见问题](https://github.com/deimo-s/serenity/blob/master/Documentation/FAQ.md) | [文档](#如何阅读文档) | [构建说明](#如何构建和运行)
+
+## 关于
+
+SerenityOS 是一封写给 90 年代用户界面的情书，它拥有一个自定义的类 Unix 内核。它通过借鉴其他系统中优美的想法，真诚地取悦用户。
+
+粗略地说，目标是 90 年代末生产力软件的美学与 00 年代末 \*nix 系统的强大用户可访问性的结合。这是一个由我们、为我们、基于我们喜爱的事物而构建的系统。
+
+您可以在 YouTube 上观看该系统的开发视频：
+
+- [Andreas Kling 的频道](https://youtube.com/andreaskling)
+- [Linus Groh 的频道](https://youtube.com/linusgroh)
+- [kleines Filmröllchen 的频道](https://www.youtube.com/c/kleinesfilmroellchen)
+
+## 截图
+
+![Screenshot c03b788.png](https://raw.githubusercontent.com/deimo-s/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+
+## 特性
+
+- 具有抢占式多线程的现代 64 位内核
+- 带有 JavaScript、WebAssembly 等功能的[浏览器](https://github.com/deimo-s/serenity/blob/master/Userland/Applications/Browser)（查看 [JS](https://serenityos.github.io/libjs-website/test262/)、[CSS](https://css.tobyase.de/) 和 [Wasm](https://serenityos.github.io/libjs-website/wasm/) 的规范合规性）
+- 安全特性（硬件保护、有限的用户空间能力、W^X 内存、`pledge` 和 `unveil`、(K)ASLR、OOM 抵抗、Web 内容隔离、最先进的 TLS 算法等）
+- [系统服务](https://github.com/deimo-s/serenity/blob/master/Userland/Services)（WindowServer、LoginServer、AudioServer、WebServer、RequestServer、CrashServer 等）和现代 IPC
+- 良好的 POSIX 兼容性（[LibC](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries/LibC)、Shell、系统调用、信号、伪终端、文件系统通知、标准的 Unix [实用程序](https://github.com/deimo-s/serenity/blob/master/Userland/Utilities) 等）
+- 类 POSIX 的虚拟文件系统（/proc、/dev、/sys、/tmp 等）和 ext2 文件系统
+- 支持 IPv4、TCP、UDP 的网络协议栈及应用程序，支持 DNS、HTTP、Gemini、IMAP、NTP
+- 分析、调试和其他开发工具（内核支持的分析、CrashReporter、交互式 GUI playground、HexEditor、适用于 C++ 的 HackStudio IDE 等）
+- 从密码学到 OpenGL、音频、JavaScript、GUI、下棋等各个领域的[库](https://github.com/deimo-s/serenity/blob/master/Userland/Libraries)
+- 支持许多常见和不常见的文件格式（PNG、JPEG、GIF、MP3、WAV、FLAC、ZIP、TAR、PDF、QOI、Gemini 等）
+- 统一的样式和设计理念、灵活的主题系统、[自定义（位图和矢量）字体](https://fonts.serenityos.net/font-family)
+- [游戏](https://github.com/deimo-s/serenity/blob/master/Userland/Games)（Solitaire、Minesweeper、2048、国际象棋、康威生命游戏等）和[演示程序](https://github.com/deimo-s/serenity/blob/master/Userland/Demos)（CatDog、Starfield、Eyes、曼德博集合、WidgetGallery 等）
+- 日常 GUI 程序和实用工具（带 JavaScript 的电子表格、TextEditor、终端、PixelPaint、各种多媒体查看器和播放器、Mail、Assistant、计算器等）
+
+…以上所有内容都包含在此仓库中，无需额外依赖，全部由我们从零开始构建 :^)
+
+此外，还有[三百多个流行开源软件的移植版本](https://github.com/deimo-s/serenity/blob/master/Ports/AvailablePorts.md)，包括游戏、编译器、Unix 工具、多媒体应用程序等等。
+
+## 如何阅读文档？
+
+手册页可在 [man.serenityos.org](https://man.serenityos.org) 在线获取。这些页面是从 [`Base/usr/share/man`](https://github.com/SerenityOS/serenity/tree/master/Base/usr/shareman) 中的 Markdown 源文件生成的，并会自动更新。
+
+运行 SerenityOS 时，您可以使用 `man` 命令访问终端界面，或使用 `help` 命令访问 GUI。
+
+与代码相关的文档可在 [文档](https://github.com/deimo-s/serenity/blob/master/Documentation) 文件夹中找到。
+
+## 如何构建和运行？
+
+请参阅 [SerenityOS 构建说明](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructions.md) 或 [Ladybird 构建说明](https://github.com/deimo-s/serenity/blob/master/Documentation/BuildInstructionsLadybird.md)。
+
+构建系统支持从 Linux、macOS、Windows（使用 WSL2）和许多其他 \*Nix 系统交叉编译 SerenityOS。默认的构建系统命令将启动一个 QEMU 实例来运行操作系统，根据支持情况启用硬件或软件虚拟化。
+
+Ladybird 可以在与可作为 SerenityOS 交叉构建主机的相同平台上运行，也可以在 SerenityOS 本身运行。
+
+## 联系我们并参与其中！
+
+加入我们的 Discord 服务器：[SerenityOS Discord](https://serenityos.org/discord)
+
+在提交问题之前，请参阅[问题策略](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy)。
+
+贡献指南可在 [`CONTRIBUTING.md`](https://github.com/deimo-s/serenity/blob/master/CONTRIBUTING.md) 中找到。
+
+## 作者
+
+- **Andreas Kling** - [awesomekling](https://twitter.com/awesomekling) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/awesomekling)
+- **Robin Burchell** - [rburchell](https://github.com/rburchell)
+- **Conrad Pankoff** - [deoxxa](https://github.com/deoxxa)
+- **Sergey Bugaev** - [bugaevc](https://github.com/bugaevc)
+- **Liav A** - [supercomputer7](https://github.com/supercomputer7)
+- **Linus Groh** - [linusg](https://github.com/linusg) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/linusg)
+- **Ali Mohammad Pur** - [alimpfard](https://github.com/alimpfard)
+- **Shannon Booth** - [shannonbooth](https://github.com/shannonbooth)
+- **Hüseyin ASLITÜRK** - [asliturk](https://github.com/asliturk)
+- **Matthew Olsson** - [mattco98](https://github.com/mattco98)
+- **Nico Weber** - [nico](https://github.com/nico)
+- **Brian Gianforcaro** - [bgianfo](https://github.com/bgianfo)
+- **Ben Wiederhake** - [BenWiederhake](https://github.com/BenWiederhake)
+- **Tom** - [tomuta](https://github.com/tomuta)
+- **Paul Scharnofske** - [asynts](https://github.com/asynts)
+- **Itamar Shenhar** - [itamar8910](https://github.com/itamar8910)
+- **Luke Wilde** - [Lubrsi](https://github.com/Lubrsi)
+- **Brendan Coles** - [bcoles](https://github.com/bcoles)
+- **Andrew Kaster** - [ADKaster](https://github.com/ADKaster) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ADKaster)
+- **thankyouverycool** - [thankyouverycool](https://github.com/thankyouverycool)
+- **Idan Horowitz** - [IdanHo](https://github.com/IdanHo)
+- **Gunnar Beutner** - [gunnarbeutner](https://github.com/gunnarbeutner)
+- **Tim Flynn** - [trflynn89](https://github.com/trflynn89)
+- **Jean-Baptiste Boric** - [boricj](https://github.com/boricj)
+- **Stephan Unverwerth** - [sunverwerth](https://github.com/sunverwerth)
+- **Max Wipfli** - [MaxWipfli](https://github.com/MaxWipfli)
+- **Daniel Bertalan** - [BertalanD](https://github.com/BertalanD)
+- **Jelle Raaijmakers** - [GMTA](https://github.com/GMTA)
+- **Sam Atkins** - [AtkinsSJ](https://github.com/AtkinsSJ) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/AtkinsSJ)
+- **Tobias Christiansen** - [TobyAsE](https://github.com/TobyAsE)
+- **Lenny Maiorani** - [ldm5180](https://github.com/ldm5180)
+- **sin-ack** - [sin-ack](https://github.com/sin-ack)
+- **Jesse Buhagiar** - [Quaker762](https://github.com/Quaker762)
+- **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
+- **Karol Kosek** - [krkk](https://github.com/krkk)
+- **Mustafa Quraish** - [mustafaquraish](https://github.com/mustafaquraish)
+- **David Tuin** - [davidot](https://github.com/davidot)
+- **Leon Albrecht** - [Hendiadyoin1](https://github.com/Hendiadyoin1)
+- **Tim Schumacher** - [timschumi](https://github.com/timschumi)
+- **Marcus Nilsson** - [metmo](https://github.com/metmo)
+- **Gegga Thor** - [Xexxa](https://github.com/Xexxa) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/Xexxa)
+- **kleines Filmröllchen** - [kleinesfilmroellchen](https://github.com/kleinesfilmroellchen) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/kleinesfilmroellchen)
+- **Kenneth Myhra** - [kennethmyhra](https://github.com/kennethmyhra)
+- **Maciej** - [sppmacd](https://github.com/sppmacd)
+- **Sahan Fernando** - [ccapitalK](https://github.com/ccapitalK)
+- **Benjamin Maxwell** - [MacDue](https://github.com/MacDue)
+- **Dennis Esternon** - [djwisdom](https://github.com/djwisdom) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/djwisdom)
+- **frhun** - [frhun](https://github.com/frhun)
+- **networkException** - [networkException](https://github.com/networkException) [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/networkException)
+- **Brandon Jordan** - [electrikmilk](https://github.com/electrikmilk)
+- **Lucas Chollet** - [LucasChollet](https://github.com/LucasChollet)
+- **Timon Kruiper** - [FireFox317](https://github.com/FireFox317)
+- **Martin Falisse** - [martinfalisse](https://github.com/martinfalisse)
+- **Gregory Bertilson** - [Zaggy1024](https://github.com/Zaggy1024)
+- **Erik Wouters** - [EWouters](https://github.com/EWouters)
+- **Rodrigo Tobar** - [rtobar](https://github.com/rtobar)
+- **Alexander Kalenik** - [kalenikaliaksandr](https://github.com/kalenikaliaksandr)
+- **Tim Ledbetter** - [tcl3](https://github.com/tcl3)
+- **Steffen T. Larssen** - [stelar7](https://github.com/stelar7)
+- **Andi Gallo** - [axgallo](https://github.com/axgallo)
+- **Simon Wanner** - [skyrising](https://github.com/skyrising)
+- **FalseHonesty** - [FalseHonesty](https://github.com/FalseHonesty)
+- **Bastiaan van der Plaat** - [bplaat](https://github.com/bplaat)
+- **Dan Klishch** - [DanShaders](https://github.com/DanShaders)
+- **Julian Offenhäuser** - [janso3](https://github.com/janso3)
+- **Sönke Holz** - [spholz](https://github.com/spholz)
+- **implicitfield** - [implicitfield](https://github.com/implicitfield)
+
+以及更多贡献者！完整的贡献者列表请参见[这里](https://github.com/SerenityOS/serenity/graphs/contributors)。上面列出的人在项目中提交了 100 多个 commit。 :^)
+
+## 许可证
+
+SerenityOS 采用两条款 BSD 许可证授权。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # SerenityOS
 
-> 🌐 **Languages / Diller:** [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
+> 🌐  [English](README.md) · [Türkçe](README.tr.md) · [中文 (简体)](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Español](README.es.md) · [Português (Brasil)](README.pt-BR.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 [![GitHub Actions Status](https://github.com/deimo-s/serenity/actions/workflows/ci.yml/badge.svg)](https://github.com/deimo-s/serenity/actions/workflows/ci.yml) [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity) [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 

--- a/Userland/Games/Chess/Engine.cpp
+++ b/Userland/Games/Chess/Engine.cpp
@@ -43,9 +43,10 @@ void Engine::connect_to_engine_service()
     posix_spawn_file_actions_adddup2(&file_actions, wpipefds[0], STDIN_FILENO);
     posix_spawn_file_actions_adddup2(&file_actions, rpipefds[1], STDOUT_FILENO);
 
-    auto command_length = m_command.code_points().length();
+    auto command_bytes = m_command.bytes_as_string_view();
+    auto command_length = command_bytes.length();
     auto command_name = new char[command_length + 1];
-    memcpy(command_name, m_command.bytes_as_string_view().characters_without_null_termination(), command_length);
+    memcpy(command_name, command_bytes.characters_without_null_termination(), command_length);
     command_name[command_length] = '\0';
 
     char const* argv[] = { command_name, nullptr };


### PR DESCRIPTION
Two changes:

1. ChessEngine: use byte length (not code-point count) when copying the engine
   command name, so multi-byte UTF-8 paths are not truncated.

2. Add translated READMEs (tr, zh-CN, ja, ko, es, pt-BR, fr, de, ru) with a
   language navigator at the top of every README.