### PR TITLE
tar+LibArchive: Support encoding/decoding timestamps

### DIFF
--- a/Userland/Libraries/LibArchive/TarStream.cpp
+++ b/Userland/Libraries/LibArchive/TarStream.cpp
@@ -140,14 +140,14 @@ TarOutputStream::TarOutputStream(MaybeOwned<Stream> stream)
 {
 }
 
-ErrorOr<void> TarOutputStream::add_directory(StringView path, mode_t mode)
+ErrorOr<void> TarOutputStream::add_directory(StringView path, struct stat const& statbuf)
 {
     VERIFY(!m_finished);
     TarFileHeader header {};
     TRY(header.set_size(0));
     header.set_filename_and_prefix(TRY(String::formatted("{}/", path))); // Old tar implementations assume directory names end with a /
     header.set_type_flag(TarFileType::Directory);
-    TRY(header.set_mode(mode));
+    TRY(header.set_mode(statbuf.st_mode));
     header.set_magic(gnu_magic);
     header.set_version(gnu_version);
     TRY(header.calculate_checksum());
@@ -157,14 +157,14 @@ ErrorOr<void> TarOutputStream::add_directory(StringView path, mode_t mode)
     return {};
 }
 
-ErrorOr<void> TarOutputStream::add_file(StringView path, mode_t mode, ReadonlyBytes bytes)
+ErrorOr<void> TarOutputStream::add_file(StringView path, struct stat const& statbuf, ReadonlyBytes bytes)
 {
     VERIFY(!m_finished);
     TarFileHeader header {};
     TRY(header.set_size(bytes.size()));
     header.set_filename_and_prefix(path);
     header.set_type_flag(TarFileType::NormalFile);
-    TRY(header.set_mode(mode));
+    TRY(header.set_mode(statbuf.st_mode));
     header.set_magic(gnu_magic);
     header.set_version(gnu_version);
     TRY(header.calculate_checksum());
@@ -179,14 +179,14 @@ ErrorOr<void> TarOutputStream::add_file(StringView path, mode_t mode, ReadonlyBy
     return {};
 }
 
-ErrorOr<void> TarOutputStream::add_link(StringView path, mode_t mode, StringView link_name)
+ErrorOr<void> TarOutputStream::add_link(StringView path, struct stat const& statbuf, StringView link_name)
 {
     VERIFY(!m_finished);
     TarFileHeader header {};
     TRY(header.set_size(0));
     header.set_filename_and_prefix(path);
     header.set_type_flag(TarFileType::SymLink);
-    TRY(header.set_mode(mode));
+    TRY(header.set_mode(statbuf.st_mode));
     header.set_magic(gnu_magic);
     header.set_version(gnu_version);
     header.set_link_name(link_name);

--- a/Userland/Libraries/LibArchive/TarStream.cpp
+++ b/Userland/Libraries/LibArchive/TarStream.cpp
@@ -145,6 +145,7 @@ ErrorOr<void> TarOutputStream::add_directory(StringView path, struct stat const&
     VERIFY(!m_finished);
     TarFileHeader header {};
     TRY(header.set_size(0));
+    TRY(header.set_timestamp(statbuf.st_mtime));
     header.set_filename_and_prefix(TRY(String::formatted("{}/", path))); // Old tar implementations assume directory names end with a /
     header.set_type_flag(TarFileType::Directory);
     TRY(header.set_mode(statbuf.st_mode));
@@ -162,6 +163,7 @@ ErrorOr<void> TarOutputStream::add_file(StringView path, struct stat const& stat
     VERIFY(!m_finished);
     TarFileHeader header {};
     TRY(header.set_size(bytes.size()));
+    TRY(header.set_timestamp(statbuf.st_mtime));
     header.set_filename_and_prefix(path);
     header.set_type_flag(TarFileType::NormalFile);
     TRY(header.set_mode(statbuf.st_mode));
@@ -184,6 +186,7 @@ ErrorOr<void> TarOutputStream::add_link(StringView path, struct stat const& stat
     VERIFY(!m_finished);
     TarFileHeader header {};
     TRY(header.set_size(0));
+    TRY(header.set_timestamp(statbuf.st_mtime));
     header.set_filename_and_prefix(path);
     header.set_type_flag(TarFileType::SymLink);
     TRY(header.set_mode(statbuf.st_mode));

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -11,6 +11,7 @@
 #include <AK/Span.h>
 #include <AK/Stream.h>
 #include <LibArchive/Tar.h>
+#include <sys/stat.h>
 
 namespace Archive {
 
@@ -60,9 +61,9 @@ private:
 class TarOutputStream {
 public:
     TarOutputStream(MaybeOwned<Stream>);
-    ErrorOr<void> add_file(StringView path, mode_t, ReadonlyBytes);
-    ErrorOr<void> add_link(StringView path, mode_t, StringView);
-    ErrorOr<void> add_directory(StringView path, mode_t);
+    ErrorOr<void> add_file(StringView path, struct stat const&, ReadonlyBytes);
+    ErrorOr<void> add_link(StringView path, struct stat const&, StringView);
+    ErrorOr<void> add_directory(StringView path, struct stat const&);
     ErrorOr<void> finish();
 
 private:

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -109,7 +109,7 @@ int futimes(int fd, struct timeval const times[2])
     timespec ts[2];
     TIMEVAL_TO_TIMESPEC(&times[0], &ts[0]);
     TIMEVAL_TO_TIMESPEC(&times[1], &ts[1]);
-    return utimensat(fd, nullptr, ts, 0);
+    return futimens(fd, ts);
 }
 
 char* ctime(time_t const* t)

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -193,6 +193,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 auto absolute_path = TRY(FileSystem::absolute_path(filename));
                 auto parent_path = LexicalPath(absolute_path).parent();
                 auto header_mode = TRY(header.mode());
+                auto header_timestamp = TRY(header.timestamp());
+
+                struct timeval times[2] = { { header_timestamp, 0 }, { header_timestamp, 0 } };
 
                 switch (header.type_flag()) {
                 case Archive::TarFileType::NormalFile:
@@ -207,6 +210,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                         TRY(Core::System::write(fd, slice));
                     }
 
+                    if (futimes(fd, times) < 0)
+                        warnln("failed to set timestamps for {}", header.filename());
+
                     TRY(Core::System::close(fd));
                     break;
                 }
@@ -214,6 +220,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     MUST(Core::Directory::create(parent_path, Core::Directory::CreateDirectories::Yes));
 
                     TRY(Core::System::symlink(header.link_name(), absolute_path));
+                    if (lutimes(absolute_path.characters(), times) < 0)
+                        warnln("failed to set timestamps for {}", header.filename());
                     break;
                 }
                 case Archive::TarFileType::Directory: {
@@ -222,6 +230,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     auto result_or_error = Core::System::mkdir(absolute_path, header_mode);
                     if (result_or_error.is_error() && result_or_error.error().code() != EEXIST)
                         return result_or_error.release_error();
+                    if (utimes(absolute_path.characters(), times) < 0)
+                        warnln("failed to set timestamps for {}", header.filename());
                     break;
                 }
                 default:

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -274,7 +274,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
             // FIXME: We should stream instead of reading the entire file in one go, but TarOutputStream does not have any interface to do so.
             auto file_content = TRY(file->read_until_eof());
-            TRY(tar_stream.add_file(canonicalized_path, statbuf.st_mode, file_content));
+            TRY(tar_stream.add_file(canonicalized_path, statbuf, file_content));
             if (verbose)
                 outln("{}", canonicalized_path);
 
@@ -285,7 +285,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto statbuf = TRY(Core::System::lstat(path));
 
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
-            TRY(tar_stream.add_link(canonicalized_path, statbuf.st_mode, TRY(Core::System::readlink(path))));
+            TRY(tar_stream.add_link(canonicalized_path, statbuf, TRY(Core::System::readlink(path))));
             if (verbose)
                 outln("{}", canonicalized_path);
 
@@ -296,7 +296,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto statbuf = TRY(Core::System::lstat(path));
 
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
-            TRY(tar_stream.add_directory(canonicalized_path, statbuf.st_mode));
+            TRY(tar_stream.add_directory(canonicalized_path, statbuf));
             if (verbose)
                 outln("{}", canonicalized_path);
 

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -9,6 +9,7 @@
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
 #include <AK/Span.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibArchive/TarStream.h>
 #include <LibCompress/Gzip.h>
@@ -42,6 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView directory;
     Vector<ByteString> paths;
     u32 strip_components {};
+    StringView mtime_or_file;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(create, "Create archive", "create", 'c');
@@ -56,6 +58,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(archive_file, "Archive file", "file", 'f', "FILE");
     args_parser.add_option(dereference, "Follow symlinks", "dereference", 'h');
     args_parser.add_option(strip_components, "Strip the first NUMBER path components from each file path", "strip-components", {}, "NUMBER");
+    args_parser.add_option(mtime_or_file, "Set mtime for added files", "mtime", {}, "NUMBER or FILE");
     args_parser.add_positional_argument(paths, "Paths", "PATHS", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
@@ -243,6 +246,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return 1;
         }
 
+        Optional<time_t> mtime;
+        if (!mtime_or_file.is_null()) {
+            if (auto time = mtime_or_file.to_number<time_t>(); time.has_value()) {
+                mtime = time;
+            } else {
+                auto statbuf = TRY(Core::System::lstat(mtime_or_file));
+                mtime = statbuf.st_mtime;
+            }
+        }
+
         NonnullOwnPtr<Stream> output_stream = TRY(Core::File::standard_output());
 
         if (!archive_file.is_empty())
@@ -271,6 +284,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto file = file_or_error.release_value();
 
             auto statbuf = TRY(Core::System::lstat(path));
+            if (mtime.has_value())
+                statbuf.st_mtime = *mtime;
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
             // FIXME: We should stream instead of reading the entire file in one go, but TarOutputStream does not have any interface to do so.
             auto file_content = TRY(file->read_until_eof());
@@ -283,6 +298,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto add_link = [&](ByteString path) -> ErrorOr<void> {
             auto statbuf = TRY(Core::System::lstat(path));
+            if (mtime.has_value())
+                statbuf.st_mtime = *mtime;
 
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
             TRY(tar_stream.add_link(canonicalized_path, statbuf, TRY(Core::System::readlink(path))));
@@ -294,6 +311,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto add_directory = [&](ByteString path, auto handle_directory) -> ErrorOr<void> {
             auto statbuf = TRY(Core::System::lstat(path));
+            if (mtime.has_value())
+                statbuf.st_mtime = *mtime;
 
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
             TRY(tar_stream.add_directory(canonicalized_path, statbuf));


### PR DESCRIPTION
This should also make it easier to do the same for the UID and GID entries.