### PR TITLE
Kernel/PCI: Don't truncate the MSI-X table offset to 16-bit

### DIFF
--- a/Kernel/Arch/x86_64/PCI/Controller/PIIX4HostBridge.cpp
+++ b/Kernel/Arch/x86_64/PCI/Controller/PIIX4HostBridge.cpp
@@ -30,43 +30,43 @@ static u32 io_address_for_pci_field(BusNumber bus, DeviceNumber device, Function
 void PIIX4HostBridge::write8_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u8 value)
 {
     VERIFY(m_access_lock.is_locked());
-    IO::out32(PCI::address_port, io_address_for_pci_field(bus, device, function, field));
-    IO::out8(PCI::value_port + (field & 3), value);
+    IO::out32(PCI::ADDRESS_PORT, io_address_for_pci_field(bus, device, function, field));
+    IO::out8(PCI::VALUE_PORT + (field & 3), value);
 }
 
 void PIIX4HostBridge::write16_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u16 value)
 {
     VERIFY(m_access_lock.is_locked());
-    IO::out32(PCI::address_port, io_address_for_pci_field(bus, device, function, field));
-    IO::out16(PCI::value_port + (field & 2), value);
+    IO::out32(PCI::ADDRESS_PORT, io_address_for_pci_field(bus, device, function, field));
+    IO::out16(PCI::VALUE_PORT + (field & 2), value);
 }
 
 void PIIX4HostBridge::write32_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u32 value)
 {
     VERIFY(m_access_lock.is_locked());
-    IO::out32(PCI::address_port, io_address_for_pci_field(bus, device, function, field));
-    IO::out32(PCI::value_port, value);
+    IO::out32(PCI::ADDRESS_PORT, io_address_for_pci_field(bus, device, function, field));
+    IO::out32(PCI::VALUE_PORT, value);
 }
 
 u8 PIIX4HostBridge::read8_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
 {
     VERIFY(m_access_lock.is_locked());
-    IO::out32(PCI::address_port, io_address_for_pci_field(bus, device, function, field));
-    return IO::in8(PCI::value_port + (field & 3));
+    IO::out32(PCI::ADDRESS_PORT, io_address_for_pci_field(bus, device, function, field));
+    return IO::in8(PCI::VALUE_PORT + (field & 3));
 }
 
 u16 PIIX4HostBridge::read16_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
 {
     VERIFY(m_access_lock.is_locked());
-    IO::out32(PCI::address_port, io_address_for_pci_field(bus, device, function, field));
-    return IO::in16(PCI::value_port + (field & 2));
+    IO::out32(PCI::ADDRESS_PORT, io_address_for_pci_field(bus, device, function, field));
+    return IO::in16(PCI::VALUE_PORT + (field & 2));
 }
 
 u32 PIIX4HostBridge::read32_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
 {
     VERIFY(m_access_lock.is_locked());
-    IO::out32(PCI::address_port, io_address_for_pci_field(bus, device, function, field));
-    return IO::in32(PCI::value_port);
+    IO::out32(PCI::ADDRESS_PORT, io_address_for_pci_field(bus, device, function, field));
+    return IO::in32(PCI::VALUE_PORT);
 }
 
 }

