### PR TITLE
Kernel: Make the Intel HDA driver work on my PC

### DIFF
--- a/Kernel/Devices/Audio/IntelHDA/Controller.cpp
+++ b/Kernel/Devices/Audio/IntelHDA/Controller.cpp
@@ -41,14 +41,17 @@ UNMAP_AFTER_INIT ErrorOr<void> Controller::initialize(Badge<AudioManagement>)
     PCI::enable_memory_space(device_identifier());
     PCI::enable_bus_mastering(device_identifier());
 
+    auto interrupt_type = TRY(reserve_irqs(1, PCI::AllowedInterruptTypes::Pin | PCI::AllowedInterruptTypes::MSI));
+
     // 255 means "unknown" or "no connection".
     // FIXME: This not the best place to catch this. We should probably make interrupt_line() return an Optional<>.
     //        Or even better, support getting PCI interrupt lines from AML code, which would remove the
     //        need for us to rely on the firmware setting the correct interrupt line in PCI config space.
-    if (device_identifier().interrupt_line().value() == 255)
+    if (interrupt_type == PCI::InterruptType::PIN && device_identifier().interrupt_line().value() == 255)
         return ENOTSUP;
 
-    m_interrupt_handler = TRY(InterruptHandler::create(*this));
+    auto interrupt_number = TRY(allocate_irq(0));
+    m_interrupt_handler = TRY(InterruptHandler::create(*this, interrupt_number));
 
     // 3.3.3, 3.3.4: Controller version
     auto version_minor = m_controller_io_window->read8(ControllerRegister::VersionMinor);

--- a/Kernel/Devices/Audio/IntelHDA/Controller.cpp
+++ b/Kernel/Devices/Audio/IntelHDA/Controller.cpp
@@ -37,7 +37,8 @@ UNMAP_AFTER_INIT Controller::Controller(PCI::DeviceIdentifier const& pci_device_
 
 UNMAP_AFTER_INIT ErrorOr<void> Controller::initialize(Badge<AudioManagement>)
 {
-    // Enable DMA and interrupts
+    // Enable MMIO, DMA and interrupts
+    PCI::enable_memory_space(device_identifier());
     PCI::enable_bus_mastering(device_identifier());
 
     // 255 means "unknown" or "no connection".

--- a/Kernel/Devices/Audio/IntelHDA/InterruptHandler.cpp
+++ b/Kernel/Devices/Audio/IntelHDA/InterruptHandler.cpp
@@ -9,8 +9,8 @@
 
 namespace Kernel::Audio::IntelHDA {
 
-InterruptHandler::InterruptHandler(Controller& controller)
-    : PCI::IRQHandler(controller, controller.device_identifier().interrupt_line().value())
+InterruptHandler::InterruptHandler(Controller& controller, InterruptNumber interrupt_number)
+    : PCI::IRQHandler(controller, interrupt_number)
     , m_controller(controller)
 {
     enable_irq();

--- a/Kernel/Devices/Audio/IntelHDA/InterruptHandler.h
+++ b/Kernel/Devices/Audio/IntelHDA/InterruptHandler.h
@@ -17,16 +17,16 @@ class InterruptHandler
     : public PCI::IRQHandler
     , public RefCounted<InterruptHandler> {
 public:
-    static ErrorOr<NonnullRefPtr<InterruptHandler>> create(Controller& controller)
+    static ErrorOr<NonnullRefPtr<InterruptHandler>> create(Controller& controller, InterruptNumber interrupt_number)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) InterruptHandler(controller));
+        return adopt_nonnull_ref_or_enomem(new (nothrow) InterruptHandler(controller, interrupt_number));
     }
 
     // ^PCI::IRQHandler
     virtual StringView purpose() const override { return "IntelHDA IRQ Handler"sv; }
 
 private:
-    InterruptHandler(Controller& controller);
+    InterruptHandler(Controller& controller, InterruptNumber interrupt_number);
 
     // ^PCI::IRQHandler
     virtual bool handle_irq() override;


### PR DESCRIPTION
Similar to the E1000 driver (#26871 and #26874), this required setting the memory space enable bit in the PCI COMMAND register and adding support for Message Signaled Interrupts.
PCI pin interrupts don't seem to work in serenity on my PC at the moment.

Intel HDA MSIs also work in QEMU:
<img width="609" height="425" alt="image" src="https://github.com/user-attachments/assets/1cd733ab-db8f-4fc8-9780-68744db10380" />

