### PR TITLE
CI: Bump actions/cache from 4 to 6

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -105,7 +105,7 @@ runs:
         echo "::endgroup::"
 
     - name: 'Toolchain Prebuilt Cache'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       id: 'toolchain-prebuilt'
       if: ${{ inputs.arch != 'Lagom' }}
       with:
@@ -113,14 +113,14 @@ runs:
         key: '"toolchain" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ steps.toolchain-stamps.outputs.toolchain_stamp }}"'
 
     - name: 'Jakt Toolchain Prebuilt Cache'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       id: 'jakt-prebuilt'
       with:
         path: ${{ inputs.jakt_toolchain_cache_path }}
         key: toolchain-${{ runner.os }}-jakt-toolchain-${{ inputs.arch }}-${{ steps.toolchain-stamps.outputs.toolchain_stamp }}-${{ hashFiles('Toolchain/BuildJakt.sh') }}
 
     - name: 'Toolchain Compiler Cache'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       id: 'toolchain-ccache'
       if: ${{ inputs.toolchain_ccache_path != '' }}
       with:
@@ -138,7 +138,7 @@ runs:
           CCACHE_DIR=${{ inputs.toolchain_ccache_path }} ccache -z
 
     - name: 'Serenity Compiler Cache'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       id: 'serenity-ccache'
       if: ${{ inputs.serenity_ccache_path != '' }}
       with:
@@ -160,19 +160,19 @@ runs:
           CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -z
 
     - name: 'TimeZoneData cache'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ inputs.download_cache_path }}/TZDB
         key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
 
     - name: 'UnicodeData cache'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
           path: ${{ inputs.download_cache_path }}/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
 
     - name: 'UnicodeLocale cache'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
           path: ${{ inputs.download_cache_path }}/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -62,7 +62,7 @@ runs:
         echo "::endgroup::"
 
     - name: 'Toolchain Prebuilt Cache'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       # Do not waste time and storage space by updating the toolchain cache from a PR,
       # as it would be discarded after being merged anyway.
       if: ${{ github.event_name != 'pull_request' && !inputs.toolchain_prebuilt_hit && inputs.arch != 'Lagom' }}
@@ -71,14 +71,14 @@ runs:
         key: ${{ inputs.toolchain_prebuilt_primary_key }}
 
     - name: 'Jakt Toolchain Prebuilt Cache'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       if: ${{ github.event_name != 'pull_request' && !inputs.jakt_prebuilt_hit }}
       with:
           path: ${{ inputs.jakt_prebuilt_path }}
           key: ${{ inputs.jakt_prebuilt_primary_key }}
 
     - name: 'Toolchain Compiler Cache'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       if: ${{ github.event_name != 'pull_request' && inputs.toolchain_ccache_path != '' }}
       with:
         path: ${{ inputs.toolchain_ccache_path }}
@@ -91,7 +91,7 @@ runs:
         CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache --evict-older-than=1d
 
     - name: 'Serenity Compiler Cache'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       if: ${{ github.event_name != 'pull_request' && inputs.serenity_ccache_path != '' }}
       with:
         path: ${{ inputs.serenity_ccache_path }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,14 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
     commit-message:
       prefix: "CI:"
+    groups:
+      actions:
+        group-by: dependency-name


### PR DESCRIPTION
Each CI run currently contains multiple of these warnings:
"Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache/restore@v4, actions/cache/save@v4, actions/cache@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/"

This PR should make these warnings disappear by updating "actions/cache" to v6 and ensuring that dependabot will notify us about future action updates in ".github/actions".

(ref https://github.com/LadybirdBrowser/ladybird/pull/10184 and https://github.com/LadybirdBrowser/ladybird/pull/10282)