--- a/Kernel/Arch/x86_64/PCI/Initializer.cpp
+++ b/Kernel/Arch/x86_64/PCI/Initializer.cpp
@@ -95,8 +95,8 @@ UNMAP_AFTER_INIT bool test_pci_io()
 {
     dmesgln("Testing PCI via manual probing...");
     u32 tmp = 0x80000000;
-    IO::out32(PCI::address_port, tmp);
-    tmp = IO::in32(PCI::address_port);
+    IO::out32(PCI::ADDRESS_PORT, tmp);
+    tmp = IO::in32(PCI::ADDRESS_PORT);
     if (tmp == 0x80000000) {
         dmesgln("PCI IO supported");
         return true;

--- a/Kernel/Bus/PCI/API.cpp
+++ b/Kernel/Bus/PCI/API.cpp
@@ -227,7 +227,7 @@ size_t get_BAR_space_size(DeviceIdentifier const& identifier, HeaderType0BaseReg
     write32_offsetted(identifier, field, 0xFFFFFFFF);
     u32 space_size = read32_offsetted(identifier, field);
     write32_offsetted(identifier, field, bar_reserved);
-    space_size &= bar_address_mask;
+    space_size &= BAR_ADDRESS_MASK;
     space_size = (~space_size) + 1;
     return space_size;
 }
@@ -240,7 +240,7 @@ size_t get_expansion_rom_space_size(DeviceIdentifier const& identifier)
     write32_offsetted(identifier, field, 0xFFFFFFFF);
     u32 space_size = read32_offsetted(identifier, field);
     write32_offsetted(identifier, field, bar_reserved);
-    space_size &= bar_address_mask;
+    space_size &= BAR_ADDRESS_MASK;
     space_size = (~space_size) + 1;
     return space_size;
 }

--- a/Kernel/Bus/PCI/BarMapping.h
+++ b/Kernel/Bus/PCI/BarMapping.h
@@ -19,7 +19,7 @@ inline ErrorOr<u64> get_bar_bus_address(DeviceIdentifier const& device, HeaderTy
     auto pci_bar_space_type = get_BAR_space_type(pci_bar_value);
 
     if (pci_bar_space_type == BARSpaceType::IOSpace)
-        return pci_bar_value & bar_io_address_mask;
+        return pci_bar_value & BAR_IO_ADDRESS_MASK;
 
     if (pci_bar_space_type == BARSpaceType::Memory64BitSpace) {
         // FIXME: In theory, BAR5 cannot be assigned to 64 bit as it is the last one...
@@ -31,10 +31,10 @@ inline ErrorOr<u64> get_bar_bus_address(DeviceIdentifier const& device, HeaderTy
         u64 next_pci_bar_value = get_BAR(device, static_cast<PCI::HeaderType0BaseRegister>(to_underlying(bar) + 1));
         pci_bar_value |= next_pci_bar_value << 32;
 
-        return pci_bar_value & bar_address_mask;
+        return pci_bar_value & BAR_ADDRESS_MASK;
     }
 
-    return pci_bar_value & bar_address_mask;
+    return pci_bar_value & BAR_ADDRESS_MASK;
 }
 
 inline ErrorOr<PhysicalAddress> get_bar_address(DeviceIdentifier const& device, HeaderType0BaseRegister bar)

--- a/Kernel/Bus/PCI/Controller/GenericECAMHostController.cpp
+++ b/Kernel/Bus/PCI/Controller/GenericECAMHostController.cpp
@@ -21,7 +21,7 @@ public:
         auto domain = TRY(determine_pci_domain_for_devicetree_node(device.node(), device.node_name()));
         auto configuration_space = TRY(device.get_resource(0));
 
-        if (configuration_space.size < memory_range_per_bus * (domain.end_bus() - domain.start_bus() + 1))
+        if (configuration_space.size < MEMORY_RANGE_PER_BUS * (domain.end_bus() - domain.start_bus() + 1))
             return ERANGE;
 
         return adopt_nonnull_own_or_enomem(new (nothrow) GenericDeviceTreeECAMHostController(domain, configuration_space.paddr));

--- a/Kernel/Bus/PCI/Controller/HostController.cpp
+++ b/Kernel/Bus/PCI/Controller/HostController.cpp
@@ -172,13 +172,13 @@ UNMAP_AFTER_INIT void HostController::enumerate_functions(Function<void(Enumerab
 UNMAP_AFTER_INIT void HostController::enumerate_device(Function<void(EnumerableDeviceIdentifier const&)> const& callback, Function<void(EnumerableDeviceIdentifier const&)>& post_bridge_callback, BusNumber bus, DeviceNumber device, bool recursive_search_into_bridges)
 {
     dbgln_if(PCI_DEBUG, "PCI: Enumerating device in bus={}, device={}", bus, device);
-    if (read16_field(bus, device, 0, PCI::RegisterOffset::VENDOR_ID) == PCI::none_value)
+    if (read16_field(bus, device, 0, PCI::RegisterOffset::VENDOR_ID) == PCI::NONE_VALUE)
         return;
     enumerate_functions(callback, post_bridge_callback, bus, device, 0, recursive_search_into_bridges);
     if (!(read8_field(bus, device, 0, PCI::RegisterOffset::HEADER_TYPE) & 0x80))
         return;
     for (u8 function = 1; function < 8; ++function) {
-        if (read16_field(bus, device, function, PCI::RegisterOffset::VENDOR_ID) != PCI::none_value)
+        if (read16_field(bus, device, function, PCI::RegisterOffset::VENDOR_ID) != PCI::NONE_VALUE)
             enumerate_functions(callback, post_bridge_callback, bus, device, function, recursive_search_into_bridges);
     }
 }
@@ -206,7 +206,7 @@ UNMAP_AFTER_INIT void HostController::enumerate_attached_devices(Function<void(E
     // recursive PCI-to-PCI bridges starting from bus 0, we might find them here.
     if ((read8_field(0, 0, 0, PCI::RegisterOffset::HEADER_TYPE) & 0x80) != 0) {
         for (int bus_as_function_number = 1; bus_as_function_number < 8; ++bus_as_function_number) {
-            if (read16_field(0, 0, bus_as_function_number, PCI::RegisterOffset::VENDOR_ID) == PCI::none_value)
+            if (read16_field(0, 0, bus_as_function_number, PCI::RegisterOffset::VENDOR_ID) == PCI::NONE_VALUE)
                 continue;
             if (read8_field(0, 0, bus_as_function_number, PCI::RegisterOffset::CLASS) != to_underlying(PCI::ClassID::Bridge))
                 continue;
@@ -253,7 +253,7 @@ void HostController::configure_attached_devices(PCIConfiguration& config)
                 write32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset, 0xFFFFFFFF);
                 auto bar_size = read32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset);
                 write32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset, bar_value);
-                bar_size &= bar_address_mask;
+                bar_size &= BAR_ADDRESS_MASK;
                 bar_size = (~bar_size) + 1;
 
                 if (bar_size == 0)
@@ -284,7 +284,7 @@ void HostController::configure_attached_devices(PCIConfiguration& config)
                 bar_size |= (u64)read32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset + 4) << 32;
                 write32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset, bar_value);
                 write32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset + 4, next_bar_value);
-                bar_size &= bar_address_mask;
+                bar_size &= BAR_ADDRESS_MASK;
                 bar_size = (~bar_size) + 1;
 
                 if (bar_size == 0) {
@@ -316,7 +316,7 @@ void HostController::configure_attached_devices(PCIConfiguration& config)
                 write32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset, 0xFFFFFFFF);
                 auto bar_size = read32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset);
                 write32_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), bar_offset, bar_value);
