### PR TITLE
Kernel/Net: Support MSIs in the E1000 driver

### DIFF
--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -89,31 +89,36 @@ PCI::InterruptType Device::get_interrupt_type()
 
 // Reserve `numbers_of_irqs` for this device. Returns the interrupt type
 // that was reserved. It is a noop for pin based interrupts as there
-// is nothing left to do. The second parameter `msi` is used by the
-// driver to indicate its intent to use message signalled interrupts.
-// MSI(x) is preferred over MSI if the device supports both.
-ErrorOr<InterruptType> Device::reserve_irqs(size_t number_of_irqs, bool msi)
+// is nothing left to do.
+ErrorOr<InterruptType> Device::reserve_irqs(size_t number_of_irqs, AllowedInterruptTypes allowed_interrupt_types)
 {
     // Let us not allow partial allocation of IRQs for MSIx.
-    if (msi && is_msix_capable()) {
+    if (has_flag(allowed_interrupt_types, AllowedInterruptTypes::MSIX) && is_msix_capable()) {
         m_interrupt_range.m_start_irq = TRY(reserve_interrupt_handlers(number_of_irqs));
         m_interrupt_range.m_irq_count = number_of_irqs;
         m_interrupt_range.m_type = InterruptType::MSIX;
         // If MSIx is available, disable the pin based interrupts
         disable_pin_based_interrupts();
         enable_extended_message_signalled_interrupts();
-    } else if (msi && is_msi_capable()) {
-        // TODO: Add MME support. Fallback to pin-based until this support is added.
-        if (number_of_irqs > 1)
-            return m_interrupt_range.m_type;
+        return m_interrupt_range.m_type;
+    }
 
+    if (has_flag(allowed_interrupt_types, AllowedInterruptTypes::MSI) && is_msi_capable()
+        && number_of_irqs == 1 // TODO: Add MME support. Fallback to pin-based until this support is added.
+    ) {
         m_interrupt_range.m_start_irq = TRY(reserve_interrupt_handlers(number_of_irqs));
         m_interrupt_range.m_irq_count = number_of_irqs;
         m_interrupt_range.m_type = InterruptType::MSI;
         disable_pin_based_interrupts();
         enable_message_signalled_interrupts();
+        return m_interrupt_range.m_type;
     }
-    return m_interrupt_range.m_type;
+
+    if (has_flag(allowed_interrupt_types, AllowedInterruptTypes::Pin)) {
+        return m_interrupt_range.m_type;
+    }
+
+    return ENOTSUP;
 }
 
 PhysicalAddress Device::msix_table_entry_address(InterruptNumber irq)

--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -21,6 +21,15 @@ enum class InterruptType {
     MSIX
 };
 
+enum class AllowedInterruptTypes {
+    Pin = 1u << 0,
+    MSI = 1u << 1,
+    MSIX = 1u << 2,
+
+    PinAndMSIAndMSIX = Pin | MSI | MSIX,
+};
+AK_ENUM_BITWISE_OPERATORS(AllowedInterruptTypes);
+
 struct InterruptRange {
     InterruptNumber m_start_irq { 0 };
     InterruptNumber m_irq_count { 0 };
@@ -53,7 +62,7 @@ public:
 
     void enable_extended_message_signalled_interrupts();
     void disable_extended_message_signalled_interrupts();
-    ErrorOr<InterruptType> reserve_irqs(size_t number_of_irqs, bool msi);
+    ErrorOr<InterruptType> reserve_irqs(size_t number_of_irqs, AllowedInterruptTypes);
     ErrorOr<InterruptNumber> allocate_irq(size_t index);
     PCI::InterruptType get_interrupt_type();
     void enable_interrupt(InterruptNumber irq);

--- a/Kernel/Bus/USB/xHCI/PCIxHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/PCIxHCIController.cpp
@@ -23,7 +23,7 @@ ErrorOr<NonnullLockRefPtr<PCIxHCIController>> PCIxHCIController::try_to_initiali
     auto registers_mapping = TRY(PCI::map_bar<u8>(pci_device_identifier, PCI::HeaderType0BaseRegister::BAR0));
     auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) PCIxHCIController(pci_device_identifier, move(registers_mapping))));
 
-    auto interrupt_type = TRY(controller->reserve_irqs(1, true)); // TODO: Support more than one interrupter using MSI/MSI-X
+    auto interrupt_type = TRY(controller->reserve_irqs(1, PCI::AllowedInterruptTypes::PinAndMSIAndMSIX)); // TODO: Support more than one interrupter using MSI/MSI-X
     controller->m_using_message_signalled_interrupts = interrupt_type != PCI::InterruptType::PIN;
 
     TRY(controller->initialize());

