### PR TITLE
js: Pledge fattr to support atomic line editor history saving

### DIFF
--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -535,7 +535,7 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath tty sigaction map_fixed"));
+    TRY(Core::System::pledge("stdio rpath wpath cpath fattr tty sigaction map_fixed"));
 
     bool gc_on_every_allocation = false;
     bool disable_syntax_highlight = false;


### PR DESCRIPTION
As of ff75e05bbd484f5b4a8f858e9202f5738f6ee139, Editor::save_history() uses FileSystem::copy_file_or_directory() to save the history file to disk. In its implementation, copy_file_or_directory() uses fchmod to ensure the right permission bits are set on the destination file.

Since that commit, closing the js executable on Serenity causes a pledge violation for the fattr pledge during shutdown when trying to save the editor history. Pledge fattr to avoid that.

cc @alimpfard , this is delayed fallout from https://github.com/SerenityOS/serenity/pull/26556