### PR TITLE
Kernel/Net: Add support for the Intel I211 Ethernet Controller

### DIFF
--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -110,7 +110,6 @@ ErrorOr<InterruptType> Device::reserve_irqs(size_t number_of_irqs, AllowedInterr
         m_interrupt_range.m_irq_count = number_of_irqs;
         m_interrupt_range.m_type = InterruptType::MSI;
         disable_pin_based_interrupts();
-        enable_message_signalled_interrupts();
         return m_interrupt_range.m_type;
     }
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -247,7 +247,6 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::setup_interrupts()
 {
     out32(REG_INTERRUPT_RATE, 6000); // Interrupt rate of 1.536 milliseconds
     out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0 | INTERRUPT_RXO);
-    in32(REG_INTERRUPT_CAUSE_READ);
 
     // FIXME: Support MSI-X on newer controllers. This requires allocating one or more MSI-X vectors
     //        and using the IVAR register to configure interrupt vector routing.

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -36,7 +36,8 @@ namespace Kernel {
 #define REG_TXDESCHEAD 0x3810
 #define REG_TXDESCTAIL 0x3818
 #define REG_RDTR 0x2820             // RX Delay Timer Register
-#define REG_RXDCTL 0x3828           // RX Descriptor Control
+#define REG_RXDCTL 0x2828           // RX Descriptor Control
+#define REG_TXDCTL 0x3828           // TX Descriptor Control
 #define REG_RADV 0x282C             // RX Int. Absolute Delay Timer
 #define REG_RSRPD 0x2C00            // RX Small Packet Detect Interrupt
 #define REG_TIPG 0x0410             // Transmit Inter Packet Gap
@@ -136,6 +137,14 @@ namespace Kernel {
 
 #define GIGABIT_PHY_ID 1
 
+// RXDCTL Register
+
+#define RXDCTL_ENABLE (1u << 25)
+
+// TXDCTL Register
+
+#define TXDCTL_ENABLE (1u << 25)
+
 // https://www.intel.com/content/dam/doc/manual/pci-pci-x-family-gbe-controllers-software-dev-manual.pdf Section 5.2
 UNMAP_AFTER_INIT static bool is_valid_device_id(u16 device_id)
 {
@@ -166,6 +175,7 @@ UNMAP_AFTER_INIT static bool is_valid_device_id(u16 device_id)
     case 0x100E: // 82540EM-A
     case 0x1015: // 82540EM-A
     case 0x10D3: // 82574L
+    case 0x1539: // I211
         return true;
     default:
         return false;
@@ -214,8 +224,12 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::initialize(Badge<NetworkingM
     auto const& mac = mac_address();
     dmesgln_pci(*this, "MAC address: {}", mac.to_string());
 
-    if (has_flag(m_hardware_features, HardwareFeatures::MDIOAccess))
-        m_mdio_handling_process = TRY(spawn_mdio_handling_task(GIGABIT_PHY_ID));
+    if (has_flag(m_hardware_features, HardwareFeatures::MDIOAccess)) {
+        if (has_flag(m_hardware_features, HardwareFeatures::HasPreconfiguredPHYAddress))
+            m_mdio_handling_process = TRY(spawn_mdio_handling_task(0)); // This PHY ID will be ignored.
+        else
+            m_mdio_handling_process = TRY(spawn_mdio_handling_task(GIGABIT_PHY_ID));
+    }
 
     initialize_rx_descriptors();
     initialize_tx_descriptors();
@@ -239,10 +253,13 @@ E1000NetworkAdapter::HardwareFeatures E1000NetworkAdapter::determine_hardware_fe
 {
     auto device_id = device_identifier().hardware_id().device_id;
     switch (device_id) {
+        using enum HardwareFeatures;
     case 0x10D3: // 82574L
-        return HardwareFeatures::MDIOAccess;
+        return MDIOAccess;
+    case 0x1539: // I211
+        return MDIOAccess | HasQueueEnableBit | HasPreconfiguredPHYAddress;
     default:
-        return HardwareFeatures::None;
+        return None;
     }
 }
 
@@ -317,9 +334,10 @@ u16 E1000NetworkAdapter::read_phy_register(u8 phy_id, MDIO::Clause22::RegisterAd
 {
     VERIFY(has_flag(m_hardware_features, HardwareFeatures::MDIOAccess));
 
-    // FIXME: Newer controllers (like the I211) don't have a PHYADD field in the MDIC register.
-    //        They instead have it in a separate register.
-    out32(REG_MDIC, MDIC_OP_READ | (to_underlying(address) << MDIC_REGADD_OFFSET) | (phy_id << MDIC_PHYADD_OFFSET));
+    u32 mdic = MDIC_OP_READ | (to_underlying(address) << MDIC_REGADD_OFFSET);
+    if (!has_flag(m_hardware_features, HardwareFeatures::HasPreconfiguredPHYAddress))
+        mdic |= phy_id << MDIC_PHYADD_OFFSET;
+    out32(REG_MDIC, mdic);
 
     for (;;) {
         u32 mdic = in32(REG_MDIC);
@@ -336,9 +354,10 @@ void E1000NetworkAdapter::write_phy_register(u8 phy_id, MDIO::Clause22::Register
 {
     VERIFY(has_flag(m_hardware_features, HardwareFeatures::MDIOAccess));
 
-    // FIXME: Newer controllers (like the I211) don't have a PHYADD field in the MDIC register.
-    //        They instead have it in a separate register.
-    out32(REG_MDIC, MDIC_OP_WRITE | (to_underlying(address) << MDIC_REGADD_OFFSET) | (value << MDIC_DATA_OFFSET) | (phy_id << MDIC_PHYADD_OFFSET));
+    u32 mdic = MDIC_OP_WRITE | (to_underlying(address) << MDIC_REGADD_OFFSET) | (value << MDIC_DATA_OFFSET);
+    if (!has_flag(m_hardware_features, HardwareFeatures::HasPreconfiguredPHYAddress))
+        mdic |= phy_id << MDIC_PHYADD_OFFSET;
+    out32(REG_MDIC, mdic);
 
     while ((in32(REG_MDIC) & MDIC_R) == 0)
         Processor::wait_check();
@@ -375,6 +394,10 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_rx_descriptors()
     out32(REG_RXDESCHI, 0);
     out32(REG_RXDESCLEN, number_of_rx_descriptors * sizeof(RxDescriptor));
     out32(REG_RXDESCHEAD, 0);
+
+    if (has_flag(m_hardware_features, HardwareFeatures::HasQueueEnableBit))
+        out32(REG_RXDCTL, in32(REG_RXDCTL) | RXDCTL_ENABLE);
+
     out32(REG_RXDESCTAIL, number_of_rx_descriptors - 1);
 
     VERIFY(rx_buffer_size >= mtu() + sizeof(EthernetFrameHeader) + 4); // + 4 for the CRC
@@ -406,6 +429,9 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_tx_descriptors()
     out32(REG_TXDESCLEN, number_of_tx_descriptors * sizeof(TxDescriptor));
     out32(REG_TXDESCHEAD, 0);
     out32(REG_TXDESCTAIL, 0);
+
+    if (has_flag(m_hardware_features, HardwareFeatures::HasQueueEnableBit))
+        out32(REG_TXDCTL, in32(REG_TXDCTL) | TXDCTL_ENABLE);
 
     out32(REG_TCTRL, in32(REG_TCTRL) | TCTL_EN | TCTL_PSP);
     out32(REG_TIPG, 0x0060200A);

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -203,7 +203,7 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::initialize(Badge<NetworkingM
 {
     dmesgln_pci(*this, "Found @ {}", device_identifier().address());
 
-    enable_bus_mastering(device_identifier());
+    PCI::enable_bus_mastering(device_identifier());
 
     dmesgln_pci(*this, "IO base: {}", m_registers_io_window);
     read_mac_address();

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -203,6 +203,7 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::initialize(Badge<NetworkingM
 {
     dmesgln_pci(*this, "Found @ {}", device_identifier().address());
 
+    PCI::enable_memory_space(device_identifier());
     PCI::enable_bus_mastering(device_identifier());
 
     dmesgln_pci(*this, "IO base: {}", m_registers_io_window);

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -356,11 +356,14 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::read_mac_address()
 
 UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_rx_descriptors()
 {
-    constexpr auto rx_buffer_page_count = rx_buffer_size / PAGE_SIZE;
     for (size_t i = 0; i < number_of_rx_descriptors; ++i) {
+        auto offset = rx_buffer_size * i;
+        auto page_index = offset / PAGE_SIZE;
+        auto page_offset = offset % PAGE_SIZE;
+
         auto& descriptor = m_rx_descriptors[i];
-        m_rx_buffers[i] = m_rx_buffer_region->vaddr().as_ptr() + rx_buffer_size * i;
-        descriptor.addr = m_rx_buffer_region->physical_page(rx_buffer_page_count * i)->paddr().get();
+        m_rx_buffers[i] = m_rx_buffer_region->vaddr().as_ptr() + offset;
+        descriptor.addr = m_rx_buffer_region->physical_page(page_index)->paddr().offset(page_offset).get();
         descriptor.status = 0;
     }
 
@@ -375,12 +378,14 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_rx_descriptors()
 
 UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_tx_descriptors()
 {
-    constexpr auto tx_buffer_page_count = tx_buffer_size / PAGE_SIZE;
-
     for (size_t i = 0; i < number_of_tx_descriptors; ++i) {
+        auto offset = tx_buffer_size * i;
+        auto page_index = offset / PAGE_SIZE;
+        auto page_offset = offset % PAGE_SIZE;
+
         auto& descriptor = m_tx_descriptors[i];
-        m_tx_buffers[i] = m_tx_buffer_region->vaddr().as_ptr() + tx_buffer_size * i;
-        descriptor.addr = m_tx_buffer_region->physical_page(tx_buffer_page_count * i)->paddr().get();
+        m_tx_buffers[i] = m_tx_buffer_region->vaddr().as_ptr() + offset;
+        descriptor.addr = m_tx_buffer_region->physical_page(page_index)->paddr().offset(page_offset).get();
         descriptor.cmd = 0;
         descriptor.status = TSTA_DD;
     }

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -206,6 +206,9 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::initialize(Badge<NetworkingM
     PCI::enable_memory_space(device_identifier());
     PCI::enable_bus_mastering(device_identifier());
 
+    // Ensure that interrupts are disabled during initialization.
+    out32(REG_INTERRUPT_MASK_CLEAR, 0xffff'ffff);
+
     dmesgln_pci(*this, "IO base: {}", m_registers_io_window);
     read_mac_address();
     auto const& mac = mac_address();
@@ -246,7 +249,6 @@ E1000NetworkAdapter::HardwareFeatures E1000NetworkAdapter::determine_hardware_fe
 UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::setup_interrupts()
 {
     out32(REG_INTERRUPT_RATE, 6000); // Interrupt rate of 1.536 milliseconds
-    out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0 | INTERRUPT_RXO);
 
     // FIXME: Support MSI-X on newer controllers. This requires allocating one or more MSI-X vectors
     //        and using the IVAR register to configure interrupt vector routing.
@@ -255,6 +257,8 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::setup_interrupts()
     auto interrupt_number = TRY(allocate_irq(0));
 
     m_interrupt_handler = TRY(InterruptHandler::create(*this, interrupt_number));
+
+    out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0 | INTERRUPT_RXO);
 
     return {};
 }

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -66,13 +66,13 @@ namespace Kernel {
 #define RCTL_SECRC (1 << 26)        // Strip Ethernet CRC
 
 // Buffer Sizes
+// Sizes larger than 2048 are requested differently across hardware revisions.
+// The I211 has a separate field BSIZEPACKET in the SRRCTL register, whereas older controllers have a BSEX field
+// in the RCTL register to multiply the BSIZE by 16.
 #define RCTL_BSIZE_256 (3 << 16)
 #define RCTL_BSIZE_512 (2 << 16)
 #define RCTL_BSIZE_1024 (1 << 16)
 #define RCTL_BSIZE_2048 (0 << 16)
-#define RCTL_BSIZE_4096 ((3 << 16) | (1 << 25))
-#define RCTL_BSIZE_8192 ((2 << 16) | (1 << 25))
-#define RCTL_BSIZE_16384 ((1 << 16) | (1 << 25))
 
 // Transmit Command
 
@@ -373,11 +373,18 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_rx_descriptors()
     out32(REG_RXDESCHEAD, 0);
     out32(REG_RXDESCTAIL, number_of_rx_descriptors - 1);
 
-    out32(REG_RCTRL, RCTL_EN | RCTL_SBP | RCTL_UPE | RCTL_MPE | RCTL_LBM_NONE | RTCL_RDMTS_HALF | RCTL_BAM | RCTL_SECRC | RCTL_BSIZE_8192);
+    VERIFY(rx_buffer_size >= mtu() + sizeof(EthernetFrameHeader) + 4); // + 4 for the CRC
+
+    VERIFY(rx_buffer_size == 2048);
+    auto bsize_field = RCTL_BSIZE_2048;
+
+    out32(REG_RCTRL, RCTL_EN | RCTL_SBP | RCTL_UPE | RCTL_MPE | RCTL_LBM_NONE | RTCL_RDMTS_HALF | RCTL_BAM | RCTL_SECRC | bsize_field);
 }
 
 UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_tx_descriptors()
 {
+    VERIFY(tx_buffer_size >= mtu() + sizeof(EthernetFrameHeader) + 4); // + 4 for the CRC
+
     for (size_t i = 0; i < number_of_tx_descriptors; ++i) {
         auto offset = tx_buffer_size * i;
         auto page_index = offset / PAGE_SIZE;
@@ -429,7 +436,7 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
             .release_value_but_fixme_should_propagate_errors();
     }
 
-    VERIFY(payload.size() <= 8192);
+    VERIFY(payload.size() <= tx_buffer_size);
     auto* vptr = (void*)m_tx_buffers[tx_current];
     memcpy(vptr, payload.data(), payload.size());
     descriptor.length = payload.size();
@@ -452,7 +459,7 @@ void E1000NetworkAdapter::receive()
             break;
         auto* buffer = m_rx_buffers[rx_current];
         u16 length = m_rx_descriptors[rx_current].length;
-        VERIFY(length <= 8192);
+        VERIFY(length <= rx_buffer_size);
         dbgln_if(E1000_DEBUG, "E1000: Received 1 packet @ {:p} ({} bytes)", buffer, length);
         did_receive({ buffer, length });
         m_rx_descriptors[rx_current].status = 0;

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -40,8 +40,8 @@ public:
     virtual Type adapter_type() const override { return Type::Ethernet; }
 
 private:
-    static constexpr size_t rx_buffer_size = 8192;
-    static constexpr size_t tx_buffer_size = 8192;
+    static constexpr size_t rx_buffer_size = 2048;
+    static constexpr size_t tx_buffer_size = 2048;
 
     struct RxDescriptor {
         uint64_t addr { 0 };

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -68,6 +68,8 @@ private:
         None = 0u,
 
         MDIOAccess = 1u << 0,
+        HasQueueEnableBit = 1u << 1,
+        HasPreconfiguredPHYAddress = 1u << 2,
     };
     AK_ENUM_BITWISE_FRIEND_OPERATORS(E1000NetworkAdapter::HardwareFeatures);
 

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
@@ -345,7 +345,7 @@ UNMAP_AFTER_INIT ErrorOr<void> RTL8168NetworkAdapter::initialize(Badge<Networkin
     // software reset
     reset();
 
-    enable_bus_mastering(device_identifier());
+    PCI::enable_bus_mastering(device_identifier());
 
     read_mac_address();
     dmesgln_pci(*this, "MAC address: {}", mac_address().to_string());


### PR DESCRIPTION
This makes Ethernet work on my (bare metal) PC! This might be the first time that the E1000 driver works on real hardware.

See individual commits for details.