### PR TITLE
Kernel: Add support for Privileged Access Never (PAN) on aarch64

### DIFF
--- a/Kernel/Arch/aarch64/CPUID.cpp
+++ b/Kernel/Arch/aarch64/CPUID.cpp
@@ -244,9 +244,9 @@ CPUFeature::Type detect_cpu_features()
     if (memory_model_feature_register_1.PAN == 0b0001)
         features |= CPUFeature::PAN;
     if (memory_model_feature_register_1.PAN == 0b0010)
-        features |= CPUFeature::PAN2;
+        features |= CPUFeature::PAN2 | CPUFeature::PAN;
     if (memory_model_feature_register_1.PAN == 0b0011)
-        features |= CPUFeature::PAN3;
+        features |= CPUFeature::PAN3 | CPUFeature::PAN2 | CPUFeature::PAN;
     if (memory_model_feature_register_1.XNX == 0b0001)
         features |= CPUFeature::XNX;
     if (memory_model_feature_register_1.TWED == 0b0001)

--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -55,7 +55,7 @@ void dump_registers(RegisterState const& regs)
     dbgln("x30={:p}", regs.x[30]);
 }
 
-static ErrorOr<PageFault> page_fault_from_exception_syndrome_register(VirtualAddress fault_address, Aarch64::ESR_EL1 esr_el1)
+static ErrorOr<PageFault> page_fault_from_exception_syndrome_register(VirtualAddress fault_address, Aarch64::ESR_EL1 esr_el1, Aarch64::SPSR_EL1 spsr_el1)
 {
     PageFault fault { fault_address };
 
@@ -72,7 +72,7 @@ static ErrorOr<PageFault> page_fault_from_exception_syndrome_register(VirtualAdd
     fault.set_access((esr_el1.ISS & (1 << 6)) == (1 << 6) ? PageFault::Access::Write : PageFault::Access::Read);
 
     fault.set_mode(Aarch64::exception_class_is_data_or_instruction_abort_from_lower_exception_level(esr_el1.EC) ? ExecutionMode::User : ExecutionMode::Kernel);
-    fault.set_was_smap_disabled(true); // We don't support SMAP protection on AArch64 yet, so it's always disabled.
+    fault.set_was_smap_disabled(spsr_el1.PAN == 0);
 
     if (Aarch64::exception_class_is_instruction_abort(esr_el1.EC))
         fault.set_instruction_fetch(true);
@@ -86,6 +86,7 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
     Processor::current().enter_trap(*trap_frame, false);
 
     auto esr_el1 = bit_cast<Aarch64::ESR_EL1>(trap_frame->regs->esr_el1);
+    auto spsr_el1 = bit_cast<Aarch64::SPSR_EL1>(trap_frame->regs->spsr_el1);
     auto fault_address = Aarch64::FAR_EL1::read().virtual_address;
     if (Aarch64::exception_class_is_breakpoint_instruction(esr_el1.EC)) {
         // When breakpoint instruction exception is triggered, the pc is set to the address of the
@@ -96,11 +97,11 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
 
     // Only enable interrupts if they were enabled when the exception happened
     // (spsr_el1.I specifiers an interrupt mask, so it's 0 if interrupts were enabled).
-    if (bit_cast<Aarch64::SPSR_EL1>(trap_frame->regs->spsr_el1).I == 0)
+    if (spsr_el1.I == 0)
         Processor::enable_interrupts();
 
     if (Aarch64::exception_class_is_data_abort(esr_el1.EC) || Aarch64::exception_class_is_instruction_abort(esr_el1.EC)) {
-        auto page_fault_or_error = page_fault_from_exception_syndrome_register(VirtualAddress(fault_address), esr_el1);
+        auto page_fault_or_error = page_fault_from_exception_syndrome_register(VirtualAddress(fault_address), esr_el1, spsr_el1);
         if (page_fault_or_error.is_error()) {
             handle_crash(*trap_frame->regs, "Unknown page fault", SIGSEGV, false);
         } else {

--- a/Kernel/Arch/aarch64/PrivilegedAccessNever.S
+++ b/Kernel/Arch/aarch64/PrivilegedAccessNever.S
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+// Privileged Access Never (PAN) is a feature of ARMv8.1-A.
+// https://developer.arm.com/documentation/ddi0595/2021-03/AArch64-Registers/PAN--Privileged-Access-Never
+// The default compile architecture we use is ARMv8-A, which does not include this extension.
+.arch_extension pan
+
+.global asm_clear_pan
+.type asm_clear_pan, @function
+asm_clear_pan:
+    msr pan, #0
+    ret
+
+.global asm_set_pan
+.type asm_set_pan, @function
+asm_set_pan:
+    msr pan, #1
+    ret
+
+.global asm_is_pan_set
+.type asm_is_pan_set, @function
+asm_is_pan_set:
+    mrs x0, pan
+    ubfx x0, x0, #22, #1
+    ret

--- a/Kernel/Arch/aarch64/PrivilegedAccessNever.h
+++ b/Kernel/Arch/aarch64/PrivilegedAccessNever.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Arch/CPUID.h>
+#include <Kernel/Arch/Processor.h>
+#include <Kernel/Arch/aarch64/ASM_wrapper.h>
+
+namespace Kernel::Aarch64::Asm {
+
+extern "C" void asm_clear_pan();
+extern "C" void asm_set_pan();
+extern "C" bool asm_is_pan_set();
+
+inline void clear_pan()
+{
+    if (!Processor::current().has_feature(CPUFeature::PAN))
+        return;
+    asm_clear_pan();
+}
+
+inline void set_pan()
+{
+    if (!Processor::current().has_feature(CPUFeature::PAN))
+        return;
+    asm_set_pan();
+}
+
+inline bool is_pan_set()
+{
+    if (!Processor::current().has_feature(CPUFeature::PAN))
+        return false;
+    return asm_is_pan_set();
+}
+
+inline void clear_sctlr_el1_span()
+{
+    if (!Processor::current().has_feature(CPUFeature::PAN))
+        return;
+
+    auto sctlr_el1 = SCTLR_EL1::read();
+    sctlr_el1.SPAN = 0;
+    SCTLR_EL1::write(sctlr_el1);
+    instruction_synchronization_barrier();
+}
+
+}

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -15,6 +15,7 @@
 #include <Kernel/Arch/aarch64/ASM_wrapper.h>
 #include <Kernel/Arch/aarch64/CPU.h>
 #include <Kernel/Arch/aarch64/CPUID.h>
+#include <Kernel/Arch/aarch64/PrivilegedAccessNever.h>
 #include <Kernel/Interrupts/InterruptDisabler.h>
 #include <Kernel/Security/Random.h>
 #include <Kernel/Tasks/Process.h>
@@ -67,6 +68,9 @@ void ProcessorBase::initialize(u32)
 
     store_fpu_state(s_clean_fpu_state);
 
+    Aarch64::Asm::clear_sctlr_el1_span();
+    Aarch64::Asm::set_pan();
+
     Aarch64::Asm::load_el1_vector_table(+vector_table_el1);
 
     initialize_interrupts();
@@ -105,6 +109,8 @@ void ProcessorBase::flush_data_cache(VirtualAddress vaddr, size_t byte_count)
 {
     // NOTE: This assumes that all processors have the same cache line size,
     //       as a context switch can happen during execution of this function.
+
+    SmapDisabler disabler;
 
     auto const cache_line_size = Aarch64::Asm::get_cache_line_size();
     for (FlatPtr addr = align_down_to(vaddr.get(), cache_line_size); addr < vaddr.get() + byte_count; addr += cache_line_size)

--- a/Kernel/Arch/aarch64/SmapDisabler.cpp
+++ b/Kernel/Arch/aarch64/SmapDisabler.cpp
@@ -5,17 +5,19 @@
  */
 
 #include <Kernel/Arch/SmapDisabler.h>
+#include <Kernel/Arch/aarch64/PrivilegedAccessNever.h>
 
 namespace Kernel {
-
 SmapDisabler::SmapDisabler()
-    : m_flags(0)
+    : m_flags(Aarch64::Asm::is_pan_set())
 {
-    // FIXME: Implement this using FEAT_PAN.
-    //        Once implemented, make sure to use PageFault::set_was_smap_disabled()
-    //        appropriately in the page fault handler.
+    Aarch64::Asm::clear_pan();
 }
 
-SmapDisabler::~SmapDisabler() = default;
+SmapDisabler::~SmapDisabler()
+{
+    if (m_flags)
+        Aarch64::Asm::set_pan();
+}
 
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -517,6 +517,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
         Arch/aarch64/MainIdRegister.cpp
         Arch/aarch64/PSCI.cpp
         Arch/aarch64/PageDirectory.cpp
+        Arch/aarch64/PrivilegedAccessNever.S
         Arch/aarch64/Processor.cpp
         Arch/aarch64/PowerState.cpp
         Arch/aarch64/SafeMem.cpp

--- a/Kernel/Syscalls/SyscallHandler.cpp
+++ b/Kernel/Syscalls/SyscallHandler.cpp
@@ -107,7 +107,7 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
     // Make sure SMAP protection is enabled on syscall entry.
     clac();
 #elif ARCH(AARCH64)
-    // FIXME: Implement the security mechanism for aarch64
+    // SCTLR_EL1.SPAN == 0 ensures that PAN is set on syscall entry when the CPU has FEAT_PAN
 #elif ARCH(RISCV64)
     RISCV64::CSR::clear_bits<RISCV64::CSR::Address::SSTATUS>(RISCV64::CSR::SSTATUS::Bit::SUM);
 #else


### PR DESCRIPTION
This is the aarch64 version of SMAP, which is alrready supported on x86_64 and RISC-V.

We need to cascade the PAN feature bit from PAN3 and PAN2, in order to
make the runtime checks less expensive.