### PR TITLE
LibCore+LibGUI: More Core::Resource, part N/M

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -75,7 +75,7 @@ static bool takes_byte_string(StringView property)
 {
     static HashTable<StringView> byte_string_properties;
     if (byte_string_properties.is_empty()) {
-        byte_string_properties.set("icon_from_path"sv);
+        byte_string_properties.set("icon_from_resource"sv);
         byte_string_properties.set("name"sv);
     }
     return byte_string_properties.contains(property);

--- a/Userland/Applications/CharacterMap/CharacterMapWindow.gml
+++ b/Userland/Applications/CharacterMap/CharacterMapWindow.gml
@@ -52,7 +52,7 @@
 
                 @GUI::Button {
                     name: "copy_output_button"
-                    icon: "/res/icons/16x16/edit-copy.png"
+                    icon: "icons/16x16/edit-copy.png"
                     fixed_width: 22
                 }
             }

--- a/Userland/Applications/FontEditor/FontPreviewWindow.gml
+++ b/Userland/Applications/FontEditor/FontPreviewWindow.gml
@@ -26,7 +26,7 @@
 
         @GUI::Button {
             name: "reload_button"
-            icon: "/res/icons/16x16/reload.png"
+            icon: "icons/16x16/reload.png"
             fixed_width: 22
         }
     }

--- a/Userland/Applications/Maps/SearchPanel.gml
+++ b/Userland/Applications/Maps/SearchPanel.gml
@@ -21,7 +21,7 @@
 
         @GUI::Button {
             name: "search_button"
-            icon_from_path: "/res/icons/16x16/find.png"
+            icon_from_resource: "icons/16x16/find.png"
             fixed_width: 24
         }
     }

