### PR TITLE
Kernel/aarch64: Allow setting the RPi framebuffer size from the cmdline

### DIFF
--- a/Kernel/Arch/aarch64/RPi/Framebuffer.cpp
+++ b/Kernel/Arch/aarch64/RPi/Framebuffer.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Arch/aarch64/RPi/Framebuffer.h>
 #include <Kernel/Arch/aarch64/RPi/FramebufferMailboxMessages.h>
 #include <Kernel/Boot/BootInfo.h>
+#include <Kernel/Boot/CommandLine.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel::RPi {
@@ -16,8 +17,11 @@ Framebuffer::Framebuffer()
 {
     // FIXME: query HDMI for best mode
     // https://github.com/raspberrypi/userland/blob/master/host_applications/linux/apps/tvservice/tvservice.c
-    m_width = 1280;
-    m_height = 720;
+
+    auto requested_framebuffer_size = kernel_command_line().rpi_framebuffer_size();
+
+    m_width = requested_framebuffer_size.width;
+    m_height = requested_framebuffer_size.height;
     m_depth = 32;
     m_initialized = false;
 

--- a/Kernel/Boot/CommandLine.cpp
+++ b/Kernel/Boot/CommandLine.cpp
@@ -327,4 +327,30 @@ UNMAP_AFTER_INIT size_t CommandLine::switch_to_tty() const
     }
     PANIC("Invalid default tty value: {}", default_tty);
 }
+
+UNMAP_AFTER_INIT CommandLine::RPiFramebufferSize CommandLine::rpi_framebuffer_size() const
+{
+    auto framebuffer_size_str = lookup("rpi_framebuffer_size"sv).value_or("1280x720"sv);
+
+    RPiFramebufferSize framebuffer_size;
+
+    framebuffer_size_str.for_each_split_view('x', SplitBehavior::Nothing,
+        [i = 0, framebuffer_size_str, &framebuffer_size](StringView part) mutable {
+            auto maybe_value = part.to_number<u32>();
+            if (!maybe_value.has_value())
+                PANIC("Invalid Raspberry Pi framebuffer size: {}", framebuffer_size_str);
+
+            if (i == 0)
+                framebuffer_size.width = maybe_value.release_value();
+            else if (i == 1)
+                framebuffer_size.height = maybe_value.release_value();
+            else
+                PANIC("Invalid Raspberry Pi framebuffer size: {}", framebuffer_size_str);
+
+            i++;
+        });
+
+    return framebuffer_size;
+}
+
 }

--- a/Kernel/Boot/CommandLine.h
+++ b/Kernel/Boot/CommandLine.h
@@ -67,6 +67,11 @@ public:
         Disabled
     };
 
+    struct RPiFramebufferSize {
+        u32 width;
+        u32 height;
+    };
+
     [[nodiscard]] StringView string() const { return m_string->view(); }
     Optional<StringView> lookup(StringView key) const;
     [[nodiscard]] bool contains(StringView key) const;
@@ -101,6 +106,7 @@ public:
     [[nodiscard]] bool is_nvme_polling_enabled() const;
     [[nodiscard]] bool is_xhci_polling_enabled() const;
     [[nodiscard]] size_t switch_to_tty() const;
+    [[nodiscard]] RPiFramebufferSize rpi_framebuffer_size() const;
 
 private:
     CommandLine(StringView);


### PR DESCRIPTION
In the future, it's probably better to somehow turn this framebuffer code into a GraphicsAdapter so we can change it in DisplaySettings at runtime. But for now this is better than having to be stuck with a 1280x720 framebuffer.