### PR TITLE
Meta: Fix prekernel image from Prekernel64 to kernel_x86-64 within debug-kernel.sh 

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -40,7 +40,7 @@ fi
 #
 if [ "$SERENITY_ARCH" = "x86_64" ]; then
     gdb_arch=i386:x86-64
-    prekernel_image=Prekernel64
+    prekernel_image=kernel_x86-64
     kernel_image=Kernel_shared_object
     kernel_base=0x2000200000
 elif [ "$SERENITY_ARCH" = "aarch64" ]; then


### PR DESCRIPTION
## Summary of problem

`Meta/debug-kernel.sh` currently attempts to load `Prekernel64` as the prekernel executable on x86_64 architecture:
(https://github.com/SerenityOS/serenity/blob/d62c97ce483fa85f621f28f1212e0d5b359be3b0/Meta/debug-kernel.sh#L43)

However, the current build system produces `Build/x86_64/Kernel/Prekernel/kernel_x86-64` and not `Build/x86_64/Kernel/Prekernel/Prekernel64`. This can be seen in the CMakeLists.txt:

https://github.com/SerenityOS/serenity/blob/d62c97ce483fa85f621f28f1212e0d5b359be3b0/Kernel/Prekernel/CMakeLists.txt#L29

When debugging the serenity Operating System with `tmux` using the command `Meta/serenity.sh gdb`, the prekernel symbols are not automatically loaded into GDB. GDB tries to load `Build/x86_64/Kernel/Prekernel/Prekernel64`  and fails with `No such file or directory`.

```
+file /home/vboxuser/Documents/SerenityOS/Meta/../Build/x86_64/Kernel/Prekernel/Prekernel64
/home/vboxuser/Documents/SerenityOS/Meta/../Build/x86_64/Kernel/Prekernel/Prekernel64: No such file or directory.
```

Therefore to debug the Prekernel image (_or the early boot process like what I was trying to do_),  someone has to manually work around this by running `add-symbol-file Build/x86_64/Kernel/Prekernel/kernel_x86-64` within GDB.

## What this change does
This change updates `Meta/debug-kernel.sh` to load the `kernel_x86-64` executable directly when a user runs `Meta/serenity.sh gdb` command. The user is then able to set breakpoints in prekernel files like `Kernel/Prekernel/init.cpp` as GDB recognizes the symbols.

## A few background infos
Remember that `Meta/serenity.sh gdb` calls `Meta/debug-kernel.sh` by calling run_gdb below:

https://github.com/SerenityOS/serenity/blob/d62c97ce483fa85f621f28f1212e0d5b359be3b0/Meta/serenity.sh#L529

And then `run_gdb()` function calls `Meta/debug-kernel.sh` below:

https://github.com/SerenityOS/serenity/blob/d62c97ce483fa85f621f28f1212e0d5b359be3b0/Meta/serenity.sh#L361

## Testing

- Removed the build directory using `rm -rf Build/` at the root of the project.
- Rebuilt the project using `Meta/serenity.sh gdb`.
- Verified that GDB now loads the prekernel executable automatically.
- Verified that breakpoints in Kernel/Prekernel/init.cpp work without manually adding the symbol file.

### GDB log before change:

```
warning: Currently logging to gdb.txt.  Turn the logging off and on to make the new setting effective.
+set pagination off
+file /home/vboxuser/Documents/SerenityOS/Meta/../Build/x86_64/Kernel/Prekernel/Prekernel64
/home/vboxuser/Documents/SerenityOS/Meta/../Build/x86_64/Kernel/Prekernel/Prekernel64: No such file or directory.
```

### GDB prekernel breakpoint attempt before change:

<img width="1266" height="281" alt="image" src="https://github.com/user-attachments/assets/aa0c7d5a-c31c-4795-b9b9-888ce0d9a000" />


### GDB log after change:

```
warning: Currently logging to gdb.txt.  Turn the logging off and on to make the new setting effective.
+set pagination off
+file /home/vboxuser/Documents/SerenityOS/Meta/../Build/x86_64/Kernel/Prekernel/kernel_x86-64
Reading symbols from /home/vboxuser/Documents/SerenityOS/Meta/../Build/x86_64/Kernel/Prekernel/kernel_x86-64...
```

### GDB prekernel breakpoint attempt after change:

<img width="1252" height="216" alt="image" src="https://github.com/user-attachments/assets/8c065384-23c8-4ecc-a213-ae2504750491" />

This aligns with the presence of the file in my Build directory as below:

<img width="1261" height="675" alt="image" src="https://github.com/user-attachments/assets/fb9e38bf-ba76-43a2-bd55-9ed15821d8df" />

## Disclaimer on architecture where I have tested this change
I suspect that all the references to `Prekernel` in `Meta/debug-kernel.sh` might be affected since the prekernel CMakeLists.txt sets the prekernel image to kernel_x86_64? I however I am not an expert in CMake and would not like to assume that the other architectures will be affected e.g. "aarch64" or "riscv64". 

I made this change only to affect my architecture which is a x86 on a 64 bit system. This is where I have tested this change and  the basis of this PR. 
