### PR TITLE
Kernel: Switch to SharedIRQHandler atomically

### DIFF
--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -212,13 +212,14 @@ void register_generic_interrupt_handler(InterruptNumber interrupt_number, Generi
             // FIXME: Add support for spurious interrupts on aarch64
             TODO_AARCH64();
         }
+
         VERIFY(handler_slot->type() == HandlerType::IRQHandler);
         auto& previous_handler = *handler_slot;
-        handler_slot = nullptr;
-        SharedIRQHandler::initialize(interrupt_number);
-        VERIFY(handler_slot);
-        static_cast<SharedIRQHandler*>(handler_slot)->register_handler(previous_handler);
-        static_cast<SharedIRQHandler*>(handler_slot)->register_handler(handler);
+
+        auto* shared_handler = SharedIRQHandler::initialize(interrupt_number, previous_handler, handler);
+        handler_slot = shared_handler;
+        VERIFY(handler_slot->type() == HandlerType::SharedIRQHandler);
+
         return;
     }
     VERIFY_NOT_REACHED();

--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -142,6 +142,12 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
 
 // This spinlock is used to reserve IRQs that can be later used by interrupt mechanism such as MSIx
 static Spinlock<LockRank::None> s_interrupt_handler_lock {};
+
+// FIXME: There is a possible race here on SMP systems. When we modify/set the interrupt handler for a specific interrupt,
+//        that change isn't immediately visible for other cores, so if that interrupt happens on another core before this
+//        change is visible, it will call the incorrect handler. Maybe some lock for each handler would be enough.
+//        But we shouldn't use a lock for CPU-local interrupts. Otherwise, that CPU-local interrupt can only happen on one
+//        core at a time. So we might need a different solution for those or possibly altogether.
 // A GICv2 supports a maximum of 1020 interrupts.
 static Array<GenericInterruptHandler*, 1020> s_interrupt_handlers;
 

--- a/Kernel/Arch/riscv64/Interrupts.cpp
+++ b/Kernel/Arch/riscv64/Interrupts.cpp
@@ -26,6 +26,11 @@ namespace Kernel {
 
 extern "C" void syscall_handler(TrapFrame const*);
 
+// FIXME: There is a possible race here on SMP systems. When we modify/set the interrupt handler for a specific interrupt,
+//        that change isn't immediately visible for other cores, so if that interrupt happens on another core before this
+//        change is visible, it will call the incorrect handler. Maybe some lock for each handler would be enough.
+//        But we shouldn't use a lock for CPU-local interrupts. Otherwise, that CPU-local interrupt can only happen on one
+//        core at a time. So we might need a different solution for those or possibly altogether.
 // FIXME: Share this array with x86_64/aarch64 somehow and consider if this really needs to use raw pointers and not OwnPtrs
 static Array<GenericInterruptHandler*, GENERIC_INTERRUPT_HANDLERS_COUNT> s_interrupt_handlers;
 

--- a/Kernel/Arch/riscv64/Interrupts.cpp
+++ b/Kernel/Arch/riscv64/Interrupts.cpp
@@ -214,13 +214,14 @@ void register_generic_interrupt_handler(InterruptNumber interrupt_number, Generi
             // FIXME: Add support for spurious interrupts on riscv64
             TODO_RISCV64();
         }
+
         VERIFY(handler_slot->type() == HandlerType::IRQHandler);
         auto& previous_handler = *handler_slot;
-        handler_slot = nullptr;
-        SharedIRQHandler::initialize(interrupt_number);
-        VERIFY(handler_slot);
-        static_cast<SharedIRQHandler*>(handler_slot)->register_handler(previous_handler);
-        static_cast<SharedIRQHandler*>(handler_slot)->register_handler(handler);
+
+        auto* shared_handler = SharedIRQHandler::initialize(interrupt_number, previous_handler, handler);
+        handler_slot = shared_handler;
+        VERIFY(handler_slot->type() == HandlerType::SharedIRQHandler);
+
         return;
     }
     VERIFY_NOT_REACHED();

--- a/Kernel/Arch/x86_64/Interrupts.cpp
+++ b/Kernel/Arch/x86_64/Interrupts.cpp
@@ -426,14 +426,14 @@ void register_generic_interrupt_handler(InterruptNumber interrupt_number, Generi
             static_cast<SpuriousInterruptHandler*>(handler_slot)->register_handler(handler);
             return;
         }