-                bar_size &= bar_io_address_mask;
+                bar_size &= BAR_IO_ADDRESS_MASK;
                 bar_size = (~bar_size) + 1;
                 if (bar_size == 0)
                     continue;

--- a/Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.cpp
+++ b/Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.cpp
@@ -69,7 +69,7 @@ void MemoryBackedHostBridge::map_bus_region(BusNumber bus)
     if (m_mapped_bus == bus && m_mapped_bus_region)
         return;
     auto bus_base_address = determine_memory_mapped_bus_base_address(bus);
-    auto region_or_error = MM.allocate_mmio_kernel_region(bus_base_address, memory_range_per_bus, "PCI ECAM"sv, Memory::Region::Access::ReadWrite);
+    auto region_or_error = MM.allocate_mmio_kernel_region(bus_base_address, MEMORY_RANGE_PER_BUS, "PCI ECAM"sv, Memory::Region::Access::ReadWrite);
     // FIXME: Find a way to propagate error from here.
     if (region_or_error.is_error())
         VERIFY_NOT_REACHED();
@@ -82,13 +82,13 @@ VirtualAddress MemoryBackedHostBridge::get_device_configuration_memory_mapped_sp
 {
     VERIFY(m_access_lock.is_locked());
     map_bus_region(bus);
-    return m_mapped_bus_region->vaddr().offset(mmio_device_space_size * function.value() + (mmio_device_space_size * to_underlying(Limits::MaxFunctionsPerDevice)) * device.value());
+    return m_mapped_bus_region->vaddr().offset(MMIO_DEVICE_SPACE_SIZE * function.value() + (MMIO_DEVICE_SPACE_SIZE * to_underlying(Limits::MaxFunctionsPerDevice)) * device.value());
 }
 
 PhysicalAddress MemoryBackedHostBridge::determine_memory_mapped_bus_base_address(BusNumber bus) const
 {
     auto start_bus = min(bus.value(), m_domain.start_bus());
-    return m_start_address.offset(memory_range_per_bus * (bus.value() - start_bus));
+    return m_start_address.offset(MEMORY_RANGE_PER_BUS * (bus.value() - start_bus));
 }
 
 }

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -86,27 +86,27 @@ enum class Limits {
     MaxFunctionsPerDevice = 8,
 };
 