--- a/Kernel/Bus/VirtIO/Transport/PCIe/TransportLink.cpp
+++ b/Kernel/Bus/VirtIO/Transport/PCIe/TransportLink.cpp
@@ -62,7 +62,7 @@ StringView PCIeTransportLink::determine_device_class_name() const
 
 ErrorOr<void> PCIeTransportLink::create_interrupt_handler(VirtIO::Device& parent_device)
 {
-    TRY(reserve_irqs(1, false));
+    TRY(reserve_irqs(1, PCI::AllowedInterruptTypes::Pin));
     auto irq = MUST(allocate_irq(0));
     m_irq_handler = TRY(PCIeTransportInterruptHandler::create(*this, parent_device, irq));
     return {};

--- a/Kernel/Devices/Storage/AHCI/Controller.cpp
+++ b/Kernel/Devices/Storage/AHCI/Controller.cpp
@@ -166,7 +166,7 @@ UNMAP_AFTER_INIT ErrorOr<void> AHCIController::initialize_hba(PCI::DeviceIdentif
 
     hba().control_regs.ghc = 0x80000000; // Ensure that HBA knows we are AHCI aware.
     PCI::enable_bus_mastering(device_identifier());
-    TRY(reserve_irqs(1, true));
+    TRY(reserve_irqs(1, PCI::AllowedInterruptTypes::PinAndMSIAndMSIX));
     auto irq = MUST(allocate_irq(0));
     enable_global_interrupts();
 

--- a/Kernel/Devices/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeController.cpp
@@ -57,7 +57,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::initialize(bool is_queue_polled)
     calculate_doorbell_stride();
     if (queue_type == QueueType::IRQ) {
         // IO queues + 1 admin queue
-        m_irq_type = TRY(reserve_irqs(nr_of_queues + 1, true));
+        m_irq_type = TRY(reserve_irqs(nr_of_queues + 1, PCI::AllowedInterruptTypes::PinAndMSIAndMSIX));
     }
 
     TRY(create_admin_queue(queue_type));

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
@@ -214,7 +214,6 @@ UNMAP_AFTER_INIT ErrorOr<bool> E1000ENetworkAdapter::probe(PCI::DeviceIdentifier
 
 UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NetworkAdapter>> E1000ENetworkAdapter::create(PCI::DeviceIdentifier const& pci_device_identifier)
 {
-    InterruptNumber irq = pci_device_identifier.interrupt_line().value();
     auto interface_name = TRY(NetworkingManagement::generate_interface_name_from_pci_address(pci_device_identifier));
     auto registers_io_window = TRY(IOWindow::create_for_pci_device_bar(pci_device_identifier, PCI::HeaderType0BaseRegister::BAR0));
 
@@ -225,7 +224,7 @@ UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NetworkAdapter>> E1000ENetworkAdapter::cr
 
     return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) E1000ENetworkAdapter(interface_name.representable_view(),
         pci_device_identifier,
-        irq, move(registers_io_window),
+        move(registers_io_window),
         move(rx_buffer_region),
         move(tx_buffer_region),
         move(rx_descriptors_region),
@@ -238,7 +237,6 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<Networking
     enable_bus_mastering(device_identifier());
 
     dmesgln("E1000e: IO base: {}", m_registers_io_window);
-    dmesgln("E1000e: Interrupt line: {}", interrupt_number());
     detect_eeprom();
     dmesgln("E1000e: Has EEPROM? {}", m_has_eeprom.was_set());
     read_mac_address();
@@ -251,17 +249,17 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<Networking
     initialize_tx_descriptors();
 
     setup_link();
-    setup_interrupts();
+    TRY(setup_interrupts());
     autoconfigure_link_local_ipv6();
     return {};
 }
 
 UNMAP_AFTER_INIT E1000ENetworkAdapter::E1000ENetworkAdapter(StringView interface_name,
-    PCI::DeviceIdentifier const& device_identifier, InterruptNumber irq,
+    PCI::DeviceIdentifier const& device_identifier,
     NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
     NonnullOwnPtr<Memory::Region> tx_buffer_region, Memory::TypedMapping<RxDescriptor volatile[]> rx_descriptors,
     Memory::TypedMapping<TxDescriptor volatile[]> tx_descriptors)
-    : E1000NetworkAdapter(interface_name, device_identifier, irq, move(registers_io_window),
+    : E1000NetworkAdapter(interface_name, device_identifier, move(registers_io_window),
           move(rx_buffer_region),
           move(tx_buffer_region),
           move(rx_descriptors),

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.h
@@ -28,8 +28,6 @@ public:
 
     virtual ~E1000ENetworkAdapter() override;
 
-    virtual StringView purpose() const override { return class_name(); }
-
 protected:
     // ^MDIO::Clause22::Interface
     virtual void on_phy_link_status_change(MDIO::LinkStatus) override;
@@ -37,7 +35,7 @@ protected:
     virtual void write_phy_register(u8 phy_id, MDIO::Clause22::RegisterAddress address, u16 value) override;
 
 private:
-    E1000ENetworkAdapter(StringView interface_name, PCI::DeviceIdentifier const&, InterruptNumber irq,
+    E1000ENetworkAdapter(StringView interface_name, PCI::DeviceIdentifier const&,
         NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
         NonnullOwnPtr<Memory::Region> tx_buffer_region, Memory::TypedMapping<RxDescriptor volatile[]> rx_descriptors,
         Memory::TypedMapping<TxDescriptor volatile[]> tx_descriptors);

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -168,7 +168,6 @@ UNMAP_AFTER_INIT ErrorOr<bool> E1000NetworkAdapter::probe(PCI::DeviceIdentifier 
 
 UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NetworkAdapter>> E1000NetworkAdapter::create(PCI::DeviceIdentifier const& pci_device_identifier)
 {
-    InterruptNumber irq = pci_device_identifier.interrupt_line().value();
     auto interface_name = TRY(NetworkingManagement::generate_interface_name_from_pci_address(pci_device_identifier));
     auto registers_io_window = TRY(IOWindow::create_for_pci_device_bar(pci_device_identifier, PCI::HeaderType0BaseRegister::BAR0));
 
@@ -180,7 +179,7 @@ UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NetworkAdapter>> E1000NetworkAdapter::cre
 
     return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) E1000NetworkAdapter(interface_name.representable_view(),
         pci_device_identifier,
-        irq, move(registers_io_window),
+        move(registers_io_window),
         move(rx_buffer_region),
         move(tx_buffer_region),
         move(rx_descriptors),
@@ -194,7 +193,6 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::initialize(Badge<NetworkingM
     enable_bus_mastering(device_identifier());
 
     dmesgln_pci(*this, "IO base: {}", m_registers_io_window);
-    dmesgln_pci(*this, "Interrupt line: {}", interrupt_number());
     detect_eeprom();
     dmesgln_pci(*this, "Has EEPROM? {}", m_has_eeprom.was_set());
     read_mac_address();
@@ -205,7 +203,7 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::initialize(Badge<NetworkingM
     initialize_tx_descriptors();
 
     setup_link();
-    setup_interrupts();
+    TRY(setup_interrupts());
 
     m_link_up = ((in32(REG_STATUS) & STATUS_LU) != 0);
     autoconfigure_link_local_ipv6();
@@ -219,22 +217,24 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::setup_link()
     out32(REG_CTRL, flags | ECTRL_SLU);
 }
 
-UNMAP_AFTER_INIT void E1000NetworkAdapter::setup_interrupts()
+UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::setup_interrupts()
 {
     out32(REG_INTERRUPT_RATE, 6000); // Interrupt rate of 1.536 milliseconds
     out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0 | INTERRUPT_RXO);
     in32(REG_INTERRUPT_CAUSE_READ);
-    enable_irq();
+
+    m_interrupt_handler = TRY(InterruptHandler::create(*this, device_identifier().interrupt_line().value()));
+
+    return {};
 }
 
 UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(StringView interface_name,
-    PCI::DeviceIdentifier const& device_identifier, InterruptNumber irq,
+    PCI::DeviceIdentifier const& device_identifier,
     NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
     NonnullOwnPtr<Memory::Region> tx_buffer_region, Memory::TypedMapping<RxDescriptor volatile[]> rx_descriptors,
     Memory::TypedMapping<TxDescriptor volatile[]> tx_descriptors)
     : NetworkAdapter(interface_name)
     , PCI::Device(device_identifier)
-    , IRQHandler(irq)
     , m_registers_io_window(move(registers_io_window))
     , m_rx_descriptors(move(rx_descriptors))
     , m_tx_descriptors(move(tx_descriptors))
@@ -245,7 +245,7 @@ UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(StringView interface_n
 
 UNMAP_AFTER_INIT E1000NetworkAdapter::~E1000NetworkAdapter() = default;
 
-bool E1000NetworkAdapter::handle_irq()
+bool E1000NetworkAdapter::handle_interrupt()
 {
     u32 status = in32(REG_INTERRUPT_CAUSE_READ);
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -223,7 +223,13 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::setup_interrupts()
     out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0 | INTERRUPT_RXO);
     in32(REG_INTERRUPT_CAUSE_READ);
 
-    m_interrupt_handler = TRY(InterruptHandler::create(*this, device_identifier().interrupt_line().value()));
+    // FIXME: Support MSI-X on newer controllers. This requires allocating one or more MSI-X vectors
+    //        and using the IVAR register to configure interrupt vector routing.
+    TRY(reserve_irqs(1, PCI::AllowedInterruptTypes::Pin | PCI::AllowedInterruptTypes::MSI));
+
+    auto interrupt_number = TRY(allocate_irq(0));
+
+    m_interrupt_handler = TRY(InterruptHandler::create(*this, interrupt_number));
 
     return {};
 }

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -19,8 +19,7 @@
 namespace Kernel {
 
 class E1000NetworkAdapter : public NetworkAdapter
-    , public PCI::Device
-    , public IRQHandler {
+    , public PCI::Device {
 public:
     static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
     static ErrorOr<NonnullRefPtr<NetworkAdapter>> create(PCI::DeviceIdentifier const&);
@@ -33,7 +32,6 @@ public:
     virtual i32 link_speed() override;
     virtual bool link_full_duplex() override;
 
-    virtual StringView purpose() const override { return class_name(); }
     virtual StringView device_name() const override { return "E1000"sv; }
     virtual Type adapter_type() const override { return Type::Ethernet; }
 
@@ -62,16 +60,43 @@ protected:
     };
     static_assert(AssertSize<TxDescriptor, 16>());
 
-    void setup_interrupts();
+    ErrorOr<void> setup_interrupts();
     void setup_link();
 
-    E1000NetworkAdapter(StringView, PCI::DeviceIdentifier const&, InterruptNumber irq,
+    E1000NetworkAdapter(StringView, PCI::DeviceIdentifier const&,
         NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
         NonnullOwnPtr<Memory::Region> tx_buffer_region,
         Memory::TypedMapping<RxDescriptor volatile[]> rx_descriptors,
         Memory::TypedMapping<TxDescriptor volatile[]> tx_descriptors);
 
-    virtual bool handle_irq() override;
+    bool handle_interrupt();
+
+    class InterruptHandler final : public IRQHandler {
+    public:
+        static ErrorOr<NonnullOwnPtr<InterruptHandler>> create(E1000NetworkAdapter& network_adapter, InterruptNumber interrupt_number)
+        {
+            auto interrupt_handler = TRY(adopt_nonnull_own_or_enomem(new (nothrow) InterruptHandler(network_adapter, interrupt_number)));
+            dmesgln_pci(network_adapter, "Interrupt number: {}", interrupt_number);
+            interrupt_handler->enable_irq();
+            return interrupt_handler;
+        }
+
+    private:
+        InterruptHandler(E1000NetworkAdapter& network_adapter, InterruptNumber interrupt_number)
+            : IRQHandler(interrupt_number)
+            , m_network_adapter(network_adapter)
+        {
+        }
+
+        virtual StringView purpose() const override { return "E1000 Interrupt Handler"sv; }
+        virtual bool handle_irq() override
+        {
+            return m_network_adapter.handle_interrupt();
+        }
+
+        E1000NetworkAdapter& m_network_adapter;
+    };
+
     virtual StringView class_name() const override { return "E1000NetworkAdapter"sv; }
 
     virtual void detect_eeprom();
@@ -105,5 +130,7 @@ protected:
 
     Mutex m_write_lock;
     WaitQueue m_wait_queue;
+
+    OwnPtr<InterruptHandler> m_interrupt_handler;
 };
 }

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -10,7 +10,7 @@
 #include <AK/SetOnce.h>
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/Device.h>
-#include <Kernel/Interrupts/IRQHandler.h>
+#include <Kernel/Interrupts/PCIIRQHandler.h>
 #include <Kernel/Library/IOWindow.h>
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/Security/Random.h>
@@ -71,7 +71,7 @@ protected:
 
     bool handle_interrupt();
 
-    class InterruptHandler final : public IRQHandler {
+    class InterruptHandler final : public PCI::IRQHandler {
     public:
         static ErrorOr<NonnullOwnPtr<InterruptHandler>> create(E1000NetworkAdapter& network_adapter, InterruptNumber interrupt_number)
         {
@@ -83,7 +83,7 @@ protected:
 
     private:
         InterruptHandler(E1000NetworkAdapter& network_adapter, InterruptNumber interrupt_number)
-            : IRQHandler(interrupt_number)
+            : PCI::IRQHandler(network_adapter, interrupt_number)
             , m_network_adapter(network_adapter)
         {
         }


### PR DESCRIPTION
This can be tested using the "e1000e" QEMU device. The "e1000" device doesn't have the MSI capability.

<img width="616" height="433" alt="Screenshot_20260717_013716" src="https://github.com/user-attachments/assets/16b5a328-03a3-477d-8919-c4bf37dda34a" />
