### PR TITLE
LibCore: Don't convert EventReceivers to RefPtrs unconditionally

### DIFF
--- a/Userland/Libraries/LibCore/ThreadEventQueue.cpp
+++ b/Userland/Libraries/LibCore/ThreadEventQueue.cpp
@@ -21,14 +21,14 @@ struct ThreadEventQueue::Private {
         AK_MAKE_DEFAULT_MOVABLE(QueuedEvent);
 
     public:
-        QueuedEvent(RefPtr<EventReceiver> const& receiver, NonnullOwnPtr<Event> event)
+        QueuedEvent(EventReceiver* receiver, NonnullOwnPtr<Event> event)
             : receiver(receiver)
             , event(move(event))
             , event_type(this->event->type())
         {
         }
 
-        QueuedEvent(RefPtr<EventReceiver> const& receiver, Event::Type event_type)
+        QueuedEvent(EventReceiver* receiver, Event::Type event_type)
             : receiver(receiver)
             , event_type(event_type)
         {


### PR DESCRIPTION
In https://github.com/serenityos/serenity/commit/0aa569fcad23d270a127d672fb08ce4b0c29d5e5, which is a port of
https://github.com/ladybirdbrowser/ladybird/commit/b572ae95a91cfcd7189c1cd772c1e7d42a06afb2, the EventReceiver
argument to ThreadEventQueue's QueuedEvents was changed from a reference
to a pointer. However, the actual receiver is supposed to only be a
WeakPtr. By converting to RefPtr in the constructor, any Weakable
receivers that are in the process of being destroyed when an event
targeting them was queued would crash the application.

The commit https://github.com/serenityos/serenity/commit/3de118dc9d48f4e542387bce2249c43858e7fa7e, which was cherry-
picked from https://github.com/ladybirdbrowser/ladybird/commit/69515f8c8548fe35f1bb08fcc5a1d9e851b6e675, carried
over this bug/oversight to the EventType constructor for QueuedEvents.

This is actually horrifying behavior to depend on, as it means there are
applications (like WindowServer) that rely on the behavior of an event
receiver calling a function from its destructor that could post events
at its soon-to-be-destroyed self. This is expected to work in
ThreadEventQueue and related classes because the QueuedEvent will only
hold a WeakPtr to the reciever. There is no requirement that the
reference count of an object be > 0 when creating a WeakPtr, for some
reason. In sequence, the destructor for the reciver-derived object calls
post_event(this), which creates a QueuedEvent with a WeakPtr to the
receiver. Next, the destructor for EventReciever is called, which is
mostly a no-op. The destructor for `Weakable<EventReciever>` then runs
and clears out all the WeakLinks, including the one in the QueuedEvent
we just posted. This only works when the code is careful to avoid
creating RefPtrs to weakable objects that may be in the process of being
destroyed. Keeping track of such possibilities is quite confusing, and
makes it seem like a refactor is in order.

Either way, this commit fixes the regression where opening and closing
DisplaySettings would crash WindowServer.

cc @nico , @alimpfard , @Zaggy1024 