-static constexpr u16 address_port = 0xcf8;
-static constexpr u16 value_port = 0xcfc;
+static constexpr u16 ADDRESS_PORT = 0xcf8;
+static constexpr u16 VALUE_PORT = 0xcfc;
 
-static constexpr size_t mmio_device_space_size = 4096;
-static constexpr u16 none_value = 0xffff;
-static constexpr size_t memory_range_per_bus = mmio_device_space_size * to_underlying(Limits::MaxFunctionsPerDevice) * to_underlying(Limits::MaxDevicesPerBus);
-static constexpr u64 bar_address_mask = ~0xfull;
-static constexpr u64 bar_io_address_mask = ~0x3ull;
+static constexpr size_t MMIO_DEVICE_SPACE_SIZE = 4096;
+static constexpr u16 NONE_VALUE = 0xffff;
+static constexpr size_t MEMORY_RANGE_PER_BUS = MMIO_DEVICE_SPACE_SIZE * to_underlying(Limits::MaxFunctionsPerDevice) * to_underlying(Limits::MaxDevicesPerBus);
+static constexpr u64 BAR_ADDRESS_MASK = ~0xfull;
+static constexpr u64 BAR_IO_ADDRESS_MASK = ~0x3ull;
 
-static constexpr u8 msi_control_offset = 2;
-static constexpr u16 msi_control_enable = 0x0001;
-static constexpr u8 msi_address_low_offset = 4;
-static constexpr u8 msi_address_high_or_data_offset = 8;
-static constexpr u8 msi_data_offset = 0xc;
-static constexpr u16 msi_address_format_mask = 0x80;
-static constexpr u8 msi_mmc_format_mask = 0xe;
+static constexpr u8 MSI_CONTROL_OFFSET = 2;
+static constexpr u16 MSI_CONTROL_ENABLE = 0x0001;
+static constexpr u8 MSI_ADDRESS_LOW_OFFSET = 4;
+static constexpr u8 MSI_ADDRESS_HIGH_OR_DATA_OFFSET = 8;
+static constexpr u8 MSI_DATA_OFFSET = 0xc;
+static constexpr u16 MSI_ADDRESS_FORMAT_MASK = 0x80;
+static constexpr u8 MSI_MMC_FORMAT_MASK = 0xe;
 
