### PR TITLE
SSHServer: Support receiving big files over scp

### DIFF
--- a/Tests/LibSSH/SFTP/Shared.h
+++ b/Tests/LibSSH/SFTP/Shared.h
@@ -32,7 +32,8 @@ inline ErrorOr<void> server_process_data(SSH::SFTP::Server& server, ReadonlyByte
     auto session = MUST(SSH::Session::create(0, 0, 0));
     session->channel_data.append(bytes);
 
-    return Core::run_async_in_new_event_loop([&]() { return server.handle_channel_data(session); });
+    TRY(Core::run_async_in_new_event_loop([&]() { return server.handle_channel_data(session); }));
+    return {};
 }
 
 struct Message {

--- a/Userland/Libraries/LibSSH/BehaviorControl.h
+++ b/Userland/Libraries/LibSSH/BehaviorControl.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace SSH {
+
+enum class BehaviorControl : u8 {
+    ContinueExecution,
+    WaitForMoreData,
+    Disconnect,
+};
+
+}

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -13,7 +13,7 @@
 
 namespace SSH::SFTP {
 
-Coroutine<ErrorOr<void>> Server::handle_channel_data(Session& session)
+Coroutine<ErrorOr<BehaviorControl>> Server::handle_channel_data(Session& session)
 {
     // FIXME: For the moment everything is done sequentially, but we should
     //        probably make most IO related syscall asynchronous.
@@ -21,13 +21,15 @@ Coroutine<ErrorOr<void>> Server::handle_channel_data(Session& session)
     FixedMemoryStream stream { session.channel_data.data() };
     ScopeGuard commit_read_bytes { [&] { session.channel_data.dequeue(stream.offset()); } };
 
-    if (m_state == State::Constructed)
-        co_return handle_init_message(stream);
+    if (m_state == State::Constructed) {
+        CO_TRY(handle_init_message(stream));
+        co_return BehaviorControl::ContinueExecution;
+    }
 
     VERIFY(m_state == State::Initialized);
     while (stream.remaining() > 0) {
-        if (!is_buffer_containing_a_full_packet(session.channel_data.data()))
-            co_return {};
+        if (!is_buffer_containing_a_full_packet(session.channel_data.data().slice(stream.offset())))
+            co_return BehaviorControl::WaitForMoreData;
 
         CO_TRY(handle_packet(stream));
     }
@@ -35,7 +37,7 @@ Coroutine<ErrorOr<void>> Server::handle_channel_data(Session& session)
     if (session.has_received_eof)
         m_is_ready_to_be_closed = true;
 
-    co_return {};
+    co_return BehaviorControl::ContinueExecution;
 }
 
 void Server::handle_channel_eof(Session const& session)

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -9,6 +9,7 @@
 #include <AK/Vector.h>
 #include <LibCore/File.h>
 #include <LibCrypto/Hash/MD5.h>
+#include <LibSSH/BehaviorControl.h>
 #include <LibSSH/Forward.h>
 #include <LibSSH/SFTP/Peer.h>
 #include <sys/stat.h>
@@ -22,7 +23,7 @@ public:
     {
     }
 
-    Coroutine<ErrorOr<void>> handle_channel_data(Session&);
+    Coroutine<ErrorOr<BehaviorControl>> handle_channel_data(Session&);
     void handle_channel_eof(Session const&);
 
     bool is_ready_to_be_closed() const { return m_is_ready_to_be_closed; }

--- a/Userland/Libraries/LibSSH/Session.cpp
+++ b/Userland/Libraries/LibSSH/Session.cpp
@@ -24,7 +24,7 @@ ErrorOr<ExecData> ExecData::create(Core::Process&& process, int fd_stdin, int fd
     return exec_data;
 }
 
-Coroutine<ErrorOr<void>> ExecData::handle_channel_data(Session& session)
+Coroutine<ErrorOr<BehaviorControl>> ExecData::handle_channel_data(Session& session)
 {
     CO_TRY(co_await stdin_->wait_for_state(Core::Notifier::Type::Write));
     auto& stream = session.channel_data;
@@ -33,7 +33,7 @@ Coroutine<ErrorOr<void>> ExecData::handle_channel_data(Session& session)
 
     close_stdin_if_required(session);
 
-    co_return {};
+    co_return BehaviorControl::ContinueExecution;
 }
 
 void ExecData::handle_channel_eof(Session const& session)

--- a/Userland/Libraries/LibSSH/Session.h
+++ b/Userland/Libraries/LibSSH/Session.h
@@ -14,6 +14,7 @@
 #include <AK/Variant.h>
 #include <LibCore/File.h>
 #include <LibCore/Process.h>
+#include <LibSSH/BehaviorControl.h>
 #include <LibSSH/SFTP/Server.h>
 
 namespace SSH {
@@ -34,7 +35,7 @@ struct ExecData {
 
     Optional<int> exit_status {};
 
-    Coroutine<ErrorOr<void>> handle_channel_data(Session&);
+    Coroutine<ErrorOr<BehaviorControl>> handle_channel_data(Session&);
     void handle_channel_eof(Session const&);
 
     bool is_ready_to_be_closed() const;

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -641,9 +641,17 @@ Coroutine<void> SSHClient::async_stream_data_to_subsystem(NonnullRefPtr<Session>
             if (session->channel_data.data().is_empty())
                 break;
 
-            CO_TRY(co_await session->system.visit(
-                [&](auto& system) -> Coroutine<ErrorOr<void>> { return system.handle_channel_data(session); },
-                [](Empty) -> Coroutine<ErrorOr<void>> { VERIFY_NOT_REACHED(); }));
+            auto behavior = CO_TRY(co_await session->system.visit(
+                [&](auto& system) -> Coroutine<ErrorOr<BehaviorControl>> { return system.handle_channel_data(session); },
+                [](Empty) -> Coroutine<ErrorOr<BehaviorControl>> { VERIFY_NOT_REACHED(); }));
+            switch (behavior) {
+            case BehaviorControl::ContinueExecution:
+                break;
+            case BehaviorControl::WaitForMoreData:
+                co_return {};
+            case BehaviorControl::Disconnect:
+                co_return Error::from_string_literal("Subsystem disconnected");
+            }
         }
 
         CO_TRY(close_session_if_needed(session));

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -43,7 +43,7 @@ SSHClient::~SSHClient()
     Core::EventLoop::unregister_signal(m_sigchld_handler_id);
 }
 
-ErrorOr<SSHClient::BehaviorControl> SSHClient::handle_data(ByteBuffer& data)
+ErrorOr<BehaviorControl> SSHClient::handle_data(ByteBuffer& data)
 {
     if (m_state != State::Constructed) {
         if (!is_buffer_containing_a_full_packet(data))
@@ -483,7 +483,7 @@ ErrorOr<void> SSHClient::send_user_authentication_success()
     return {};
 }
 
-ErrorOr<SSHClient::BehaviorControl> SSHClient::handle_generic_packet(GenericMessage&& message)
+ErrorOr<BehaviorControl> SSHClient::handle_generic_packet(GenericMessage&& message)
 {
     switch (message.type) {
     case MessageID::DISCONNECT:

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <LibCore/Forward.h>
+#include <LibSSH/BehaviorControl.h>
 #include <LibSSH/KeyExchangeData.h>
 #include <LibSSH/Peer.h>
 #include <LibSSH/Session.h>
@@ -43,12 +44,6 @@ class SSHClient : public Peer {
 public:
     explicit SSHClient(Core::TCPSocket& tcp_socket, Function<void()> disconnect);
     ~SSHClient();
-
-    enum class BehaviorControl : u8 {
-        ContinueExecution,
-        WaitForMoreData,
-        Disconnect,
-    };
 
     ErrorOr<BehaviorControl> handle_data(ByteBuffer& data);
 

--- a/Userland/Services/SSHServer/TCPClient.cpp
+++ b/Userland/Services/SSHServer/TCPClient.cpp
@@ -55,11 +55,11 @@ ErrorOr<void> TCPClient::on_ready_to_read()
     while (!m_read_buffer.is_empty()) {
         auto next_behavior = TRY(m_ssh_client.handle_data(m_read_buffer));
         switch (next_behavior) {
-        case SSHClient::BehaviorControl::ContinueExecution:
+        case SSH::BehaviorControl::ContinueExecution:
             continue;
-        case SSHClient::BehaviorControl::WaitForMoreData:
+        case SSH::BehaviorControl::WaitForMoreData:
             return {};
-        case SSHClient::BehaviorControl::Disconnect:
+        case SSH::BehaviorControl::Disconnect:
             die();
         }
     }


### PR DESCRIPTION
With this patch, I am able to copy my 800MiB test file to SerenityOS.

Note that the `scp` process doesn't exit cleanly as we don't support the `FSETSTAT` command.