### PR TITLE
Kernel: Store InodeWatcher inode member as LockWeakPtr

### DIFF
--- a/Kernel/FileSystem/InodeWatcher.cpp
+++ b/Kernel/FileSystem/InodeWatcher.cpp
@@ -71,8 +71,8 @@ ErrorOr<void> InodeWatcher::close()
 {
     m_watch_maps.with([this](auto& watch_maps) {
         for (auto& entry : watch_maps.wd_to_watches) {
-            auto& inode = entry.value->inode;
-            inode.unregister_watcher({}, *this);
+            if (auto inode = entry.value->inode.strong_ref())
+                inode->unregister_watcher({}, *this);
         }
 
         watch_maps.inode_to_watches.clear();
@@ -99,7 +99,7 @@ void InodeWatcher::notify_inode_event(Badge<Inode>, InodeIdentifier inode_id, In
         if (!(watcher.event_mask & static_cast<unsigned>(event_type)))
             return;
 
-        m_queue.with([watcher, event_type, name](auto& queue) {
+        m_queue.with([&watcher, event_type, name](auto& queue) {
             OwnPtr<KString> path;
             if (!name.is_null())
                 path = KString::try_create(name).release_value_but_fixme_should_propagate_errors();
@@ -152,10 +152,10 @@ ErrorOr<void> InodeWatcher::unregister_by_wd(int wd)
         if (it == watch_maps.wd_to_watches.end())
             return ENOENT;
 
-        auto& inode = it->value->inode;
-        inode.unregister_watcher({}, *this);
+        if (auto inode = it->value->inode.strong_ref())
+            inode->unregister_watcher({}, *this);
 
-        watch_maps.inode_to_watches.remove(inode.identifier());
+        watch_maps.inode_to_watches.remove(it->value->inode_identifier);
         watch_maps.wd_to_watches.remove(it);
         return {};
     }));

--- a/Kernel/FileSystem/InodeWatcher.cpp
+++ b/Kernel/FileSystem/InodeWatcher.cpp
@@ -71,7 +71,7 @@ ErrorOr<void> InodeWatcher::close()
 {
     m_watch_maps.with([this](auto& watch_maps) {
         for (auto& entry : watch_maps.wd_to_watches) {
-            auto& inode = const_cast<Inode&>(entry.value->inode);
+            auto& inode = entry.value->inode;
             inode.unregister_watcher({}, *this);
         }
 

--- a/Kernel/FileSystem/InodeWatcher.h
+++ b/Kernel/FileSystem/InodeWatcher.h
@@ -14,6 +14,8 @@
 #include <AK/NonnullOwnPtr.h>
 #include <Kernel/API/InodeWatcherEvent.h>
 #include <Kernel/FileSystem/File.h>
+#include <Kernel/FileSystem/Inode.h>
+#include <Kernel/FileSystem/InodeIdentifier.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/MutexProtected.h>
 #include <Kernel/Locking/SpinlockProtected.h>
@@ -23,7 +25,8 @@ namespace Kernel {
 // A specific description of a watch.
 struct WatchDescription {
     int wd;
-    Inode& inode;
+    LockWeakPtr<Inode> inode;
+    InodeIdentifier inode_identifier;
     unsigned event_mask;
 
     static ErrorOr<NonnullOwnPtr<WatchDescription>> create(int wd, Inode& inode, unsigned event_mask)
@@ -35,6 +38,7 @@ private:
     WatchDescription(int wd, Inode& inode, unsigned event_mask)
         : wd(wd)
         , inode(inode)
+        , inode_identifier(inode.identifier())
         , event_mask(event_mask)
     {
     }


### PR DESCRIPTION
This prevents use-after-frees when the watcher tries to access the inode after it has been freed.

Before fe5ca6ca276, the inode was correctly stored as a WeakPtr. For some reason that commit changed it to a raw reference instead. (This was before 11eee67b851, so before the old WeakPtr was renamed to LockWeakPtr. Inode derives from LockWeakable, so we unfortunately have to use LockWeakPtr here.)

We have to add a new WatchDescription member to store the InodeIdentifier for the inode so that we can still remove the inode_to_watches entry for inodes that have already been freed.

---

I noticed this while trying to run git's `./configure` script in serenity. Doing so while having FileManager open sometimes led to a deadlock. This deadlock was caused by `Inode::unregister_watcher()` trying to access its freed `m_watcher` member. The spinlock from that `SpinlockProtected` member was filled with garbage data (most likely the kfree scrub byte), causing it to never unlock.