### PR TITLE
Kernel: Use correct custody for symlink syscall

### DIFF
--- a/Kernel/Syscalls/link.cpp
+++ b/Kernel/Syscalls/link.cpp
@@ -30,7 +30,7 @@ ErrorOr<FlatPtr> Process::sys$symlink(Userspace<Syscall::SC_symlink_params const
 
     auto target = TRY(get_syscall_path_argument(params.target));
     auto linkpath = TRY(get_syscall_path_argument(params.linkpath));
-    CustodyBase base(params.dirfd, target->view());
+    CustodyBase base(params.dirfd, linkpath->view());
     TRY(VirtualFileSystem::symlink(vfs_root_context(), credentials(), target->view(), linkpath->view(), base));
     return 0;
 }

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -62,6 +62,7 @@ set(LIBTEST_BASED_SOURCES
     TestSigAltStack.cpp
     TestSigHandler.cpp
     TestSignalDispatch.cpp
+    TestSymlink.cpp
     TestTCPSocket.cpp
     TestWXProtection.cpp
 )

--- a/Tests/Kernel/TestSymlink.cpp
+++ b/Tests/Kernel/TestSymlink.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibTest/TestCase.h>
+
+static void test_symlink(StringView target, StringView link_path, StringView resolved_path)
+{
+    if (FileSystem::exists(link_path))
+        TRY_OR_FAIL(Core::System::unlink(link_path));
+
+    TRY_OR_FAIL(Core::System::symlink(target, link_path));
+    auto real_path = TRY_OR_FAIL(FileSystem::real_path(link_path));
+    EXPECT(real_path == resolved_path);
+}
+
+TEST_CASE(absolute_to_absolute_symlink)
+{
+    test_symlink("/"sv, "/tmp/test_absolute_to_absolute_symlink"sv, "/"sv);
+}
+
+TEST_CASE(absolute_to_relative_symlink)
+{
+    TRY_OR_FAIL(Core::System::chdir("/tmp"sv));
+    test_symlink("/"sv, "test_absolute_to_relative_symlink"sv, "/"sv);
+}
+
+TEST_CASE(relative_to_absolute_symlink)
+{
+    TRY_OR_FAIL(Core::System::chdir("/tmp"sv));
+    test_symlink("../"sv, "/tmp/test_relative_to_absolute_symlink"sv, "/"sv);
+}
+
+TEST_CASE(relative_to_relative_symlink)
+{
+    TRY_OR_FAIL(Core::System::chdir("/tmp"sv));
+    test_symlink("../"sv, "test_relative_to_relative_symlink"sv, "/"sv);
+}


### PR DESCRIPTION
The symlink syscall incorrectally used the target path for resolving the custody instead of the linkpath. If the target path was absolute and the linkpath relative the linkpath would be erroneously
treated as an absolute one.