### PR TITLE
tar+LibArchive: Various improvements

### DIFF
--- a/Userland/Libraries/LibArchive/Tar.cpp
+++ b/Userland/Libraries/LibArchive/Tar.cpp
@@ -56,16 +56,16 @@ void TarFileHeader::set_filename_and_prefix(StringView filename)
     VERIFY(filename.length() <= sizeof(m_filename) + sizeof(m_prefix));
 
     if (filename.length() <= sizeof(m_filename)) {
-        set_prefix(""sv);
-        set_filename(filename);
+        MUST(set_prefix(""sv));
+        MUST(set_filename(filename));
         return;
     }
 
     Optional<size_t> slash = filename.find('/', filename.length() - sizeof(m_filename));
 
     VERIFY(slash.has_value());
-    set_prefix(filename.substring_view(0, slash.value() + 1));
-    set_filename(filename.substring_view(slash.value() + 1));
+    MUST(set_prefix(filename.substring_view(0, slash.value() + 1)));
+    MUST(set_filename(filename.substring_view(slash.value() + 1)));
 }
 
 }

--- a/Userland/Libraries/LibArchive/Tar.h
+++ b/Userland/Libraries/LibArchive/Tar.h
@@ -73,19 +73,21 @@ static StringView get_field_as_string_view(char const (&field)[N])
 }
 
 template<size_t N, class TSource>
-static void set_field(char (&field)[N], TSource&& source)
+static ErrorOr<void> set_field(char (&field)[N], TSource&& source)
 {
-    VERIFY(N >= source.length());
+    if (N < source.length())
+        return Error::from_string_literal("Source too long");
     memcpy(field, StringView(source).characters_without_null_termination(), source.length());
     if (N > source.length())
         field[source.length()] = 0;
+    return {};
 }
 
 template<class TSource, size_t N>
 static ErrorOr<void> set_octal_field(char (&field)[N], TSource&& source)
 {
     auto octal = TRY(String::formatted("{:o}", forward<TSource>(source)));
-    set_field(field, octal.bytes_as_string_view());
+    TRY(set_field(field, octal.bytes_as_string_view()));
     return {};
 }
 
@@ -110,23 +112,23 @@ public:
     // FIXME: support ustar filename prefix
     StringView prefix() const { return get_field_as_string_view(m_prefix); }
 
-    void set_filename(StringView filename) { set_field(m_filename, filename); }
+    ErrorOr<void> set_filename(StringView filename) { return set_field(m_filename, filename); }
     ErrorOr<void> set_mode(mode_t mode) { return set_octal_field(m_mode, mode); }
     ErrorOr<void> set_uid(uid_t uid) { return set_octal_field(m_uid, uid); }
     ErrorOr<void> set_gid(gid_t gid) { return set_octal_field(m_gid, gid); }
     ErrorOr<void> set_size(size_t size) { return set_octal_field(m_size, size); }
     ErrorOr<void> set_timestamp(time_t timestamp) { return set_octal_field(m_timestamp, timestamp); }
     void set_type_flag(TarFileType type) { m_type_flag = to_underlying(type); }
-    void set_link_name(StringView link_name) { set_field(m_link_name, link_name); }
+    ErrorOr<void> set_link_name(StringView link_name) { return set_field(m_link_name, link_name); }
     // magic doesn't necessarily include a null byte
-    void set_magic(StringView magic) { set_field(m_magic, magic); }
+    ErrorOr<void> set_magic(StringView magic) { return set_field(m_magic, magic); }
     // version doesn't necessarily include a null byte
-    void set_version(StringView version) { set_field(m_version, version); }
-    void set_owner_name(StringView owner_name) { set_field(m_owner_name, owner_name); }
-    void set_group_name(StringView group_name) { set_field(m_group_name, group_name); }
+    ErrorOr<void> set_version(StringView version) { return set_field(m_version, version); }
+    ErrorOr<void> set_owner_name(StringView owner_name) { return set_field(m_owner_name, owner_name); }
+    ErrorOr<void> set_group_name(StringView group_name) { return set_field(m_group_name, group_name); }
     ErrorOr<void> set_major(int major) { return set_octal_field(m_major, major); }
     ErrorOr<void> set_minor(int minor) { return set_octal_field(m_minor, minor); }
