### PR TITLE
EFIPrekernel: Insert missing SMBIOS configuration table null check

### DIFF
--- a/Kernel/EFIPrekernel/ConfigurationTable.cpp
+++ b/Kernel/EFIPrekernel/ConfigurationTable.cpp
@@ -46,12 +46,15 @@ void populate_firmware_boot_info(BootInfo* boot_info)
         boot_info->smbios.maximum_structure_table_length = entry_point->table_maximum_size;
     } else {
         boot_info->smbios.entry_point_paddr = PhysicalAddress { bit_cast<PhysicalPtr>(search_efi_configuration_table(EFI::SMBIOS_TABLE_GUID)) };
-        boot_info->smbios.entry_point_is_64_bit = false;
 
-        auto* entry_point = reinterpret_cast<SMBIOS::EntryPoint32bit*>(boot_info->smbios.entry_point_paddr.as_ptr());
-        boot_info->smbios.entry_point_length = entry_point->length;
-        boot_info->smbios.structure_table_paddr = PhysicalAddress { entry_point->legacy_structure.smbios_table_ptr };
-        boot_info->smbios.maximum_structure_table_length = entry_point->legacy_structure.smbios_table_length;
+        if (!boot_info->smbios.entry_point_paddr.is_null()) {
+            boot_info->smbios.entry_point_is_64_bit = false;
+
+            auto* entry_point = reinterpret_cast<SMBIOS::EntryPoint32bit*>(boot_info->smbios.entry_point_paddr.as_ptr());
+            boot_info->smbios.entry_point_length = entry_point->length;
+            boot_info->smbios.structure_table_paddr = PhysicalAddress { entry_point->legacy_structure.smbios_table_ptr };
+            boot_info->smbios.maximum_structure_table_length = entry_point->legacy_structure.smbios_table_length;
+        }
     }
 }
 

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -486,8 +486,10 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_efi(MemoryManager::GlobalD
 
     // SMBIOS data can be in a BootServicesData memory region (see https://uefi.org/specs/UEFI/2.10/02_Overview.html#x64-platforms, the same requirement is listed for AArch64 and RISC-V as well).
     // BootServices* memory regions are treated as normal main memory after ExitBootServices, so we need to explicitly mark its ranges as used.
-    global_data.used_memory_ranges.try_append(UsedMemoryRange { UsedMemoryRangeType::SMBIOS, g_boot_info.smbios.entry_point_paddr, g_boot_info.smbios.entry_point_paddr.offset(g_boot_info.smbios.entry_point_length) }).release_value_but_fixme_should_propagate_errors();
-    global_data.used_memory_ranges.try_append(UsedMemoryRange { UsedMemoryRangeType::SMBIOS, g_boot_info.smbios.structure_table_paddr, g_boot_info.smbios.structure_table_paddr.offset(g_boot_info.smbios.maximum_structure_table_length) }).release_value_but_fixme_should_propagate_errors();
+    if (!g_boot_info.smbios.entry_point_paddr.is_null())
+        global_data.used_memory_ranges.try_append(UsedMemoryRange { UsedMemoryRangeType::SMBIOS, g_boot_info.smbios.entry_point_paddr, g_boot_info.smbios.entry_point_paddr.offset(g_boot_info.smbios.entry_point_length) }).release_value_but_fixme_should_propagate_errors();
+    if (!g_boot_info.smbios.structure_table_paddr.is_null())
+        global_data.used_memory_ranges.try_append(UsedMemoryRange { UsedMemoryRangeType::SMBIOS, g_boot_info.smbios.structure_table_paddr, g_boot_info.smbios.structure_table_paddr.offset(g_boot_info.smbios.maximum_structure_table_length) }).release_value_but_fixme_should_propagate_errors();
 }
 
 UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_fdt(MemoryManager::GlobalData& global_data, u8 const* fdt_addr)


### PR DESCRIPTION
The 32-bit SMBIOS case was missing a null check. This caused KUBSAN
to trigger if neither a 64-bit SMBIOS nor a 32-bit SMBIOS configuration
table was present.

---

I additionally made MM not insert reserved memory regions for SMBIOS structures if their physical addresses are null.

I noticed this while attempting to make serenity boot in the QEMU microvm via EDK II. (I most likely won't upstream my patches for that, as I needed multiple hacks due to us not having an AML interpreter at the moment.)