+
         VERIFY(handler_slot->type() == HandlerType::IRQHandler);
-        static_cast<IRQHandler*>(handler_slot)->set_shared_with_others(true);
         auto& previous_handler = *handler_slot;
-        handler_slot = nullptr;
-        SharedIRQHandler::initialize(interrupt_number);
-        VERIFY(handler_slot);
-        static_cast<SharedIRQHandler*>(handler_slot)->register_handler(previous_handler);
-        static_cast<SharedIRQHandler*>(handler_slot)->register_handler(handler);
+
+        auto* shared_handler = SharedIRQHandler::initialize(interrupt_number, previous_handler, handler);
+        handler_slot = shared_handler;
+        VERIFY(handler_slot->type() == HandlerType::SharedIRQHandler);
+
         return;
     }
     VERIFY_NOT_REACHED();

--- a/Kernel/Arch/x86_64/Interrupts.cpp
+++ b/Kernel/Arch/x86_64/Interrupts.cpp
@@ -47,6 +47,12 @@ READONLY_AFTER_INIT static IDTEntry s_idt[256];
 
 // This spinlock is used to reserve IRQs that can be later used by interrupt mechanism such as MSIx
 static Spinlock<LockRank::None> s_interrupt_handler_lock {};
+
+// FIXME: There is a possible race here on SMP systems. When we modify/set the interrupt handler for a specific interrupt,
+//        that change isn't immediately visible for other cores, so if that interrupt happens on another core before this
+//        change is visible, it will call the incorrect handler. Maybe some lock for each handler would be enough.
+//        But we shouldn't use a lock for CPU-local interrupts. Otherwise, that CPU-local interrupt can only happen on one
+//        core at a time. So we might need a different solution for those or possibly altogether.
 static GenericInterruptHandler* s_interrupt_handler[GENERIC_INTERRUPT_HANDLERS_COUNT];
 static GenericInterruptHandler* s_disabled_interrupt_handler[2];
 

--- a/Kernel/Interrupts/SharedIRQHandler.cpp
+++ b/Kernel/Interrupts/SharedIRQHandler.cpp
@@ -13,19 +13,20 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT void SharedIRQHandler::initialize(InterruptNumber interrupt_number)
+UNMAP_AFTER_INIT SharedIRQHandler* SharedIRQHandler::initialize(InterruptNumber interrupt_number, GenericInterruptHandler& handler1, GenericInterruptHandler& handler2)
 {
     auto* handler = new SharedIRQHandler(interrupt_number);
-    handler->register_interrupt_handler();
-    handler->disable_interrupt_vector();
+    handler->register_handler(handler1);
+    handler->register_handler(handler2);
+    return handler;
 }
 
 void SharedIRQHandler::register_handler(GenericInterruptHandler& handler)
 {
     dbgln_if(INTERRUPT_DEBUG, "Interrupt Handler registered @ Shared Interrupt Handler {}", interrupt_number());
     m_handlers.with([&handler](auto& list) { list.append(handler); });
-    enable_interrupt_vector();
 }
+
 void SharedIRQHandler::unregister_handler(GenericInterruptHandler& handler)
 {
     dbgln_if(INTERRUPT_DEBUG, "Interrupt Handler unregistered @ Shared Interrupt Handler {}", interrupt_number());

--- a/Kernel/Interrupts/SharedIRQHandler.h
+++ b/Kernel/Interrupts/SharedIRQHandler.h
@@ -17,7 +17,7 @@ namespace Kernel {
 class IRQHandler;
 class SharedIRQHandler final : public GenericInterruptHandler {
 public:
-    static void initialize(InterruptNumber interrupt_number);
+    static SharedIRQHandler* initialize(InterruptNumber interrupt_number, GenericInterruptHandler&, GenericInterruptHandler&);
     virtual ~SharedIRQHandler();
     virtual bool handle_interrupt() override;
 


### PR DESCRIPTION
Previously, there was a short time window where there was no valid
interrupt handler registered while switching to a SharedIRQHandler.
If the interrupt vector whose handler function we are converting to
a SharedIRQHandler occurs during that time, we would previously attempt
to read the uninitialized or only partially initialized handler.

The second commit adds FIXMEs for another possible race that occurs on SMP systems.