### PR TITLE
Kernel/PCI: Don't use Region::physical_page() to print the ECAM address

### DIFF
--- a/Kernel/Arch/x86_64/PCI/Initializer.cpp
+++ b/Kernel/Arch/x86_64/PCI/Initializer.cpp
@@ -44,10 +44,11 @@ UNMAP_AFTER_INIT void initialize()
         g_pci_access_is_disabled_from_commandline.set();
 
     Optional<PhysicalAddress> possible_mcfg;
-    // FIXME: There are other arch-specific methods to find the memory range
-    // for accessing the PCI configuration space.
-    // For example, the QEMU microvm machine type might expose an FDT so we could
-    // parse it to find a PCI host bridge.
+
+    // FIXME: Support accessing the PCI configuration space via the
+    //        _CBA ACPI method. To do so, we likely also need to assign
+    //        resources specified by the _CRS method, similar to the devicetree code.
+
     if (ACPI::is_enabled()) {
         possible_mcfg = ACPI::Parser::the()->find_table("MCFG"sv);
         if ((!test_pci_io()) && (!possible_mcfg.has_value()))

--- a/Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.cpp
+++ b/Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.cpp
@@ -75,7 +75,7 @@ void MemoryBackedHostBridge::map_bus_region(BusNumber bus)
         VERIFY_NOT_REACHED();
     m_mapped_bus_region = region_or_error.release_value();
     m_mapped_bus = bus;
-    dbgln_if(PCI_DEBUG, "PCI: New PCI ECAM Mapped region for bus {} @ {} {}", bus, m_mapped_bus_region->vaddr(), m_mapped_bus_region->physical_page(0)->paddr());
+    dbgln_if(PCI_DEBUG, "PCI: New PCI ECAM Mapped region for bus {} @ {} {}", bus, m_mapped_bus_region->vaddr(), bus_base_address);
 }
 
 VirtualAddress MemoryBackedHostBridge::get_device_configuration_memory_mapped_space(BusNumber bus, DeviceNumber device, FunctionNumber function)


### PR DESCRIPTION
Since 827322c1396, MMIO regions aren't backed by physical page classes anymore, so this caused a null RefPtr to be dereferenced.

---

Additionally, tweak an outdated FIXME i noticed.