### PR TITLE
LibC: Remove ESUCCESS as a public macro

### DIFF
--- a/Kernel/API/POSIX/errno.h
+++ b/Kernel/API/POSIX/errno.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #define ENUMERATE_ERRNO_CODES(E)                                      \
-    E(ESUCCESS, "Success (not an error)")                             \
+    E(__ESUCCESS, "Success (not an error)")                           \
     E(EPERM, "Operation not permitted")                               \
     E(ENOENT, "No such file or directory")                            \
     E(ESRCH, "No such process")                                       \

--- a/Userland/Libraries/LibC/errno_codes.h
+++ b/Userland/Libraries/LibC/errno_codes.h
@@ -9,7 +9,7 @@
 #include <Kernel/API/POSIX/errno.h>
 
 // NOTE: You can't define with a macro, so these have to be duplicated.
-#define ESUCCESS ESUCCESS
+// __ESUCCESS omitted intentionally
 #define EPERM EPERM
 #define ENOENT ENOENT
 #define ESRCH ESRCH

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -117,13 +117,13 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
 
     if (ipc_file.has_value()) {
         if (FileSystem::is_device(ipc_file->fd()))
-            error = is_silencing_devices() ? ESUCCESS : EINVAL;
+            error = is_silencing_devices() ? 0 : EINVAL;
         else if (FileSystem::is_directory(ipc_file->fd()))
-            error = is_silencing_directories() ? ESUCCESS : EISDIR;
+            error = is_silencing_directories() ? 0 : EISDIR;
     }
 
     switch (error) {
-    case ESUCCESS:
+    case 0:
     case ECANCELED:
         break;
     case ENOENT:
@@ -140,7 +140,7 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
             (void)GUI::MessageBox::try_show_error(request_data.parent_window, maybe_message.release_value());
     }
 
-    if (error != ESUCCESS)
+    if (error != 0)
         return (void)request_data.promise->resolve(Error::from_errno(error));
 
     auto file_or_error = [&]() -> ErrorOr<File> {

--- a/Userland/Services/ChessEngine/ChessEngine.cpp
+++ b/Userland/Services/ChessEngine/ChessEngine.cpp
@@ -65,7 +65,7 @@ void ChessEngine::handle_go(GoCommand const& command)
 void ChessEngine::handle_quit()
 {
     if (on_quit)
-        on_quit(ESUCCESS);
+        on_quit(0);
 }
 
 void ChessEngine::handle_unexpected_eof()


### PR DESCRIPTION
ESUCCESS is not part of POSIX or any SUS standard, and is only present
in esoteric Unix-like systems from days gone by. And glibc, for some
reason. Remove it from the public headers now that there's no uses
in Userland/ anymore.