### PR TITLE
define PR_SET_PDEATHSIG and bump gnu coreutils to 9.11

### DIFF
--- a/Ports/coreutils/package.sh
+++ b/Ports/coreutils/package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='coreutils'
-version='9.9'
+version='9.11'
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${version}.tar.gz#91a719fcf923de686016f2c8d084a8be1f793f34173861273c4668f7c65af94a"
+    "https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${version}.tar.gz#2033b8a3049c06bff49a9e3cea72bdf4683bcd0cbeb975211dd56dbaf8b736ae"
 )
 
 # Exclude some non-working utilities:

--- a/Userland/Libraries/LibC/sys/prctl.h
+++ b/Userland/Libraries/LibC/sys/prctl.h
@@ -10,6 +10,8 @@
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
+#define PR_SET_PDEATHSIG 1
+
 __BEGIN_DECLS
 
 int prctl(int option, ...);


### PR DESCRIPTION
PR_SET_PDEATHSIG is needed to compile the timeout utility since 9.10, otherwise we'd have to exclude timeout