### PR TITLE
LibSSH: Fix off-by-one in read_packet's payload length check

### DIFF
--- a/Tests/LibSSH/TestSSHPeer.cpp
+++ b/Tests/LibSSH/TestSSHPeer.cpp
@@ -128,6 +128,32 @@ TEST_CASE(stable_session_id)
     EXPECT_EQ(peer.session_id(), session_id);
 }
 
+TEST_CASE(packet_without_payload)
+{
+    AllocatingMemoryStream stream;
+    SocketMock socket(stream);
+    auto peer = PeerMock(socket);
+
+    // packet_length only covers padding_length and the padding, leaving no payload.
+    auto raw_message = "\x00\x00\x00\x05\x04\x00\x00\x00\x00"sv;
+    auto message = TRY_OR_FAIL(ByteBuffer::copy(raw_message.bytes()));
+
+    EXPECT(peer.read_packet(message).is_error());
+}
+
+TEST_CASE(padding_longer_than_packet)
+{
+    AllocatingMemoryStream stream;
+    SocketMock socket(stream);
+    auto peer = PeerMock(socket);
+
+    // padding_length is bigger than packet_length, which used to underflow the payload length.
+    auto raw_message = "\x00\x00\x00\x04\xff\x00\x00\x00\x00"sv;
+    auto message = TRY_OR_FAIL(ByteBuffer::copy(raw_message.bytes()));
+
+    EXPECT(peer.read_packet(message).is_error());
+}
+
 TEST_CASE(is_buffer_containing_a_full_packet)
 {
     // A session ID is stable, even after the peers rekeyed.

--- a/Userland/Libraries/LibSSH/Peer.cpp
+++ b/Userland/Libraries/LibSSH/Peer.cpp
@@ -49,13 +49,12 @@ ErrorOr<ByteBuffer> Peer::read_packet(ByteBuffer& data)
 
     u8 padding_length = TRY(stream.read_value<u8>());
 
-    if (packet_length == padding_length)
-        return Error::from_string_literal("Packet doesn't have a payload");
-
     // "There MUST be at least four bytes of padding."
     if (padding_length < 4)
         return Error::from_string_literal("Padding length is too short");
 
+    if (packet_length <= padding_length + 1u)
+        return Error::from_string_literal("Packet doesn't have a payload");
     auto payload_length = packet_length - padding_length - 1;
     auto payload = TRY(ByteBuffer::create_uninitialized(payload_length));
     TRY(stream.read_until_filled(payload));


### PR DESCRIPTION
read_packet computes the payload as packet_length - padding_length - 1 but only rejects packet_length == padding_length, so the guard is one byte short. length 5 with padding 4 slips through and returns a zero-length payload, which breaks the size >= 1 invariant unpack_generic_message asserts on and that handle_new_keys_message relies on when it indexes payload[0]. padding_length can also just exceed packet_length: 4 with padding 255 wraps the subtraction and asks create_uninitialized for 4294967044 bytes off a nine byte packet, which asan flags as an allocation-size-too-big at Peer.cpp:60. both land before authentication since the transport is still on the identity cipher until NEWKEYS. found it reading the framing code against rfc 4253 section 6.