### PR TITLE
Kernel: Ignore Intel HDA devices with Interrupt Line == 255

### DIFF
--- a/Kernel/Devices/Audio/IntelHDA/Controller.cpp
+++ b/Kernel/Devices/Audio/IntelHDA/Controller.cpp
@@ -39,6 +39,14 @@ UNMAP_AFTER_INIT ErrorOr<void> Controller::initialize(Badge<AudioManagement>)
 {
     // Enable DMA and interrupts
     PCI::enable_bus_mastering(device_identifier());
+
+    // 255 means "unknown" or "no connection".
+    // FIXME: This not the best place to catch this. We should probably make interrupt_line() return an Optional<>.
+    //        Or even better, support getting PCI interrupt lines from AML code, which would remove the
+    //        need for us to rely on the firmware setting the correct interrupt line in PCI config space.
+    if (device_identifier().interrupt_line().value() == 255)
+        return ENOTSUP;
+
     m_interrupt_handler = TRY(InterruptHandler::create(*this));
 
     // 3.3.3, 3.3.4: Controller version


### PR DESCRIPTION
Several bare metal systems have Intel HDA controllers with the Interrupt Line PCI configuration space register set to 255. Before, we would crash because the interrupt number is too high. 255 appears to mean "unknown" or "no connection", so ignore devices with this value.

Instead of doing this in every device driver, we should make interrupt_line() return an Optional and make device drivers react accordingly if the Optional doesn't have a value.

If we have an AML interpreter in the future, we could use it to properly determine PCI interrupt routing info without having to rely on the firmware setting the Interrupt Line register for every device.