-    void set_prefix(StringView prefix) { set_field(m_prefix, prefix); }
+    ErrorOr<void> set_prefix(StringView prefix) { return set_field(m_prefix, prefix); }
 
     unsigned expected_checksum() const;
     ErrorOr<void> calculate_checksum();

--- a/Userland/Libraries/LibArchive/TarStream.cpp
+++ b/Userland/Libraries/LibArchive/TarStream.cpp
@@ -140,7 +140,7 @@ TarOutputStream::TarOutputStream(MaybeOwned<Stream> stream)
 {
 }
 
-ErrorOr<void> TarOutputStream::add_directory(StringView path, struct stat const& statbuf)
+ErrorOr<void> TarOutputStream::add_directory(StringView path, struct stat const& statbuf, StringView group_name, StringView owner_name)
 {
     VERIFY(!m_finished);
     TarFileHeader header {};
@@ -149,6 +149,12 @@ ErrorOr<void> TarOutputStream::add_directory(StringView path, struct stat const&
     header.set_filename_and_prefix(TRY(String::formatted("{}/", path))); // Old tar implementations assume directory names end with a /
     header.set_type_flag(TarFileType::Directory);
     TRY(header.set_mode(statbuf.st_mode));
+
+    TRY(header.set_gid(statbuf.st_gid));
+    TRY(header.set_group_name(group_name));
+    TRY(header.set_uid(statbuf.st_uid));
+    TRY(header.set_owner_name(owner_name));
+
     MUST(header.set_magic(gnu_magic));
     MUST(header.set_version(gnu_version));
     TRY(header.calculate_checksum());
@@ -158,7 +164,7 @@ ErrorOr<void> TarOutputStream::add_directory(StringView path, struct stat const&
     return {};
 }
 
-ErrorOr<void> TarOutputStream::add_file(StringView path, struct stat const& statbuf, ReadonlyBytes bytes)
+ErrorOr<void> TarOutputStream::add_file(StringView path, struct stat const& statbuf, ReadonlyBytes bytes, StringView group_name, StringView owner_name)
 {
     VERIFY(!m_finished);
     TarFileHeader header {};
@@ -167,6 +173,12 @@ ErrorOr<void> TarOutputStream::add_file(StringView path, struct stat const& stat
     header.set_filename_and_prefix(path);
     header.set_type_flag(TarFileType::NormalFile);
     TRY(header.set_mode(statbuf.st_mode));
+
+    TRY(header.set_gid(statbuf.st_gid));
+    TRY(header.set_group_name(group_name));
+    TRY(header.set_uid(statbuf.st_uid));
+    TRY(header.set_owner_name(owner_name));
+
     MUST(header.set_magic(gnu_magic));
     MUST(header.set_version(gnu_version));
     TRY(header.calculate_checksum());
@@ -181,7 +193,7 @@ ErrorOr<void> TarOutputStream::add_file(StringView path, struct stat const& stat
     return {};
 }
 
-ErrorOr<void> TarOutputStream::add_link(StringView path, struct stat const& statbuf, StringView link_name)
+ErrorOr<void> TarOutputStream::add_link(StringView path, struct stat const& statbuf, StringView link_name, StringView group_name, StringView owner_name)
 {
     VERIFY(!m_finished);
     TarFileHeader header {};
@@ -190,6 +202,12 @@ ErrorOr<void> TarOutputStream::add_link(StringView path, struct stat const& stat
     header.set_filename_and_prefix(path);
     header.set_type_flag(TarFileType::SymLink);
     TRY(header.set_mode(statbuf.st_mode));
+
+    TRY(header.set_gid(statbuf.st_gid));
+    TRY(header.set_group_name(group_name));
+    TRY(header.set_uid(statbuf.st_uid));
+    TRY(header.set_owner_name(owner_name));
+
     MUST(header.set_magic(gnu_magic));
     MUST(header.set_version(gnu_version));
     TRY(header.set_link_name(link_name));

--- a/Userland/Libraries/LibArchive/TarStream.cpp
+++ b/Userland/Libraries/LibArchive/TarStream.cpp
@@ -149,8 +149,8 @@ ErrorOr<void> TarOutputStream::add_directory(StringView path, struct stat const&
     header.set_filename_and_prefix(TRY(String::formatted("{}/", path))); // Old tar implementations assume directory names end with a /
     header.set_type_flag(TarFileType::Directory);
     TRY(header.set_mode(statbuf.st_mode));
-    header.set_magic(gnu_magic);
-    header.set_version(gnu_version);
+    MUST(header.set_magic(gnu_magic));
+    MUST(header.set_version(gnu_version));
     TRY(header.calculate_checksum());
     TRY(m_stream->write_until_depleted(Bytes { &header, sizeof(header) }));
     u8 padding[block_size] = { 0 };
@@ -167,8 +167,8 @@ ErrorOr<void> TarOutputStream::add_file(StringView path, struct stat const& stat
     header.set_filename_and_prefix(path);
     header.set_type_flag(TarFileType::NormalFile);
     TRY(header.set_mode(statbuf.st_mode));
-    header.set_magic(gnu_magic);
-    header.set_version(gnu_version);
+    MUST(header.set_magic(gnu_magic));
+    MUST(header.set_version(gnu_version));
     TRY(header.calculate_checksum());
     TRY(m_stream->write_until_depleted(ReadonlyBytes { &header, sizeof(header) }));
     constexpr Array<u8, block_size> padding { 0 };
@@ -190,9 +190,9 @@ ErrorOr<void> TarOutputStream::add_link(StringView path, struct stat const& stat
     header.set_filename_and_prefix(path);
     header.set_type_flag(TarFileType::SymLink);
     TRY(header.set_mode(statbuf.st_mode));
-    header.set_magic(gnu_magic);
-    header.set_version(gnu_version);
-    header.set_link_name(link_name);
+    MUST(header.set_magic(gnu_magic));
+    MUST(header.set_version(gnu_version));
+    TRY(header.set_link_name(link_name));
     TRY(header.calculate_checksum());
     TRY(m_stream->write_until_depleted(Bytes { &header, sizeof(header) }));
     u8 padding[block_size] = { 0 };

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -61,9 +61,9 @@ private:
 class TarOutputStream {
 public:
     TarOutputStream(MaybeOwned<Stream>);
-    ErrorOr<void> add_file(StringView path, struct stat const&, ReadonlyBytes);
-    ErrorOr<void> add_link(StringView path, struct stat const&, StringView);
-    ErrorOr<void> add_directory(StringView path, struct stat const&);
+    ErrorOr<void> add_file(StringView path, struct stat const&, ReadonlyBytes, StringView group_name = {}, StringView owner_name = {});
+    ErrorOr<void> add_link(StringView path, struct stat const&, StringView, StringView group_name = {}, StringView owner_name = {});
+    ErrorOr<void> add_directory(StringView path, struct stat const&, StringView group_name = {}, StringView owner_name = {});
     ErrorOr<void> finish();
 
 private:

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -58,6 +58,53 @@ static Optional<time_t> parse_time(StringView time_string)
     return time.timestamp();
 }
 
+template<typename IDType>
+struct NameMapping {
+    StringView name;
+    Optional<IDType> id;
+};
+
+enum class IDTypeName {
+    UID,
+    GID,
+};
+
+template<typename IDType>
+static Optional<NameMapping<IDType>> parse_mapping(StringView argument, IDTypeName type_name)
+{
+    auto maybe_index = argument.find(':');
+    if (maybe_index.has_value()) {
+        StringView name = argument.substring_view(0, *maybe_index);
+        if (argument.length() <= *maybe_index + 1)
+            return {};
+        auto maybe_numeric = argument.substring_view(*maybe_index + 1).to_number<IDType>();
+        if (!maybe_numeric.has_value()) {
+            return {};
+        }
+        return NameMapping<IDType> { name, *maybe_numeric };
+    }
+
+    if (auto maybe_numeric = argument.to_number<IDType>(); maybe_numeric.has_value())
+        return NameMapping<IDType> { {}, *maybe_numeric };
+
+    switch (type_name) {
+    case IDTypeName::UID: {
+        auto maybe_passwd = Core::System::getpwnam(argument);
+        if (!maybe_passwd.is_error() && maybe_passwd.value().has_value())
+            return NameMapping<IDType> { argument, maybe_passwd.value()->pw_uid };
+        break;
+    }
+    case IDTypeName::GID: {
+        auto maybe_group = Core::System::getgrnam(argument);
+        if (!maybe_group.is_error() && maybe_group.value().has_value())
+            return NameMapping<IDType> { argument, maybe_group.value()->gr_gid };
+        break;
+    }
+    }
+
+    return NameMapping<IDType> { argument, {} };
+}
+
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     bool create = false;
@@ -74,6 +121,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Vector<ByteString> paths;
     u32 strip_components {};
     StringView mtime_or_file;
+    StringView group_string;
+    StringView owner_string;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(create, "Create archive", "create", 'c');
@@ -89,6 +138,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(dereference, "Follow symlinks", "dereference", 'h');
     args_parser.add_option(strip_components, "Strip the first NUMBER path components from each file path", "strip-components", {}, "NUMBER");
     args_parser.add_option(mtime_or_file, "Set mtime for added files", "mtime", {}, "NUMBER or FILE");
+    args_parser.add_option(group_string, "Set group for added files", "group", {}, "NAME:[GID]");
+    args_parser.add_option(owner_string, "Set owner for added files", "owner", {}, "NAME:[UID]");
     args_parser.add_positional_argument(paths, "Paths", "PATHS", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
@@ -295,6 +346,24 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
         }
 
+        Optional<NameMapping<gid_t>> group;
+        StringView group_name;
+        if (!group_string.is_null()) {
+            group = parse_mapping<gid_t>(group_string, IDTypeName::GID);
+            if (!group.has_value())
+                return Error::from_string_literal("Could not parse the provided group string");
+            group_name = group->name;
+        }
+
+        Optional<NameMapping<uid_t>> owner;
+        StringView owner_name;
+        if (!owner_string.is_null()) {
+            owner = parse_mapping<uid_t>(owner_string, IDTypeName::UID);
+            if (!owner.has_value())
+                return Error::from_string_literal("Could not parse the provided owner string");
+            owner_name = owner->name;
+        }
+
         if (archive_file.is_empty())
             archive_file = "-"sv;
 
@@ -325,10 +394,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto statbuf = TRY(Core::System::lstat(path));
             if (mtime.has_value())
                 statbuf.st_mtime = *mtime;
+            // If a group/owner string was provided, but a relevant ID
+            // was neither provided nor could be resolved, then set the
+            // ID to 1000.
+            if (group.has_value())
+                statbuf.st_gid = group->id.has_value() ? *group->id : 1000;
+            if (owner.has_value())
+                statbuf.st_uid = owner->id.has_value() ? *owner->id : 1000;
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
             // FIXME: We should stream instead of reading the entire file in one go, but TarOutputStream does not have any interface to do so.
             auto file_content = TRY(file->read_until_eof());
-            TRY(tar_stream.add_file(canonicalized_path, statbuf, file_content));
+            TRY(tar_stream.add_file(canonicalized_path, statbuf, file_content, group_name, owner_name));
             if (verbose)
                 outln("{}", canonicalized_path);
 
@@ -339,9 +415,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto statbuf = TRY(Core::System::lstat(path));
             if (mtime.has_value())
                 statbuf.st_mtime = *mtime;
+            if (group.has_value())
+                statbuf.st_gid = group->id.has_value() ? *group->id : 1000;
+            if (owner.has_value())
+                statbuf.st_uid = owner->id.has_value() ? *owner->id : 1000;
 
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
-            TRY(tar_stream.add_link(canonicalized_path, statbuf, TRY(Core::System::readlink(path))));
+            TRY(tar_stream.add_link(canonicalized_path, statbuf, TRY(Core::System::readlink(path)), group_name, owner_name));
             if (verbose)
                 outln("{}", canonicalized_path);
 
@@ -352,9 +432,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto statbuf = TRY(Core::System::lstat(path));
             if (mtime.has_value())
                 statbuf.st_mtime = *mtime;
+            if (group.has_value())
+                statbuf.st_gid = group->id.has_value() ? *group->id : 1000;
+            if (owner.has_value())
+                statbuf.st_uid = owner->id.has_value() ? *owner->id : 1000;
 
             auto canonicalized_path = LexicalPath::canonicalized_path(path);
-            TRY(tar_stream.add_directory(canonicalized_path, statbuf));
+            TRY(tar_stream.add_directory(canonicalized_path, statbuf, group_name, owner_name));
             if (verbose)
                 outln("{}", canonicalized_path);
 

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -266,10 +266,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
         }
 
-        NonnullOwnPtr<Stream> output_stream = TRY(Core::File::standard_output());
+        if (archive_file.is_empty())
+            archive_file = "-"sv;
 
-        if (!archive_file.is_empty())
-            output_stream = TRY(Core::File::open(archive_file, Core::File::OpenMode::Write));
+        NonnullOwnPtr<Stream> output_stream = TRY(Core::File::open_file_or_standard_stream(archive_file, Core::File::OpenMode::Write));
 
         if (!directory.is_empty())
             TRY(Core::System::chdir(directory));

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -16,6 +16,7 @@
 #include <LibCompress/Lzma.h>
 #include <LibCompress/Xz.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/DateTime.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/Directory.h>
 #include <LibCore/System.h>
@@ -27,6 +28,35 @@
 #include <unistd.h>
 
 constexpr size_t buffer_size = 4096;
+
+static Optional<time_t> parse_time(StringView time_string)
+{
+    // TODO: Handle more time formats that GNU tar supports.
+
+    time_string = time_string.trim_whitespace();
+    if (time_string.is_empty())
+        // Handle an empty string as if "0" was passed.
+        time_string = "0"sv;
+    // Handle a UNIX timestamp.
+    if (time_string.starts_with('@')) {
+        if (auto maybe_timestamp = time_string.substring_view(1).to_number<time_t>(); maybe_timestamp.has_value()) {
+            return maybe_timestamp.release_value();
+        }
+        return {};
+    }
+    // Assume that this represents an hour + (optional) minute offset
+    // from the start of the current day (the hour takes precedence,
+    // i.e. 123 should be parsed as 12:03).
+    if (!time_string.to_number<time_t>().has_value() || time_string.length() > 4)
+        return {};
+    time_t hour = *time_string.substring_view(0, min(time_string.length(), 2)).to_number<time_t>();
+    time_t minute = time_string.length() > 2 ? *time_string.substring_view(2).to_number<time_t>() : 0;
+    if (hour >= 24 || minute >= 60)
+        return {};
+    auto time = Core::DateTime::now();
+    time.set_time_only(hour, minute, 0);
+    return time.timestamp();
+}
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -258,9 +288,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Optional<time_t> mtime;
         if (!mtime_or_file.is_null()) {
-            if (auto time = mtime_or_file.to_number<time_t>(); time.has_value()) {
-                mtime = time;
-            } else {
+            mtime = parse_time(mtime_or_file);
+            if (!mtime.has_value()) {
                 auto statbuf = TRY(Core::System::lstat(mtime_or_file));
                 mtime = statbuf.st_mtime;
             }


### PR DESCRIPTION
This improves the handling of the `--mtime` flag (though this is still far from entirely compatible with GNU tar, see [here](https://www.gnu.org/software/tar/manual/tar.html#Date-input-formats) for everything that that supports. We should probably make a generic date/time parser class if we need full compatibility so that other utilities (e.g. `date`) could make use of that as well).

I also noticed that the `-` output wasn't working correctly when creating archives, so this fixes that too. Also, this now supports encoding user/group metadata, but there isn't yet any support for preserving that when extracting archives.