### PR TITLE
Meta: Disable "readability-math-missing-parentheses" clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,6 +42,7 @@ Checks: >
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers,
+  -readability-math-missing-parentheses,
   -readability-named-parameter,
   -readability-uppercase-literal-suffix,
   -readability-use-anyofallof,


### PR DESCRIPTION
It's very noisy and we usually don't intend to follow this check.

---

This causes `'*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations` and similar. Especially for `2 * i + 1` and similar, we never want to write `(2 * i) + 1`, so turn this off.