### PR TITLE
Kernel/Net: Make E1000E work again in QEMU (by adding a basic MDIO abstraction)

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -292,6 +292,7 @@ set(KERNEL_SOURCES
     Net/IP/Socket.cpp
     Net/LocalSocket.cpp
     Net/LoopbackAdapter.cpp
+    Net/MDIO.cpp
     Net/NetworkAdapter.cpp
     Net/NetworkTask.cpp
     Net/NetworkingManagement.cpp

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
@@ -10,15 +10,34 @@
 #include <Kernel/Net/Intel/E1000ENetworkAdapter.h>
 #include <Kernel/Net/NetworkingManagement.h>
 #include <Kernel/Sections.h>
+#include <Kernel/Tasks/Process.h>
 
 namespace Kernel {
 
+#define REG_CTRL 0x0000
 #define REG_EECD 0x0010
 #define REG_EEPROM 0x0014
+#define REG_MDIC 0x0020
+
+// CTRL Register
+
+#define REG_CTRL_SLU (1 << 6)
 
 // EECD Register
 
 #define EECD_PRES 0x100
+
+// MIDC Register
+
+#define REG_MDIC_DATA_MASK (0xffff << 0)
+#define REG_MDIC_DATA_OFFSET 0
+#define REG_MDIC_REGADD_OFFSET 16
+#define REG_MDIC_R (1 << 28)
+#define REG_MDIC_OP_WRITE (0b01 << 26)
+#define REG_MDIC_OP_READ (0b10 << 26)
+#define REG_MDIC_PHYADD_OFFSET 21
+
+#define GIGABIT_PHY_ID 1
 
 static bool is_valid_device_id(u16 device_id)
 {
@@ -226,6 +245,8 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<Networking
     auto const& mac = mac_address();
     dmesgln("E1000e: MAC address: {}", mac.to_string());
 
+    m_mdio_handling_process = TRY(spawn_mdio_handling_task(GIGABIT_PHY_ID));
+
     initialize_rx_descriptors();
     initialize_tx_descriptors();
 
@@ -248,7 +269,54 @@ UNMAP_AFTER_INIT E1000ENetworkAdapter::E1000ENetworkAdapter(StringView interface
 {
 }
 
-UNMAP_AFTER_INIT E1000ENetworkAdapter::~E1000ENetworkAdapter() = default;
+UNMAP_AFTER_INIT E1000ENetworkAdapter::~E1000ENetworkAdapter()
+{
+    if (m_mdio_handling_process) {
+        m_mdio_handling_process->die();
+        // Block until all threads exited to prevent UAF
+        ErrorOr<siginfo_t> result = siginfo_t {};
+        (void)Thread::current()->block<Thread::WaitBlocker>({}, WEXITED, m_mdio_handling_process.release_nonnull(), result);
+    }
+}
+
+void E1000ENetworkAdapter::on_phy_link_status_change(MDIO::LinkStatus link_status)
+{
+    auto ctrl = in32(REG_CTRL);
+
+    if (link_status == MDIO::LinkStatus::Up)
+        ctrl |= REG_CTRL_SLU;
+    else
+        ctrl &= ~REG_CTRL_SLU;
+
+    out32(REG_CTRL, ctrl);
+}
+
+u16 E1000ENetworkAdapter::read_phy_register(u8 phy_id, MDIO::Clause22::RegisterAddress address)
+{
+    // FIXME: Newer controllers (like the I211) don't have a PHYADD field in the MDIC register.
+    //        They instead have it in a separate register.
+    out32(REG_MDIC, REG_MDIC_OP_READ | (to_underlying(address) << REG_MDIC_REGADD_OFFSET) | (phy_id << REG_MDIC_PHYADD_OFFSET));
+
+    for (;;) {
+        u32 mdic = in32(REG_MDIC);
+        if ((mdic & REG_MDIC_R) == 0) {
+            Processor::wait_check();
+            continue;
+        }
+
+        return (mdic & REG_MDIC_DATA_MASK) >> REG_MDIC_DATA_OFFSET;
+    }
+}
+
+void E1000ENetworkAdapter::write_phy_register(u8 phy_id, MDIO::Clause22::RegisterAddress address, u16 value)
+{
+    // FIXME: Newer controllers (like the I211) don't have a PHYADD field in the MDIC register.
+    //        They instead have it in a separate register.
+    out32(REG_MDIC, REG_MDIC_OP_WRITE | (to_underlying(address) << REG_MDIC_REGADD_OFFSET) | (value << REG_MDIC_DATA_OFFSET) | (phy_id << REG_MDIC_PHYADD_OFFSET));
+
+    while ((in32(REG_MDIC) & REG_MDIC_R) == 0)
+        Processor::wait_check();
+}
 
 UNMAP_AFTER_INIT void E1000ENetworkAdapter::detect_eeprom()
 {

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.h
@@ -12,13 +12,15 @@
 #include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/Library/IOWindow.h>
 #include <Kernel/Net/Intel/E1000NetworkAdapter.h>
+#include <Kernel/Net/MDIO.h>
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/Security/Random.h>
 
 namespace Kernel {
 
 class E1000ENetworkAdapter final
-    : public E1000NetworkAdapter {
+    : public E1000NetworkAdapter
+    , public MDIO::Clause22::Interface {
 public:
     static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
     static ErrorOr<NonnullRefPtr<NetworkAdapter>> create(PCI::DeviceIdentifier const&);
@@ -27,6 +29,12 @@ public:
     virtual ~E1000ENetworkAdapter() override;
 
     virtual StringView purpose() const override { return class_name(); }
+
+protected:
+    // ^MDIO::Clause22::Interface
+    virtual void on_phy_link_status_change(MDIO::LinkStatus) override;
+    virtual u16 read_phy_register(u8 phy_id, MDIO::Clause22::RegisterAddress address) override;
+    virtual void write_phy_register(u8 phy_id, MDIO::Clause22::RegisterAddress address, u16 value) override;
 
 private:
     E1000ENetworkAdapter(StringView interface_name, PCI::DeviceIdentifier const&, InterruptNumber irq,
@@ -38,5 +46,7 @@ private:
 
     virtual void detect_eeprom() override;
     virtual u32 read_eeprom(u8 address) override;
+
+    RefPtr<Process> m_mdio_handling_process;
 };
 }

--- a/Kernel/Net/MDIO.cpp
+++ b/Kernel/Net/MDIO.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, Sönke Holz <soenke.holz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Net/MDIO.h>
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel::MDIO {
+
+namespace Clause22 {
+
+ErrorOr<NonnullRefPtr<Process>> Interface::spawn_mdio_handling_task(u8 phy_id)
+{
+    auto status = read_phy_register<Status>(phy_id);
+    if (!status.has_auto_negotiation_ability) {
+        dmesgln("PHY doesn't support auto-negotiation. This is not supported.");
+        return ENOTSUP;
+    }
+
+    auto [process, _] = TRY(Process::create_kernel_process("Ethernet PHY MDIO Handling Task"sv, [this, phy_id] { mdio_handling_thread(phy_id); }));
+    return process;
+}
+
+void Interface::mdio_handling_thread(u8 phy_id)
+{
+    enum class State {
+        Initial,
+        ResetStarted,
+        LinkDown,
+        AutoNegotiationStarted,
+        AutoNegotiationComplete,
+        LinkUp,
+    };
+
+    State state = State::Initial;
+
+    while (!Process::current().is_dying()) {
+        switch (state) {
+        case State::Initial: {
+            // Reset the PHY.
+            Control control {};
+            control.reset = 1;
+            write_phy_register<Control>(phy_id, control);
+
+            state = State::ResetStarted;
+            continue;
+        }
+        case State::ResetStarted: {
+            auto control = read_phy_register<Control>(phy_id);
+            if (!control.reset) {
+                // This bit gets cleared when the PHY finished resetting.
+                state = State::LinkDown;
+                continue;
+            }
+            break;
+        }
+        case State::LinkDown: {
+            // Start auto-negotiation with default settings, so without touching register 4.
+            // FIXME: Is this always the right thing to do?
+
+            auto control = read_phy_register<Control>(phy_id);
+            control.auto_negotiation_enable = 1;
+            control.restart_auto_negotiation = 1;
+            write_phy_register<Control>(phy_id, control);
+
+            state = State::AutoNegotiationStarted;
+            continue;
+        }
+        case State::AutoNegotiationStarted: {
+            auto status = read_phy_register<Status>(phy_id);
+            if (status.auto_negotiation_process_completed) {
+                state = State::AutoNegotiationComplete;
+                continue;
+            }
+            break;
+        }
+        case State::AutoNegotiationComplete: {
+            auto status = read_phy_register<Status>(phy_id);
+            if (status.link_up) {
+                state = State::LinkUp;
+                on_phy_link_status_change(LinkStatus::Up);
+                continue;
+            }
+            break;
+        }
+        case State::LinkUp:
+            auto status = read_phy_register<Status>(phy_id);
+            if (!status.link_up) {
+                state = State::LinkDown;
+                on_phy_link_status_change(LinkStatus::Down);
+                continue;
+            }
+            break;
+        }
+
+        (void)Thread::current()->sleep(Duration::from_milliseconds(500));
+    }
+
+    Thread::current()->exit();
+    VERIFY_NOT_REACHED();
+}
+
+}
+
+}

--- a/Kernel/Net/MDIO.h
+++ b/Kernel/Net/MDIO.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026, Sönke Holz <soenke.holz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/Forward.h>
+
+namespace Kernel::MDIO {
+
+enum class LinkStatus {
+    Down,
+    Up,
+};
+
+// FIXME: Support Clause 45. At least some MACs seem to suppport both Clause 22 and 45, so we should
+//        maybe make the Interface class support both at once and move it out of the Clause22 namespace.
+
+// IEEE 802.3-2022 22. Reconciliation Sublayer (RS) and Media Independent Interface (MII)
+namespace Clause22 {
+
+// IEEE 802.3-2022 22.2.4 Management functions
+enum class RegisterAddress : u8 {
+    // Basic register set
+    Control = 0,
+    Status = 1,
+
+    // Extended register set
+    PHYIdentifier1 = 2,
+    PHYIdentifier2 = 3,
+    AutoNegotiationAdvertisement = 4,
+    AutoNegotiationLinkPartnerBasePageAbility = 5,
+    AutoNegotiationExpansion = 6,
+    AutoNegotiationNextPageTransmit = 7,
+    AutoNegotiationLinkPartnerReceivedNextPage = 8,
+    MasterSlaveControlRegister = 9,
+    MasterSlaveStatusRegister = 10,
+    PSEControlRegister = 11,
+    PSEStatusRegister = 12,
+    MMDAccessControlRegister = 13,
+    MMDAccessAddressDataRegister = 14,
+    ExtendedStatus = 15,
+};
+
+class Interface {
+public:
+    virtual ~Interface() = default;
+
+protected:
+    virtual void on_phy_link_status_change(LinkStatus) { }
+
+    virtual u16 read_phy_register(u8 phy_id, RegisterAddress address) = 0;
+    virtual void write_phy_register(u8 phy_id, RegisterAddress address, u16 value) = 0;
+
+    template<typename Register>
+    Register read_phy_register(u8 phy_id)
+    requires(requires { Register::REGISTER_ADDRESS; })
+    {
+        static_assert(sizeof(Register) == sizeof(u16));
+        return bit_cast<Register>(read_phy_register(phy_id, Register::REGISTER_ADDRESS));
+    }
+
+    template<typename Register>
+    void write_phy_register(u8 phy_id, Register value)
+    requires(requires { Register::REGISTER_ADDRESS; })
+    {
+        static_assert(sizeof(Register) == sizeof(u16));
+        write_phy_register(phy_id, Register::REGISTER_ADDRESS, bit_cast<u16>(value));
+    }
+
+    // FIXME: Support handling multiple PHYs per interface.
+    ErrorOr<NonnullRefPtr<Process>> spawn_mdio_handling_task(u8 phy_id);
+
+private:
+    void mdio_handling_thread(u8 phy_id);
+};
+
+// IEEE 802.3-2022 22.2.4.1 Control register (Register 0)
+struct Control {
+    static constexpr auto REGISTER_ADDRESS = RegisterAddress::Control;
+
+    u16 reserved : 5;
+    u16 unidirectional_enable : 1;
+    u16 speed_selection_msb : 1;
+    u16 collision_test : 1;
+    u16 full_duplex : 1;
+    u16 restart_auto_negotiation : 1;
+    u16 isolate : 1;
+    u16 power_down : 1;
+    u16 auto_negotiation_enable : 1;
+    u16 speed_selection_lsb : 1;
+    u16 enable_loopback_mode : 1;
+    u16 reset : 1;
+};
+static_assert(AssertSize<Control, sizeof(u16)>());
+
+// IEEE 802.3-2022 22.2.4.2 Status register (Register 1)
+struct Status {
+    static constexpr auto REGISTER_ADDRESS = RegisterAddress::Status;
+
+    u16 has_extended_register_capabilities : 1;
+    u16 jabber_condition_detected : 1;
+    u16 link_up : 1;
+    u16 has_auto_negotiation_ability : 1;
+    u16 remote_fault_condition_detected : 1;
+    u16 auto_negotiation_process_completed : 1;
+    u16 accepts_management_framces_with_preamble_suppressed : 1;
+    u16 has_unidirectional_ability : 1;
+    u16 has_extended_status_information_in_register_15 : 1;
+    u16 supports_half_duplex_100_base_t2 : 1;
+    u16 supports_full_duplex_100_base_t2 : 1;
+    u16 supports_10_mb_s_in_half_duplex_mode : 1;
+    u16 supports_10_mb_s_in_full_duplex_mode : 1;
+    u16 supports_half_duplex_100_base_x : 1;
+    u16 supports_full_duplex_100_base_x : 1;
+    u16 supports_100_base_t4 : 1;
+};
+static_assert(AssertSize<Status, sizeof(u16)>());
+
+}
+
+}


### PR DESCRIPTION
See individual commit for details.

[MDIO](https://en.wikipedia.org/wiki/Management_Data_Input/Output) is a serial bus for interfacing 802.3 (Ethernet) PHYs with MACs. This abstraction simply does the bare minimum to initialize a generic PHY. We might need more special-purpose drivers for quirky PHYs in the future.
I also want to use this MDIO abstraction for the RP1 ethernet driver.