-static constexpr u16 msix_control_table_mask = 0x07ff;
-static constexpr u8 msix_table_bir_mask = 0x7;
-static constexpr u32 msix_table_offset_mask = 0xffff'fff8;
-static constexpr u16 msix_control_enable = 0x8000;
+static constexpr u16 MSIX_CONTROL_TABLE_MASK = 0x07ff;
+static constexpr u8 MSIX_TABLE_BIR_MASK = 0x7;
+static constexpr u32 MSIX_TABLE_OFFSET_MASK = 0xffff'fff8;
+static constexpr u16 MSIX_CONTROL_ENABLE = 0x8000;
 
 // 2.2.1.1. Numerical Representation, https://www.devicetree.org/open-firmware/bindings/pci/pci2_1.pdf
 struct OpenFirmwareAddress {

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -107,6 +107,8 @@ static constexpr u16 MSIX_CONTROL_TABLE_MASK = 0x07ff;
 static constexpr u8 MSIX_TABLE_BIR_MASK = 0x7;
 static constexpr u32 MSIX_TABLE_OFFSET_MASK = 0xffff'fff8;
 static constexpr u16 MSIX_CONTROL_ENABLE = 0x8000;
+static constexpr u8 MSIX_CONTROL_OFFSET = 2;
+static constexpr u8 MSIX_TABLE_OFFSET_OFFSET = 4;
 
 // 2.2.1.1. Numerical Representation, https://www.devicetree.org/open-firmware/bindings/pci/pci2_1.pdf
 struct OpenFirmwareAddress {

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -94,6 +94,7 @@ static constexpr u16 none_value = 0xffff;
 static constexpr size_t memory_range_per_bus = mmio_device_space_size * to_underlying(Limits::MaxFunctionsPerDevice) * to_underlying(Limits::MaxDevicesPerBus);
 static constexpr u64 bar_address_mask = ~0xfull;
 static constexpr u64 bar_io_address_mask = ~0x3ull;
+
 static constexpr u8 msi_control_offset = 2;
 static constexpr u16 msi_control_enable = 0x0001;
 static constexpr u8 msi_address_low_offset = 4;
@@ -101,9 +102,10 @@ static constexpr u8 msi_address_high_or_data_offset = 8;
 static constexpr u8 msi_data_offset = 0xc;
 static constexpr u16 msi_address_format_mask = 0x80;
 static constexpr u8 msi_mmc_format_mask = 0xe;
+
 static constexpr u16 msix_control_table_mask = 0x07ff;
 static constexpr u8 msix_table_bir_mask = 0x7;
-static constexpr u16 msix_table_offset_mask = 0xfff8;
+static constexpr u32 msix_table_offset_mask = 0xffff'fff8;
 static constexpr u16 msix_control_enable = 0x8000;
 
 // 2.2.1.1. Numerical Representation, https://www.devicetree.org/open-firmware/bindings/pci/pci2_1.pdf

--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -55,14 +55,14 @@ void Device::enable_message_signalled_interrupts()
 {
     for (auto& capability : m_pci_identifier->capabilities()) {
         if (capability.id().value() == PCI::Capabilities::ID::MSI)
-            capability.write16(msi_control_offset, capability.read16(msi_control_offset) | msi_control_enable);
+            capability.write16(MSI_CONTROL_OFFSET, capability.read16(MSI_CONTROL_OFFSET) | MSI_CONTROL_ENABLE);
     }
 }
 void Device::disable_message_signalled_interrupts()
 {
     for (auto& capability : m_pci_identifier->capabilities()) {
         if (capability.id().value() == PCI::Capabilities::ID::MSI)
-            capability.write16(msi_control_offset, capability.read16(msi_control_offset) & ~(msi_control_enable));
+            capability.write16(MSI_CONTROL_OFFSET, capability.read16(MSI_CONTROL_OFFSET) & ~(MSI_CONTROL_ENABLE));
     }
 }
 
@@ -70,7 +70,7 @@ void Device::enable_extended_message_signalled_interrupts()
 {
     for (auto& capability : m_pci_identifier->capabilities()) {
         if (capability.id().value() == PCI::Capabilities::ID::MSIX)
-            capability.write16(msi_control_offset, capability.read16(msi_control_offset) | msix_control_enable);
+            capability.write16(MSI_CONTROL_OFFSET, capability.read16(MSI_CONTROL_OFFSET) | MSIX_CONTROL_ENABLE);
     }
 }
 
@@ -78,7 +78,7 @@ void Device::disable_extended_message_signalled_interrupts()
 {
     for (auto& capability : m_pci_identifier->capabilities()) {
         if (capability.id().value() == PCI::Capabilities::ID::MSIX)
-            capability.write16(msi_control_offset, capability.read16(msi_control_offset) & ~(msix_control_enable));
+            capability.write16(MSI_CONTROL_OFFSET, capability.read16(MSI_CONTROL_OFFSET) & ~(MSIX_CONTROL_ENABLE));
     }
 }
 
@@ -159,15 +159,15 @@ ErrorOr<InterruptNumber> Device::allocate_irq(size_t index)
         auto addr = msi_address_register(0, false, false);
         for (auto& capability : m_pci_identifier->capabilities()) {
             if (capability.id().value() == PCI::Capabilities::ID::MSI) {
-                capability.write32(msi_address_low_offset, addr & 0xffffffff);
+                capability.write32(MSI_ADDRESS_LOW_OFFSET, addr & 0xffffffff);
 
                 if (!m_pci_identifier->is_msi_64bit_address_format()) {
-                    capability.write16(msi_address_high_or_data_offset, data);
+                    capability.write16(MSI_ADDRESS_HIGH_OR_DATA_OFFSET, data);
                     break;
                 }
 
-                capability.write32(msi_address_high_or_data_offset, addr >> 32);
-                capability.write16(msi_data_offset, data);
+                capability.write32(MSI_ADDRESS_HIGH_OR_DATA_OFFSET, addr >> 32);
+                capability.write16(MSI_DATA_OFFSET, data);
             }
         }
         return m_interrupt_range.m_start_irq + index;

--- a/Kernel/Bus/PCI/DeviceIdentifier.cpp
+++ b/Kernel/Bus/PCI/DeviceIdentifier.cpp
@@ -21,9 +21,9 @@ void DeviceIdentifier::initialize()
 {
     for (auto cap : capabilities()) {
         if (cap.id() == PCI::Capabilities::ID::MSIX) {
-            auto msix_bir_bar = (cap.read8(4) & MSIX_TABLE_BIR_MASK);
-            auto msix_bir_offset = (cap.read32(4) & MSIX_TABLE_OFFSET_MASK);
-            auto msix_count = (cap.read16(2) & MSIX_CONTROL_TABLE_MASK) + 1;
+            auto msix_bir_bar = (cap.read8(MSIX_TABLE_OFFSET_OFFSET) & MSIX_TABLE_BIR_MASK);
+            auto msix_bir_offset = (cap.read32(MSIX_TABLE_OFFSET_OFFSET) & MSIX_TABLE_OFFSET_MASK);
+            auto msix_count = (cap.read16(MSIX_CONTROL_OFFSET) & MSIX_CONTROL_TABLE_MASK) + 1;
             m_msix_info = MSIxInfo(msix_count, msix_bir_bar, msix_bir_offset);
         }
 

--- a/Kernel/Bus/PCI/DeviceIdentifier.cpp
+++ b/Kernel/Bus/PCI/DeviceIdentifier.cpp
@@ -21,16 +21,16 @@ void DeviceIdentifier::initialize()
 {
     for (auto cap : capabilities()) {
         if (cap.id() == PCI::Capabilities::ID::MSIX) {
-            auto msix_bir_bar = (cap.read8(4) & msix_table_bir_mask);
-            auto msix_bir_offset = (cap.read32(4) & msix_table_offset_mask);
-            auto msix_count = (cap.read16(2) & msix_control_table_mask) + 1;
+            auto msix_bir_bar = (cap.read8(4) & MSIX_TABLE_BIR_MASK);
+            auto msix_bir_offset = (cap.read32(4) & MSIX_TABLE_OFFSET_MASK);
+            auto msix_count = (cap.read16(2) & MSIX_CONTROL_TABLE_MASK) + 1;
             m_msix_info = MSIxInfo(msix_count, msix_bir_bar, msix_bir_offset);
         }
 
         if (cap.id() == PCI::Capabilities::ID::MSI) {
-            bool message_address_64_bit_format = (cap.read8(msi_control_offset) & msi_address_format_mask);
+            bool message_address_64_bit_format = (cap.read8(MSI_CONTROL_OFFSET) & MSI_ADDRESS_FORMAT_MASK);
             u8 count = 1;
-            u8 mme_count = (cap.read8(msi_control_offset) & msi_mmc_format_mask) >> 1;
+            u8 mme_count = (cap.read8(MSI_CONTROL_OFFSET) & MSI_MMC_FORMAT_MASK) >> 1;
             if (mme_count)
                 count = mme_count;
             m_msi_info = MSIInfo(message_address_64_bit_format, count);


### PR DESCRIPTION
The table offset is 32-bit.

---

This fixes USB on my PC. I additionally included two cleanup commits to fix some small style issues I noticed while debugging this.