--- a/Userland/Applications/PixelPaint/ImageProcessor.cpp
+++ b/Userland/Applications/PixelPaint/ImageProcessor.cpp
@@ -63,7 +63,7 @@ ImageProcessor* ImageProcessor::the()
 ErrorOr<void> ImageProcessor::enqueue_command(NonnullRefPtr<ImageProcessingCommand> command)
 {
     if (auto queue_status = m_command_queue.enqueue(move(command)); queue_status.is_error())
-        return ENOSPC;
+        return Error::from_errno(ENOSPC);
 
     if (!m_processor_thread->is_started()) {
         m_processor_thread->start();

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -11,6 +11,7 @@
 #include "ImageEditor.h"
 #include <AK/Result.h>
 #include <AK/Vector.h>
+#include <LibCore/Resource.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/ColorPicker.h>
 #include <LibGUI/MessageBox.h>
@@ -129,7 +130,7 @@ PaletteWidget::PaletteWidget()
     bottom_color_container.set_name("bottom_color_container");
     bottom_color_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 1);
 
-    auto result = load_palette_path("/res/color-palettes/default.palette");
+    auto result = load_palette_path("resource://color-palettes/default.palette");
     if (result.is_error()) {
         GUI::MessageBox::show_error(window(), MUST(String::formatted("Loading default palette failed: {}", result.release_error())));
         display_color_list(fallback_colors());
@@ -216,11 +217,11 @@ Vector<Color> PaletteWidget::colors()
     return colors;
 }
 
-ErrorOr<Vector<Color>> PaletteWidget::load_palette_file(NonnullOwnPtr<Core::File> file)
+ErrorOr<Vector<Color>> PaletteWidget::load_palette_file(NonnullOwnPtr<SeekableStream> stream)
 {
     Vector<Color> palette;
-    Array<u8, PAGE_SIZE> buffer;
-    auto buffered_file = TRY(Core::InputBufferedFile::create(move(file)));
+    Array<u8, 4096> buffer;
+    auto buffered_file = TRY(AK::InputBufferedSeekable<SeekableStream>::create(move(stream)));
 
     while (TRY(buffered_file->can_read_line())) {
         auto line = TRY(buffered_file->read_line(buffer));
@@ -244,8 +245,9 @@ ErrorOr<Vector<Color>> PaletteWidget::load_palette_file(NonnullOwnPtr<Core::File
 
 ErrorOr<Vector<Color>> PaletteWidget::load_palette_path(ByteString const& file_path)
 {
-    auto file = TRY(Core::File::open(file_path, Core::File::OpenMode::Read));
-    return load_palette_file(move(file));
+    auto resource = TRY(Core::Resource::load_from_uri(file_path));
+    auto stream = make<FixedMemoryStream>(resource->data());
+    return load_palette_file(move(stream));
 }
 
 ErrorOr<void> PaletteWidget::save_palette_file(Vector<Color> palette, NonnullOwnPtr<Core::File> file)

--- a/Userland/Applications/PixelPaint/PaletteWidget.h
+++ b/Userland/Applications/PixelPaint/PaletteWidget.h
@@ -31,7 +31,7 @@ public:
 
     Vector<Color> colors();
 
-    static ErrorOr<Vector<Color>> load_palette_file(NonnullOwnPtr<Core::File>);
+    static ErrorOr<Vector<Color>> load_palette_file(NonnullOwnPtr<SeekableStream>);
     static ErrorOr<Vector<Color>> load_palette_path(ByteString const&);
     static ErrorOr<void> save_palette_file(Vector<Color>, NonnullOwnPtr<Core::File>);
 

--- a/Userland/Applications/PixelPaint/ToolboxWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.cpp
@@ -52,7 +52,8 @@ ToolboxWidget::ToolboxWidget()
 void ToolboxWidget::setup_tools()
 {
     auto add_tool = [&](StringView icon_name, GUI::Shortcut const& shortcut, NonnullOwnPtr<Tool> tool, bool is_default_tool = false) {
-        auto action = GUI::Action::create_checkable(tool->tool_name(), shortcut, Gfx::Bitmap::load_from_file(ByteString::formatted("/res/icons/pixelpaint/{}.png", icon_name)).release_value_but_fixme_should_propagate_errors(),
+        auto icon_path = ByteString::formatted("resource://icons/pixelpaint/{}.png", icon_name);
+        auto action = GUI::Action::create_checkable(tool->tool_name(), shortcut, MUST(Gfx::Bitmap::load_from_uri(icon_path.view())),
             [this, tool = tool.ptr()](auto& action) {
                 if (action.is_checked()) {
                     m_active_tool = tool;

--- a/Userland/Applications/ThemeEditor/PathProperty.gml
+++ b/Userland/Applications/ThemeEditor/PathProperty.gml
@@ -18,7 +18,7 @@
     @GUI::Button {
         name: "path_picker_button"
         fixed_width: 22
-        icon: "/res/icons/16x16/open.png"
+        icon: "icons/16x16/open.png"
         tooltip: "Choose..."
     }
 }

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.gml
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.gml
@@ -25,7 +25,7 @@
 
                 @GUI::Button {
                     name: "playback"
-                    icon_from_path: "/res/icons/16x16/play.png"
+                    icon_from_resource: "icons/16x16/play.png"
                     fixed_width: 24
                     button_style: "Coolbar"
                 }
@@ -41,7 +41,7 @@
 
                 @GUI::Button {
                     name: "sizing"
-                    icon_from_path: "/res/icons/16x16/fit-image-to-view.png"
+                    icon_from_resource: "icons/16x16/fit-image-to-view.png"
                     fixed_width: 24
                     button_style: "Coolbar"
                 }
@@ -59,7 +59,7 @@
 
                 @GUI::Button {
                     name: "fullscreen"
-                    icon_from_path: "/res/icons/16x16/fullscreen.png"
+                    icon_from_resource: "icons/16x16/fullscreen.png"
                     fixed_width: 24
                     button_style: "Coolbar"
                 }

--- a/Userland/Applications/Welcome/WelcomeWindow.gml
+++ b/Userland/Applications/Welcome/WelcomeWindow.gml
@@ -91,13 +91,13 @@
             @GUI::Button {
                 name: "help_button"
                 text: "Help Contents"
-                icon_from_path: "/res/icons/16x16/book-open.png"
+                icon_from_resource: "icons/16x16/book-open.png"
             }
 
             @GUI::Button {
                 name: "next_button"
                 text: "Next Tip"
-                icon_from_path: "/res/icons/16x16/go-forward.png"
+                icon_from_resource: "icons/16x16/go-forward.png"
             }
 
             @GUI::Layout::Spacer {}

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -8,6 +8,10 @@ set(SOURCES
     DirIterator.cpp
     Environment.cpp
     File.cpp
+    MappedFile.cpp
+    Resource.cpp
+    ResourceImplementation.cpp
+    ResourceImplementationFile.cpp
     SessionManagement.cpp
     StandardPaths.cpp
     System.cpp
@@ -50,14 +54,10 @@ set(SOURCES
     AnonymousBuffer.cpp
     Command.cpp
     LockFile.cpp
-    MappedFile.cpp
     MimeData.cpp
     NetworkJob.cpp
     Process.cpp
     ProcessStatisticsReader.cpp
-    Resource.cpp
-    ResourceImplementation.cpp
-    ResourceImplementationFile.cpp
     SecretString.cpp
     Socket.cpp
     SOCKSProxyClient.cpp

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -10,6 +10,7 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/Directory.h>
+#include <LibCore/Resource.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <pwd.h>
@@ -40,6 +41,9 @@ ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open_for_system(ByteString const&
 
 ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open(ByteString const& filename, AllowWriting allow_altering)
 {
+    if (filename.starts_with("resource://"sv))
+        return ConfigFile::open(TRY(Resource::load_from_uri(filename)));
+
     auto maybe_file = File::open(filename, allow_altering == AllowWriting::Yes ? File::OpenMode::ReadWrite : File::OpenMode::Read);
     OwnPtr<InputBufferedFile> buffered_file;
     if (maybe_file.is_error()) {
@@ -72,6 +76,19 @@ ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open(ByteString const& filename, 
     return config_file;
 }
 
+ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open(NonnullRefPtr<Resource> resource)
+{
+    auto config_file = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ConfigFile(move(resource))));
+    TRY(config_file->reparse());
+    return config_file;
+}
+
+ConfigFile::ConfigFile(NonnullRefPtr<Resource> resource)
+    : m_filename(resource->filename())
+    , m_resource(move(resource))
+{
+}
+
 ConfigFile::ConfigFile(ByteString const& filename, OwnPtr<InputBufferedFile> open_file)
     : m_filename(filename)
     , m_file(move(open_file))
@@ -86,14 +103,30 @@ ConfigFile::~ConfigFile()
 ErrorOr<void> ConfigFile::reparse()
 {
     m_groups.clear();
-    if (!m_file)
+    OwnPtr<InputBufferedSeekable<SeekableStream>> resource_stream;
+    if (!m_file && !m_resource)
         return {};
+
+    if (m_resource)
+        resource_stream = TRY(InputBufferedSeekable<SeekableStream>::create(TRY(try_make<FixedMemoryStream>(m_resource->stream()))));
+
+    auto can_read_line = [&]() -> ErrorOr<bool> {
+        if (m_file)
+            return m_file->can_read_line();
+        return resource_stream->can_read_line();
+    };
+
+    auto read_line = [&](Bytes bytes) -> ErrorOr<StringView> {
+        if (m_file)
+            return m_file->read_line(bytes);
+        return resource_stream->read_line(bytes);
+    };
 
     HashMap<ByteString, ByteString>* current_group = nullptr;
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
-    while (TRY(m_file->can_read_line())) {
-        auto line = TRY(m_file->read_line(buffer));
+    while (TRY(can_read_line())) {
+        auto line = TRY(read_line(buffer));
         size_t i = 0;
 
         while (i < line.length() && (line[i] == ' ' || line[i] == '\t' || line[i] == '\n'))
@@ -140,7 +173,7 @@ ErrorOr<void> ConfigFile::reparse()
     return {};
 }
 
-Optional<ByteString> ConfigFile::read_entry_optional(const AK::ByteString& group, const AK::ByteString& key) const
+Optional<ByteString> ConfigFile::read_entry_optional(AK::ByteString const& group, AK::ByteString const& key) const
 {
     if (!has_key(group, key))
         return {};

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -32,6 +32,7 @@ public:
     static ErrorOr<NonnullRefPtr<ConfigFile>> open(ByteString const& filename, AllowWriting = AllowWriting::No);
     static ErrorOr<NonnullRefPtr<ConfigFile>> open(ByteString const& filename, int fd);
     static ErrorOr<NonnullRefPtr<ConfigFile>> open(ByteString const& filename, NonnullOwnPtr<Core::File>);
+    static ErrorOr<NonnullRefPtr<ConfigFile>> open(NonnullRefPtr<Resource>);
     ~ConfigFile();
 
     bool has_group(ByteString const&) const;
@@ -81,11 +82,13 @@ public:
 
 private:
     ConfigFile(ByteString const& filename, OwnPtr<InputBufferedFile> open_file);
+    explicit ConfigFile(NonnullRefPtr<Resource> resource);
 
     ErrorOr<void> reparse();
 
     ByteString m_filename;
     OwnPtr<InputBufferedFile> m_file;
+    RefPtr<Resource> m_resource;
     HashMap<ByteString, HashMap<ByteString, ByteString>> m_groups;
     bool m_dirty { false };
 };

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -42,7 +42,7 @@ Button::Button(String text)
         { Gfx::ButtonStyle::Normal, "Normal" },
         { Gfx::ButtonStyle::Coolbar, "Coolbar" });
 
-    REGISTER_WRITE_ONLY_STRING_PROPERTY("icon", set_icon_from_path);
+    REGISTER_WRITE_ONLY_STRING_PROPERTY("icon", set_icon_from_resource);
     REGISTER_BOOL_PROPERTY("default", is_default, set_default);
 }
 
@@ -186,11 +186,12 @@ void Button::set_icon(RefPtr<Gfx::Bitmap const> icon)
     update();
 }
 
-void Button::set_icon_from_path(ByteString const& path)
+void Button::set_icon_from_resource(ByteString const& name)
 {
-    auto maybe_bitmap = Gfx::Bitmap::load_from_file(path);
+    auto const uri = ByteString::formatted("resource://{}", name);
+    auto maybe_bitmap = Gfx::Bitmap::load_from_uri(uri);
     if (maybe_bitmap.is_error()) {
-        dbgln("Unable to load bitmap `{}` for button icon", path);
+        dbgln("Unable to load bitmap `{}` for button icon", uri);
         return;
     }
     set_icon(maybe_bitmap.release_value());

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -29,7 +29,7 @@ public:
     virtual ~Button() override;
 
     void set_icon(RefPtr<Gfx::Bitmap const>);
-    void set_icon_from_path(ByteString const&);
+    void set_icon_from_resource(ByteString const&);
     Gfx::Bitmap const* icon() const { return m_icon.ptr(); }
 
     void set_text_alignment(Gfx::TextAlignment text_alignment) { m_text_alignment = text_alignment; }

--- a/Userland/Libraries/LibGUI/DynamicWidgetContainerControls.gml
+++ b/Userland/Libraries/LibGUI/DynamicWidgetContainerControls.gml
@@ -13,7 +13,7 @@
         button_style: "Coolbar"
         preferred_width: "shrink"
         preferred_height: "shrink"
-        icon_from_path: "/res/icons/16x16/detach.png"
+        icon_from_resource: "icons/16x16/detach.png"
     }
 
     @GUI::Button {
@@ -22,7 +22,7 @@
         button_style: "Coolbar"
         preferred_width: "shrink"
         preferred_height: "shrink"
-        icon_from_path: "/res/icons/16x16/upward-triangle.png"
+        icon_from_resource: "icons/16x16/upward-triangle.png"
     }
 
     @GUI::Button {
@@ -31,6 +31,6 @@
         button_style: "Coolbar"
         preferred_width: "shrink"
         preferred_height: "shrink"
-        icon_from_path: "/res/icons/16x16/downward-triangle.png"
+        icon_from_resource: "icons/16x16/downward-triangle.png"
     }
 }

--- a/Userland/Libraries/LibGUI/IncrementalSearchBanner.gml
+++ b/Userland/Libraries/LibGUI/IncrementalSearchBanner.gml
@@ -20,7 +20,7 @@
 
         @GUI::Button {
             name: "incremental_search_banner_previous_button"
-            icon_from_path: "/res/icons/16x16/go-up.png"
+            icon_from_resource: "icons/16x16/go-up.png"
             fixed_width: 18
             button_style: "Coolbar"
             focus_policy: "NoFocus"
@@ -28,7 +28,7 @@
 
         @GUI::Button {
             name: "incremental_search_banner_next_button"
-            icon_from_path: "/res/icons/16x16/go-down.png"
+            icon_from_resource: "icons/16x16/go-down.png"
             fixed_width: 18
             button_style: "Coolbar"
             focus_policy: "NoFocus"
@@ -51,7 +51,7 @@
         @GUI::Button {
             name: "incremental_search_banner_wrap_search_button"
             fixed_width: 24
-            icon_from_path: "/res/icons/16x16/reload.png"
+            icon_from_resource: "icons/16x16/reload.png"
             tooltip: "Wrap Search"
             checkable: true
             checked: true
@@ -62,7 +62,7 @@
         @GUI::Button {
             name: "incremental_search_banner_match_case_button"
             fixed_width: 24
-            icon_from_path: "/res/icons/16x16/app-font-editor.png"
+            icon_from_resource: "icons/16x16/app-font-editor.png"
             tooltip: "Match Case"
             checkable: true
             button_style: "Coolbar"


### PR DESCRIPTION
This patch series lets PixelPaint be built on non-serenity systems by using more Core::Resource in the app itself.

It also changes how GUI::Buttons load their icons from GML by passing the name of the icon as part of a Core::Resource `resource://` URI, rather than an absolute path.

This patch also modifies Core::ConfigFile to let a user load an ini file from a resource URI rather than requiring a specific file path.