### PR TITLE
Kernel/x86: Some interrupt handling fixes and cleanups

### DIFF
--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -214,11 +214,6 @@ void register_generic_interrupt_handler(InterruptNumber interrupt_number, Generi
         return;
     }
     if (!handler_slot->is_shared_handler()) {
-        if (handler_slot->type() == HandlerType::SpuriousInterruptHandler) {
-            // FIXME: Add support for spurious interrupts on aarch64
-            TODO_AARCH64();
-        }
-
         VERIFY(handler_slot->type() == HandlerType::IRQHandler);
         auto& previous_handler = *handler_slot;
 

--- a/Kernel/Arch/riscv64/Interrupts.cpp
+++ b/Kernel/Arch/riscv64/Interrupts.cpp
@@ -215,11 +215,6 @@ void register_generic_interrupt_handler(InterruptNumber interrupt_number, Generi
         return;
     }
     if (!handler_slot->is_shared_handler()) {
-        if (handler_slot->type() == HandlerType::SpuriousInterruptHandler) {
-            // FIXME: Add support for spurious interrupts on riscv64
-            TODO_RISCV64();
-        }
-
         VERIFY(handler_slot->type() == HandlerType::IRQHandler);
         auto& previous_handler = *handler_slot;
 

--- a/Kernel/Arch/x86_64/IRQController.h
+++ b/Kernel/Arch/x86_64/IRQController.h
@@ -34,7 +34,6 @@ public:
     virtual void spurious_eoi(GenericInterruptHandler const&) const = 0;
     virtual size_t interrupt_vectors_count() const = 0;
     virtual u32 gsi_base() const = 0;
-    virtual u16 get_isr() const = 0;
     virtual u16 get_irr() const = 0;
     virtual StringView model() const = 0;
     virtual IRQControllerType type() const = 0;

--- a/Kernel/Arch/x86_64/IRQController.h
+++ b/Kernel/Arch/x86_64/IRQController.h
@@ -34,7 +34,6 @@ public:
     virtual void spurious_eoi(GenericInterruptHandler const&) const = 0;
     virtual size_t interrupt_vectors_count() const = 0;
     virtual u32 gsi_base() const = 0;
-    virtual u16 get_irr() const = 0;
     virtual StringView model() const = 0;
     virtual IRQControllerType type() const = 0;
 

--- a/Kernel/Arch/x86_64/InterruptManagement.cpp
+++ b/Kernel/Arch/x86_64/InterruptManagement.cpp
@@ -94,15 +94,6 @@ InterruptNumber InterruptManagement::get_irq_vector(InterruptNumber mapped_inter
     return mapped_interrupt_vector;
 }
 
-NonnullLockRefPtr<IRQController> InterruptManagement::get_responsible_irq_controller(IRQControllerType controller_type, InterruptNumber interrupt_vector)
-{
-    for (auto& irq_controller : m_interrupt_controllers) {
-        if (irq_controller->gsi_base() <= interrupt_vector && irq_controller->type() == controller_type)
-            return irq_controller;
-    }
-    VERIFY_NOT_REACHED();
-}
-
 NonnullLockRefPtr<IRQController> InterruptManagement::get_responsible_irq_controller(InterruptNumber interrupt_vector)
 {
     if (m_interrupt_controllers.size() == 1 && m_interrupt_controllers[0]->type() == IRQControllerType::i8259) {
@@ -137,10 +128,13 @@ UNMAP_AFTER_INIT void InterruptManagement::switch_to_pic_mode()
     VERIFY(m_interrupt_controllers.is_empty());
     dmesgln("Interrupts: Switch to Legacy PIC mode");
     InterruptDisabler disabler;
+
     m_interrupt_controllers.try_append(adopt_lock_ref(*new PIC())).release_value_but_fixme_should_propagate_errors();
-    PICSpuriousInterruptHandler::initialize(7);
-    PICSpuriousInterruptHandler::initialize(15);
-    dbgln("Interrupts: Detected {}", m_interrupt_controllers[0]->model());
+    auto pic = static_ptr_cast<PIC>(m_interrupt_controllers[0]);
+
+    PICSpuriousInterruptHandler::initialize(pic, 7);
+    PICSpuriousInterruptHandler::initialize(pic, 15);
+    dbgln("Interrupts: Detected {}", pic->model());
 }
 
 UNMAP_AFTER_INIT void InterruptManagement::switch_to_ioapic_mode()
@@ -167,10 +161,13 @@ UNMAP_AFTER_INIT void InterruptManagement::switch_to_ioapic_mode()
     for (auto& irq_controller : m_interrupt_controllers) {
         VERIFY(irq_controller);
         if (irq_controller->type() == IRQControllerType::i8259) {
-            irq_controller->hard_disable();
-            dbgln("Interrupts: Detected {} - Disabled", irq_controller->model());
-            PICSpuriousInterruptHandler::initialize_for_disabled_master_pic();
-            PICSpuriousInterruptHandler::initialize_for_disabled_slave_pic();
+            auto pic = static_ptr_cast<PIC>(irq_controller);
+
+            pic->hard_disable();
+            dbgln("Interrupts: Detected {} - Disabled", pic->model());
+
+            PICSpuriousInterruptHandler::initialize_for_disabled_master_pic(pic);
+            PICSpuriousInterruptHandler::initialize_for_disabled_slave_pic(pic);
         } else {
             dbgln("Interrupts: Detected {}", irq_controller->model());
         }

--- a/Kernel/Arch/x86_64/InterruptManagement.cpp
+++ b/Kernel/Arch/x86_64/InterruptManagement.cpp
@@ -11,11 +11,11 @@
 #include <Kernel/Arch/x86_64/Interrupts/APIC.h>
 #include <Kernel/Arch/x86_64/Interrupts/IOAPIC.h>
 #include <Kernel/Arch/x86_64/Interrupts/PIC.h>
+#include <Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.h>
 #include <Kernel/Boot/CommandLine.h>
 #include <Kernel/Firmware/ACPI/StaticParsing.h>
 #include <Kernel/Interrupts/InterruptDisabler.h>
 #include <Kernel/Interrupts/SharedIRQHandler.h>
-#include <Kernel/Interrupts/SpuriousInterruptHandler.h>
 #include <Kernel/Memory/TypedMapping.h>
 #include <Kernel/Sections.h>
 
@@ -138,8 +138,8 @@ UNMAP_AFTER_INIT void InterruptManagement::switch_to_pic_mode()
     dmesgln("Interrupts: Switch to Legacy PIC mode");
     InterruptDisabler disabler;
     m_interrupt_controllers.try_append(adopt_lock_ref(*new PIC())).release_value_but_fixme_should_propagate_errors();
-    SpuriousInterruptHandler::initialize(7);
-    SpuriousInterruptHandler::initialize(15);
+    PICSpuriousInterruptHandler::initialize(7);
+    PICSpuriousInterruptHandler::initialize(15);
     dbgln("Interrupts: Detected {}", m_interrupt_controllers[0]->model());
 }
 
@@ -169,8 +169,8 @@ UNMAP_AFTER_INIT void InterruptManagement::switch_to_ioapic_mode()
         if (irq_controller->type() == IRQControllerType::i8259) {
             irq_controller->hard_disable();
             dbgln("Interrupts: Detected {} - Disabled", irq_controller->model());
-            SpuriousInterruptHandler::initialize_for_disabled_master_pic();
-            SpuriousInterruptHandler::initialize_for_disabled_slave_pic();
+            PICSpuriousInterruptHandler::initialize_for_disabled_master_pic();
+            PICSpuriousInterruptHandler::initialize_for_disabled_slave_pic();
         } else {
             dbgln("Interrupts: Detected {}", irq_controller->model());
         }

--- a/Kernel/Arch/x86_64/InterruptManagement.cpp
+++ b/Kernel/Arch/x86_64/InterruptManagement.cpp
@@ -99,11 +99,18 @@ NonnullLockRefPtr<IRQController> InterruptManagement::get_responsible_irq_contro
     if (m_interrupt_controllers.size() == 1 && m_interrupt_controllers[0]->type() == IRQControllerType::i8259) {
         return m_interrupt_controllers[0];
     }
+
     for (auto& irq_controller : m_interrupt_controllers) {
-        if (irq_controller->gsi_base() <= interrupt_vector)
-            if (!irq_controller->is_hard_disabled())
-                return irq_controller;
+        if (irq_controller->is_hard_disabled())
+            continue;
+
+        auto gsi_base = irq_controller->gsi_base();
+        auto gsi_end = gsi_base + irq_controller->interrupt_vectors_count();
+
+        if (interrupt_vector >= gsi_base && interrupt_vector < gsi_end)
+            return irq_controller;
     }
+
     VERIFY_NOT_REACHED();
 }
 

--- a/Kernel/Arch/x86_64/InterruptManagement.h
+++ b/Kernel/Arch/x86_64/InterruptManagement.h
@@ -52,7 +52,6 @@ public:
     void switch_to_ioapic_mode();
 
     NonnullLockRefPtr<IRQController> get_responsible_irq_controller(InterruptNumber interrupt_vector);
-    NonnullLockRefPtr<IRQController> get_responsible_irq_controller(IRQControllerType controller_type, InterruptNumber interrupt_vector);
 
     Vector<ISAInterruptOverrideMetadata> const& isa_overrides() const { return m_isa_interrupt_overrides; }
 

--- a/Kernel/Arch/x86_64/Interrupts.cpp
+++ b/Kernel/Arch/x86_64/Interrupts.cpp
@@ -9,11 +9,12 @@
 #include <AK/Types.h>
 
 #include <Kernel/Arch/Interrupts.h>
+#include <Kernel/Arch/x86_64/InterruptManagement.h>
 #include <Kernel/Arch/x86_64/Interrupts/PIC.h>
+#include <Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
 #include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/Interrupts/SharedIRQHandler.h>
-#include <Kernel/Interrupts/SpuriousInterruptHandler.h>
 #include <Kernel/Interrupts/UnhandledInterruptHandler.h>
 #include <Kernel/Library/Panic.h>
 #include <Kernel/Sections.h>
@@ -429,7 +430,12 @@ void register_generic_interrupt_handler(InterruptNumber interrupt_number, Generi
     }
     if (!handler_slot->is_shared_handler()) {
         if (handler_slot->type() == HandlerType::SpuriousInterruptHandler) {
-            static_cast<SpuriousInterruptHandler*>(handler_slot)->register_handler(handler);
+            auto controller = InterruptManagement::the().get_responsible_irq_controller(interrupt_number);
+
+            // Only PICs should ever have spurious interrupts that are shared with real interrupts.
+            VERIFY(controller->type() == IRQControllerType::i8259);
+            static_cast<PICSpuriousInterruptHandler*>(handler_slot)->register_handler(handler);
+
             return;
         }
 

--- a/Kernel/Arch/x86_64/Interrupts/APIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/APIC.cpp
@@ -16,7 +16,6 @@
 #include <Kernel/Debug.h>
 #include <Kernel/Firmware/ACPI/Parser.h>
 #include <Kernel/Firmware/ACPI/StaticParsing.h>
-#include <Kernel/Interrupts/SpuriousInterruptHandler.h>
 #include <Kernel/Library/Panic.h>
 #include <Kernel/Memory/AnonymousVMObject.h>
 #include <Kernel/Memory/MemoryManager.h>
@@ -117,6 +116,31 @@ public:
     virtual bool is_shared_handler() const override { return false; }
 
 private:
+};
+
+class APICSpuriousInterruptHandler final : public GenericInterruptHandler {
+public:
+    explicit APICSpuriousInterruptHandler(InterruptNumber interrupt_vector)
+        : GenericInterruptHandler(interrupt_vector, true)
+    {
+    }
+
+    static void initialize(InterruptNumber interrupt_number)
+    {
+        auto* handler = new APICSpuriousInterruptHandler(interrupt_number);
+        handler->register_interrupt_handler();
+    }
+
+    virtual bool handle_interrupt() override;
+
+    virtual bool eoi() override;
+
+    virtual HandlerType type() const override { return HandlerType::IRQHandler; }
+    virtual StringView purpose() const override { return "APIC Spurious Interrupt Handler"sv; }
+    virtual StringView controller() const override { return {}; }
+
+    virtual size_t sharing_devices_count() const override { return 0; }
+    virtual bool is_shared_handler() const override { return false; }
 };
 
 bool APIC::initialized()
@@ -485,7 +509,7 @@ UNMAP_AFTER_INIT void APIC::enable(u32 cpu)
     dbgln_if(APIC_DEBUG, "Enabling local APIC for CPU #{}, logical APIC ID: {}", cpu, apic_id);
 
     if (cpu == 0) {
-        SpuriousInterruptHandler::initialize(IRQ_APIC_SPURIOUS);
+        APICSpuriousInterruptHandler::initialize(IRQ_APIC_SPURIOUS);
 
         APICErrInterruptHandler::initialize(IRQ_APIC_ERR);
 
@@ -663,6 +687,18 @@ bool APICErrInterruptHandler::handle_interrupt()
 }
 
 bool APICErrInterruptHandler::eoi()
+{
+    APIC::the().eoi();
+    return true;
+}
+
+bool APICSpuriousInterruptHandler::handle_interrupt()
+{
+    dbgln("APIC: Spurious interrupt");
+    return true;
+}
+
+bool APICSpuriousInterruptHandler::eoi()
 {
     APIC::the().eoi();
     return true;

--- a/Kernel/Arch/x86_64/Interrupts/IOAPIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/IOAPIC.cpp
@@ -236,12 +236,6 @@ void IOAPIC::eoi(GenericInterruptHandler const& handler) const
     APIC::the().eoi();
 }
 
-u16 IOAPIC::get_isr() const
-{
-    InterruptDisabler disabler;
-    VERIFY_NOT_REACHED();
-}
-
 u16 IOAPIC::get_irr() const
 {
     InterruptDisabler disabler;

--- a/Kernel/Arch/x86_64/Interrupts/IOAPIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/IOAPIC.cpp
@@ -236,12 +236,6 @@ void IOAPIC::eoi(GenericInterruptHandler const& handler) const
     APIC::the().eoi();
 }
 
-u16 IOAPIC::get_irr() const
-{
-    InterruptDisabler disabler;
-    VERIFY_NOT_REACHED();
-}
-
 void IOAPIC::write_register(u32 index, u32 value) const
 {
     InterruptDisabler disabler;

--- a/Kernel/Arch/x86_64/Interrupts/IOAPIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/IOAPIC.cpp
@@ -91,7 +91,7 @@ void IOAPIC::map_interrupt_redirection(InterruptNumber interrupt_vector)
 void IOAPIC::isa_identity_map(size_t index)
 {
     InterruptDisabler disabler;
-    configure_redirection_entry(index, InterruptManagement::acquire_mapped_interrupt_number(index) + IRQ_VECTOR_BASE, DeliveryMode::Normal, false, false, false, true, Processor::by_id(0).info().apic_id());
+    configure_redirection_entry(index - gsi_base(), InterruptManagement::acquire_mapped_interrupt_number(index) + IRQ_VECTOR_BASE, DeliveryMode::Normal, false, false, false, true, Processor::by_id(0).info().apic_id());
 }
 
 bool IOAPIC::is_enabled() const
@@ -202,7 +202,7 @@ void IOAPIC::disable(GenericInterruptHandler const& handler)
     InterruptDisabler disabler;
     VERIFY(!is_hard_disabled());
     InterruptNumber interrupt_vector = handler.interrupt_number();
-    VERIFY(interrupt_vector >= gsi_base() && interrupt_vector < interrupt_vectors_count());
+    VERIFY(interrupt_vector >= gsi_base() && interrupt_vector < gsi_base() + interrupt_vectors_count());
     auto found_index = find_redirection_entry_by_vector(interrupt_vector);
     if (!found_index.has_value()) {
         map_interrupt_redirection(interrupt_vector);
@@ -217,7 +217,7 @@ void IOAPIC::enable(GenericInterruptHandler const& handler)
     InterruptDisabler disabler;
     VERIFY(!is_hard_disabled());
     InterruptNumber interrupt_vector = handler.interrupt_number();
-    VERIFY(interrupt_vector >= gsi_base() && interrupt_vector < interrupt_vectors_count());
+    VERIFY(interrupt_vector >= gsi_base() && interrupt_vector < gsi_base() + interrupt_vectors_count());
     auto found_index = find_redirection_entry_by_vector(interrupt_vector);
     if (!found_index.has_value()) {
         map_interrupt_redirection(interrupt_vector);
@@ -231,7 +231,7 @@ void IOAPIC::eoi(GenericInterruptHandler const& handler) const
 {
     InterruptDisabler disabler;
     VERIFY(!is_hard_disabled());
-    VERIFY(handler.interrupt_number() >= gsi_base() && handler.interrupt_number() < interrupt_vectors_count());
+    VERIFY(handler.interrupt_number() >= gsi_base() && handler.interrupt_number() < gsi_base() + interrupt_vectors_count());
     VERIFY(handler.type() != HandlerType::SpuriousInterruptHandler);
     APIC::the().eoi();
 }

--- a/Kernel/Arch/x86_64/Interrupts/IOAPIC.h
+++ b/Kernel/Arch/x86_64/Interrupts/IOAPIC.h
@@ -47,7 +47,6 @@ public:
     virtual void spurious_eoi(GenericInterruptHandler const&) const override;
     virtual bool is_vector_enabled(InterruptNumber number) const override;
     virtual bool is_enabled() const override;
-    virtual u16 get_isr() const override;
     virtual u16 get_irr() const override;
     virtual u32 gsi_base() const override { return m_gsi_base; }
     virtual size_t interrupt_vectors_count() const override { return m_redirection_entries_count; }

--- a/Kernel/Arch/x86_64/Interrupts/IOAPIC.h
+++ b/Kernel/Arch/x86_64/Interrupts/IOAPIC.h
@@ -47,7 +47,6 @@ public:
     virtual void spurious_eoi(GenericInterruptHandler const&) const override;
     virtual bool is_vector_enabled(InterruptNumber number) const override;
     virtual bool is_enabled() const override;
-    virtual u16 get_irr() const override;
     virtual u32 gsi_base() const override { return m_gsi_base; }
     virtual size_t interrupt_vectors_count() const override { return m_redirection_entries_count; }
     virtual StringView model() const override { return "IOAPIC"sv; }

--- a/Kernel/Arch/x86_64/Interrupts/PIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/PIC.cpp
@@ -219,12 +219,4 @@ u16 PIC::get_isr() const
     return (isr1 << 8) | isr0;
 }
 
-u16 PIC::get_irr() const
-{
-    IO::out8(PIC0_CTL, 0x0a);
-    IO::out8(PIC1_CTL, 0x0a);
-    u8 irr0 = IO::in8(PIC0_CTL);
-    u8 irr1 = IO::in8(PIC1_CTL);
-    return (irr1 << 8) | irr0;
-}
 }

--- a/Kernel/Arch/x86_64/Interrupts/PIC.h
+++ b/Kernel/Arch/x86_64/Interrupts/PIC.h
@@ -25,7 +25,6 @@ public:
     virtual bool is_vector_enabled(InterruptNumber number) const override;
     virtual bool is_enabled() const override;
     virtual void spurious_eoi(GenericInterruptHandler const&) const override;
-    virtual u16 get_irr() const override;
     virtual u32 gsi_base() const override { return 0; }
     virtual size_t interrupt_vectors_count() const override { return 16; }
     virtual StringView model() const override { return "Dual i8259"sv; }

--- a/Kernel/Arch/x86_64/Interrupts/PIC.h
+++ b/Kernel/Arch/x86_64/Interrupts/PIC.h
@@ -25,12 +25,13 @@ public:
     virtual bool is_vector_enabled(InterruptNumber number) const override;
     virtual bool is_enabled() const override;
     virtual void spurious_eoi(GenericInterruptHandler const&) const override;
-    virtual u16 get_isr() const override;
     virtual u16 get_irr() const override;
     virtual u32 gsi_base() const override { return 0; }
     virtual size_t interrupt_vectors_count() const override { return 16; }
     virtual StringView model() const override { return "Dual i8259"sv; }
     virtual IRQControllerType type() const override { return IRQControllerType::i8259; }
+
+    u16 get_isr() const;
 
 private:
     u16 m_cached_irq_mask { 0xffff };

--- a/Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.cpp
@@ -6,42 +6,42 @@
 
 #include <Kernel/Arch/InterruptManagement.h>
 #include <Kernel/Arch/x86_64/Interrupts.h>
-#include <Kernel/Interrupts/SpuriousInterruptHandler.h>
+#include <Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT void SpuriousInterruptHandler::initialize(InterruptNumber interrupt_number)
+UNMAP_AFTER_INIT void PICSpuriousInterruptHandler::initialize(InterruptNumber interrupt_number)
 {
-    auto* handler = new SpuriousInterruptHandler(interrupt_number);
+    auto* handler = new PICSpuriousInterruptHandler(interrupt_number);
     handler->register_interrupt_handler();
 }
 
-void SpuriousInterruptHandler::initialize_for_disabled_master_pic()
+void PICSpuriousInterruptHandler::initialize_for_disabled_master_pic()
 {
-    auto* handler = new SpuriousInterruptHandler(7);
+    auto* handler = new PICSpuriousInterruptHandler(7);
     register_disabled_interrupt_handler(7, *handler);
     handler->enable_interrupt_vector_for_disabled_pic();
 }
 
-void SpuriousInterruptHandler::initialize_for_disabled_slave_pic()
+void PICSpuriousInterruptHandler::initialize_for_disabled_slave_pic()
 {
-    auto* handler = new SpuriousInterruptHandler(15);
+    auto* handler = new PICSpuriousInterruptHandler(15);
     register_disabled_interrupt_handler(15, *handler);
     handler->enable_interrupt_vector_for_disabled_pic();
 }
 
-void SpuriousInterruptHandler::register_handler(GenericInterruptHandler& handler)
+void PICSpuriousInterruptHandler::register_handler(GenericInterruptHandler& handler)
 {
     VERIFY(!m_real_handler);
     m_real_handler = adopt_own_if_nonnull(&handler);
 }
-void SpuriousInterruptHandler::unregister_handler(GenericInterruptHandler&)
+void PICSpuriousInterruptHandler::unregister_handler(GenericInterruptHandler&)
 {
     TODO();
 }
 
-bool SpuriousInterruptHandler::eoi()
+bool PICSpuriousInterruptHandler::eoi()
 {
     // Actually check if IRQ7 or IRQ15 are spurious, and if not, call EOI with the correct interrupt number.
     if (m_real_irq) {
@@ -53,22 +53,22 @@ bool SpuriousInterruptHandler::eoi()
     return false;
 }
 
-StringView SpuriousInterruptHandler::purpose() const
+StringView PICSpuriousInterruptHandler::purpose() const
 {
     if (!m_real_handler)
         return "Spurious Interrupt Handler"sv;
     return m_real_handler->purpose();
 }
 
-SpuriousInterruptHandler::SpuriousInterruptHandler(InterruptNumber irq)
+PICSpuriousInterruptHandler::PICSpuriousInterruptHandler(InterruptNumber irq)
     : GenericInterruptHandler(irq)
     , m_responsible_irq_controller(InterruptManagement::the().get_responsible_irq_controller(irq))
 {
 }
 
-SpuriousInterruptHandler::~SpuriousInterruptHandler() = default;
+PICSpuriousInterruptHandler::~PICSpuriousInterruptHandler() = default;
 
-bool SpuriousInterruptHandler::handle_interrupt()
+bool PICSpuriousInterruptHandler::handle_interrupt()
 {
     // Actually check if IRQ7 or IRQ15 are spurious, and if not, call the real handler to handle the IRQ.
     if (m_responsible_irq_controller->get_isr() & (1 << interrupt_number().value())) {
@@ -83,13 +83,13 @@ bool SpuriousInterruptHandler::handle_interrupt()
     return true;
 }
 
-void SpuriousInterruptHandler::enable_interrupt_vector_for_disabled_pic()
+void PICSpuriousInterruptHandler::enable_interrupt_vector_for_disabled_pic()
 {
     m_enabled = true;
     m_responsible_irq_controller = InterruptManagement::the().get_responsible_irq_controller(IRQControllerType::i8259, interrupt_number());
 }
 
-void SpuriousInterruptHandler::enable_interrupt_vector()
+void PICSpuriousInterruptHandler::enable_interrupt_vector()
 {
     if (m_enabled)
         return;
@@ -97,7 +97,7 @@ void SpuriousInterruptHandler::enable_interrupt_vector()
     m_responsible_irq_controller->enable(*this);
 }
 
-void SpuriousInterruptHandler::disable_interrupt_vector()
+void PICSpuriousInterruptHandler::disable_interrupt_vector()
 {
     VERIFY(!m_real_irq); // this flag should not be set when we call this method
     if (!m_enabled)
@@ -106,7 +106,7 @@ void SpuriousInterruptHandler::disable_interrupt_vector()
     m_responsible_irq_controller->disable(*this);
 }
 
-StringView SpuriousInterruptHandler::controller() const
+StringView PICSpuriousInterruptHandler::controller() const
 {
     if (m_responsible_irq_controller->type() == IRQControllerType::i82093AA)
         return ""sv;

--- a/Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.cpp
@@ -6,27 +6,28 @@
 
 #include <Kernel/Arch/InterruptManagement.h>
 #include <Kernel/Arch/x86_64/Interrupts.h>
+#include <Kernel/Arch/x86_64/Interrupts/PIC.h>
 #include <Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT void PICSpuriousInterruptHandler::initialize(InterruptNumber interrupt_number)
+UNMAP_AFTER_INIT void PICSpuriousInterruptHandler::initialize(PIC& pic, InterruptNumber interrupt_number)
 {
-    auto* handler = new PICSpuriousInterruptHandler(interrupt_number);
+    auto* handler = new PICSpuriousInterruptHandler(pic, interrupt_number);
     handler->register_interrupt_handler();
 }
 
-void PICSpuriousInterruptHandler::initialize_for_disabled_master_pic()
+void PICSpuriousInterruptHandler::initialize_for_disabled_master_pic(PIC& pic)
 {
-    auto* handler = new PICSpuriousInterruptHandler(7);
+    auto* handler = new PICSpuriousInterruptHandler(pic, 7);
     register_disabled_interrupt_handler(7, *handler);
     handler->enable_interrupt_vector_for_disabled_pic();
 }
 
-void PICSpuriousInterruptHandler::initialize_for_disabled_slave_pic()
+void PICSpuriousInterruptHandler::initialize_for_disabled_slave_pic(PIC& pic)
 {
-    auto* handler = new PICSpuriousInterruptHandler(15);
+    auto* handler = new PICSpuriousInterruptHandler(pic, 15);
     register_disabled_interrupt_handler(15, *handler);
     handler->enable_interrupt_vector_for_disabled_pic();
 }
@@ -45,11 +46,11 @@ bool PICSpuriousInterruptHandler::eoi()
 {
     // Actually check if IRQ7 or IRQ15 are spurious, and if not, call EOI with the correct interrupt number.
     if (m_real_irq) {
-        m_responsible_irq_controller->eoi(*this);
+        m_pic->eoi(*this);
         m_real_irq = false; // return to default state!
         return true;
     }
-    m_responsible_irq_controller->spurious_eoi(*this);
+    m_pic->spurious_eoi(*this);
     return false;
 }
 
@@ -60,9 +61,9 @@ StringView PICSpuriousInterruptHandler::purpose() const
     return m_real_handler->purpose();
 }
 
-PICSpuriousInterruptHandler::PICSpuriousInterruptHandler(InterruptNumber irq)
+PICSpuriousInterruptHandler::PICSpuriousInterruptHandler(PIC& pic, InterruptNumber irq)
     : GenericInterruptHandler(irq)
-    , m_responsible_irq_controller(InterruptManagement::the().get_responsible_irq_controller(irq))
+    , m_pic(pic)
 {
 }
 
@@ -71,7 +72,7 @@ PICSpuriousInterruptHandler::~PICSpuriousInterruptHandler() = default;
 bool PICSpuriousInterruptHandler::handle_interrupt()
 {
     // Actually check if IRQ7 or IRQ15 are spurious, and if not, call the real handler to handle the IRQ.
-    if (m_responsible_irq_controller->get_isr() & (1 << interrupt_number().value())) {
+    if (m_pic->get_isr() & (1 << interrupt_number().value())) {
         m_real_irq = true; // remember that we had a real IRQ, when EOI later!
         if (m_real_handler->handle_interrupt()) {
             m_real_handler->increment_call_count();
@@ -86,7 +87,6 @@ bool PICSpuriousInterruptHandler::handle_interrupt()
 void PICSpuriousInterruptHandler::enable_interrupt_vector_for_disabled_pic()
 {
     m_enabled = true;
-    m_responsible_irq_controller = InterruptManagement::the().get_responsible_irq_controller(IRQControllerType::i8259, interrupt_number());
 }
 
 void PICSpuriousInterruptHandler::enable_interrupt_vector()
@@ -94,7 +94,7 @@ void PICSpuriousInterruptHandler::enable_interrupt_vector()
     if (m_enabled)
         return;
     m_enabled = true;
-    m_responsible_irq_controller->enable(*this);
+    m_pic->enable(*this);
 }
 
 void PICSpuriousInterruptHandler::disable_interrupt_vector()
@@ -103,13 +103,11 @@ void PICSpuriousInterruptHandler::disable_interrupt_vector()
     if (!m_enabled)
         return;
     m_enabled = false;
-    m_responsible_irq_controller->disable(*this);
+    m_pic->disable(*this);
 }
 
 StringView PICSpuriousInterruptHandler::controller() const
 {
-    if (m_responsible_irq_controller->type() == IRQControllerType::i82093AA)
-        return ""sv;
-    return m_responsible_irq_controller->model();
+    return m_pic->model();
 }
 }

--- a/Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.h
+++ b/Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.h
@@ -13,11 +13,13 @@
 
 namespace Kernel {
 
+class PIC;
+
 class PICSpuriousInterruptHandler final : public GenericInterruptHandler {
 public:
-    static void initialize(InterruptNumber interrupt_number);
-    static void initialize_for_disabled_master_pic();
-    static void initialize_for_disabled_slave_pic();
+    static void initialize(PIC&, InterruptNumber interrupt_number);
+    static void initialize_for_disabled_master_pic(PIC&);
+    static void initialize_for_disabled_slave_pic(PIC&);
     virtual ~PICSpuriousInterruptHandler();
     virtual bool handle_interrupt() override;
 
@@ -38,10 +40,10 @@ public:
 private:
     void enable_interrupt_vector();
     void disable_interrupt_vector();
-    explicit PICSpuriousInterruptHandler(InterruptNumber interrupt_number);
+    explicit PICSpuriousInterruptHandler(PIC&, InterruptNumber interrupt_number);
     bool m_enabled { false };
     bool m_real_irq { false };
-    NonnullLockRefPtr<IRQController> m_responsible_irq_controller;
+    NonnullLockRefPtr<PIC> m_pic;
     OwnPtr<GenericInterruptHandler> m_real_handler;
 };
 }

--- a/Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.h
+++ b/Kernel/Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.h
@@ -13,12 +13,12 @@
 
 namespace Kernel {
 
-class SpuriousInterruptHandler final : public GenericInterruptHandler {
+class PICSpuriousInterruptHandler final : public GenericInterruptHandler {
 public:
     static void initialize(InterruptNumber interrupt_number);
     static void initialize_for_disabled_master_pic();
     static void initialize_for_disabled_slave_pic();
-    virtual ~SpuriousInterruptHandler();
+    virtual ~PICSpuriousInterruptHandler();
     virtual bool handle_interrupt() override;
 
     void register_handler(GenericInterruptHandler&);
@@ -38,7 +38,7 @@ public:
 private:
     void enable_interrupt_vector();
     void disable_interrupt_vector();
-    explicit SpuriousInterruptHandler(InterruptNumber interrupt_number);
+    explicit PICSpuriousInterruptHandler(InterruptNumber interrupt_number);
     bool m_enabled { false };
     bool m_real_irq { false };
     NonnullLockRefPtr<IRQController> m_responsible_irq_controller;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -428,6 +428,7 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Arch/x86_64/Interrupts/APIC.cpp
         Arch/x86_64/Interrupts/IOAPIC.cpp
         Arch/x86_64/Interrupts/PIC.cpp
+        Arch/x86_64/Interrupts/PICSpuriousInterruptHandler.cpp
         Arch/x86_64/Time/APICTimer.cpp
         Arch/x86_64/Time/HPET.cpp
         Arch/x86_64/Time/HPETComparator.cpp
@@ -446,9 +447,6 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Arch/x86_64/RTC.cpp
         Arch/x86_64/Shutdown.cpp
         Arch/x86_64/SmapDisabler.cpp
-
-        # TODO: Share this with the aarch64 build
-        Interrupts/SpuriousInterruptHandler.cpp
     )
 
     set(KERNEL_SOURCES

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -403,6 +403,7 @@ set(KERNEL_SOURCES
     Tasks/WorkQueue.cpp
     Time/TimeManagement.cpp
     Time/TimerQueue.cpp
+    kprintf.cpp
 )
 
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
@@ -446,9 +447,8 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Arch/x86_64/Shutdown.cpp
         Arch/x86_64/SmapDisabler.cpp
 
-        # TODO: Share these with the aarch64 build
+        # TODO: Share this with the aarch64 build
         Interrupts/SpuriousInterruptHandler.cpp
-        kprintf.cpp
     )
 
     set(KERNEL_SOURCES
@@ -504,8 +504,6 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
         ${KERNEL_SOURCES}
         ${RPI_SOURCES}
         ${SOURCES_RUNNING_WITHOUT_MMU}
-
-        kprintf.cpp
 
         Arch/aarch64/archctl.cpp
         Arch/aarch64/boot.S
@@ -577,7 +575,6 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         "${extensions_header}"
 
         Arch/Processor.cpp
-        kprintf.cpp
 
         Arch/riscv64/archctl.cpp
         Arch/riscv64/boot.S

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -17,7 +17,9 @@ enum class HandlerType : u8 {
     IRQHandler = 1,
     SharedIRQHandler = 2,
     UnhandledInterruptHandler = 3,
+#if ARCH(X86_64)
     SpuriousInterruptHandler = 4
+#endif
 };
 
 class GenericInterruptHandler {


### PR DESCRIPTION
This PR makes us support systems with 2 I/O APICs properly!
While attempting to make this work, I noticed some bugs that were hidden because of us not properly supporting multiple I/O APICs and multiple cleanups that could be done in this code.

See individual commits for details.

I tested each commit in QEMU both with `enable_ioapic=on` (to use an I/O APIC) and `enable_ioapic=off` (to use 2 PICs). For `enable_ioapic=off` I had to apply a hack patch to disable MSIs because we currently always try to use MSIs, even when the APIC is disabled, leading to a crash.

To test dual I/O APIC support, I used the QEMU microvm machine, since it's the only QEMU machine that can be configured to use two I/O APICs via the `ioapic2=on` machine option. To do so, I had to apply some (hacky) local patches to make us boot on this machine without an AML interpreter. I most likely won't upstream those. Additionally, I applied a QEMU patch to actually use the second I/O APIC for PCI pin interrupts.

My motivation for this patch was to get PCI pin interrupts working on my bare metal PC, which does have two I/O APICs. Unfortunately, these patches aren't enough to get it working.