### PR TITLE
LibPDF: Do not crash on several invalid inputs, ignore unknown drawing operators

### DIFF
--- a/Tests/LibPDF/CMakeLists.txt
+++ b/Tests/LibPDF/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_FILES
     encoding.pdf
     encryption_nocopy.pdf
     group.pdf
+    invalid-operator.pdf
     jbig2-globals.pdf
     jbig2-globals-indirect-reference.pdf
     jpeg2000-indexed-small.pdf

--- a/Tests/LibPDF/CMakeLists.txt
+++ b/Tests/LibPDF/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_FILES
     encryption_nocopy.pdf
     group.pdf
     invalid-operator.pdf
+    invalid-paint-objects.pdf
     jbig2-globals.pdf
     jbig2-globals-indirect-reference.pdf
     jpeg2000-indexed-small.pdf

--- a/Tests/LibPDF/TestPDF.cpp
+++ b/Tests/LibPDF/TestPDF.cpp
@@ -141,6 +141,20 @@ TEST_CASE(resolve_indirect_reference_during_parsing)
     EXPECT_EQ(jbig2_stream->bytes().size(), 20'000U);
 }
 
+TEST_CASE(invalid_operator)
+{
+    auto file = TRY_OR_FAIL(Core::MappedFile::map("invalid-operator.pdf"sv));
+    auto document = MUST(PDF::Document::create(file->bytes()));
+    MUST(document->initialize());
+    EXPECT_EQ(document->get_page_count(), 1U);
+
+    auto page = MUST(document->get_page(0));
+    auto page_size = Gfx::IntSize { 612, 792 };
+    auto bitmap = TRY_OR_FAIL(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, page_size));
+    auto result = PDF::Renderer::render(document, page, bitmap, Color::White, PDF::RenderingPreferences {});
+    // Shouldn't crash.
+}
+
 TEST_CASE(jbig2_embedded_organization_cross_chunk_reference)
 {
     auto file = TRY_OR_FAIL(Core::MappedFile::map("jbig2-globals.pdf"sv));

--- a/Tests/LibPDF/TestPDF.cpp
+++ b/Tests/LibPDF/TestPDF.cpp
@@ -155,6 +155,22 @@ TEST_CASE(invalid_operator)
     // Shouldn't crash.
 }
 
+TEST_CASE(invalid_paint_objects)
+{
+    auto file = TRY_OR_FAIL(Core::MappedFile::map("invalid-paint-objects.pdf"sv));
+    auto document = MUST(PDF::Document::create(file->bytes()));
+    MUST(document->initialize());
+    EXPECT_EQ(document->get_page_count(), 3U);
+
+    for (size_t i = 0; i < document->get_page_count(); ++i) {
+        auto page = MUST(document->get_page(i));
+        auto page_size = Gfx::IntSize { 612, 792 };
+        auto bitmap = TRY_OR_FAIL(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, page_size));
+        auto result = PDF::Renderer::render(document, page, bitmap, Color::White, PDF::RenderingPreferences {});
+        // Shouldn't crash.
+    }
+}
+
 TEST_CASE(jbig2_embedded_organization_cross_chunk_reference)
 {
     auto file = TRY_OR_FAIL(Core::MappedFile::map("jbig2-globals.pdf"sv));

--- a/Tests/LibPDF/invalid-operator.pdf
+++ b/Tests/LibPDF/invalid-operator.pdf
@@ -1,0 +1,37 @@
+%PDF-1.3
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 525 250]/Contents 4 0 R>>
+endobj
+
+4 0 obj
+<</Length 5>>
+stream
+q
+QQ
+
+endstream
+endobj
+
+xref
+0 5
+0000000000 65536 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000195 00000 n 
+
+trailer
+<</Size 5/Root 1 0 R>>
+startxref
+248
+%%EOF

--- a/Tests/LibPDF/invalid-paint-objects.pdf
+++ b/Tests/LibPDF/invalid-paint-objects.pdf
@@ -1,0 +1,111 @@
+%PDF-1.3
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Kids[3 0 R 5 0 R 7 0 R]/Count 3>>
+endobj
+
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 525 250]/Contents 4 0 R/Resources<</ColorSpace<<>>/Font<<>>/XObject<<>>>>>>
+endobj
+
+4 0 obj
+<</Length 490>>
+stream
+% Test operators taking object names with names not in the /Resources dict.
+/InvalidXObject Do
+/InvalidFont Tf
+/InvalidColorSpace cs
+/InvalidColorSpace CS
+
+% Test color setting operators with wrong number of colors.
+0 1 rg
+0 1 RG
+
+g
+G
+
+0 1 0 k
+0 1 0 K
+
+sc
+SC
+
+scn
+SCN
+
+% Test color setting operators with wrong type of operands.
+() [] /Foo rg
+() [] /Foo RG
+
+() g
+() G
+
+() [] /Foo [] k
+() [] /Foo [] K
+
+/DeviceRGB cs
+/DeviceRGB CS
+
+() [] /Foo sc
+() [] /Foo SC
+
+() [] /Foo scn
+() [] /Foo SCN
+
+endstream
+endobj
+
+5 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 525 250]/Contents 6 0 R/Resources<<>>>>
+endobj
+
+6 0 obj
+<</Length 145>>
+stream
+% Test operators taking object names with no dicts in /Resources.
+/InvalidXObject Do
+/InvalidFont Tf
+/InvalidColorSpace cs
+/InvalidColorSpace CS
+
+endstream
+endobj
+
+7 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 525 250]/Contents 6 0 R>>
+endobj
+
+8 0 obj
+<</Length 147>>
+stream
+% Test operators taking object names with no /Resources dict t all.
+/InvalidXObject Do
+/InvalidFont Tf
+/InvalidColorSpace cs
+/InvalidColorSpace CS
+
+endstream
+endobj
+
+xref
+0 9
+0000000000 65536 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000126 00000 n 
+0000000257 00000 n 
+0000000797 00000 n 
+0000000892 00000 n 
+0000001087 00000 n 
+0000001168 00000 n 
+
+trailer
+<</Size 9/Root 1 0 R>>
+startxref
+1365
+%%EOF

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -79,9 +79,15 @@ public:
 
     PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override
     {
+        if (number_of_components() != static_cast<int>(arguments.size()))
+            return Error::malformed_error("Color space expected {} arguments, got {}", number_of_components(), arguments.size());
+
         Vector<float, 4> float_arguments;
-        for (auto& argument : arguments)
+        for (auto& argument : arguments) {
+            if (!argument.has_number())
+                return Error::malformed_error("Color space expected numeric arguments, got {}", argument);
             float_arguments.append(argument.to_float());
+        }
         return style(float_arguments);
     }
 };

--- a/Userland/Libraries/LibPDF/Operator.h
+++ b/Userland/Libraries/LibPDF/Operator.h
@@ -96,7 +96,7 @@ enum class OperatorType {
 
 class Operator {
 public:
-    static OperatorType operator_type_from_symbol(StringView symbol_string)
+    static Optional<OperatorType> operator_type_from_symbol(StringView symbol_string)
     {
 #define V(name, snake_name, symbol) \
     if (symbol_string == #symbol)   \
@@ -109,8 +109,7 @@ public:
         if (symbol_string == "\"")
             return OperatorType::TextNextLineShowStringSetSpacing;
 
-        dbgln("unsupported graphics symbol {}", symbol_string);
-        VERIFY_NOT_REACHED();
+        return {};
     }
 
     static char const* operator_name(OperatorType operator_type)

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -596,7 +596,10 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
             auto operator_string = StringView(m_reader.bytes().slice(operator_start, m_reader.offset() - operator_start));
             m_reader.consume_whitespace();
 
-            auto operator_type = Operator::operator_type_from_symbol(operator_string);
+            auto maybe_operator_type = Operator::operator_type_from_symbol(operator_string);
+            if (!maybe_operator_type.has_value())
+                return error(ByteString::formatted("unsupported operator {}", operator_string));
+            auto operator_type = maybe_operator_type.release_value();
 
             if (operator_type == OperatorType::InlineImageBegin) {
                 if (!operator_args.is_empty())

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -597,8 +597,13 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
             m_reader.consume_whitespace();
 
             auto maybe_operator_type = Operator::operator_type_from_symbol(operator_string);
-            if (!maybe_operator_type.has_value())
-                return error(ByteString::formatted("unsupported operator {}", operator_string));
+            if (!maybe_operator_type.has_value()) {
+                // Quirk: Some PDFs contain invalid operators. Per spec, they should only be ignored in BX/EX blocks,
+                //        but we ignore them everywhere. All other engines seem to do that too, so some files depend on it.
+                //        (Usually accidentally, e.g. containing "QQ" instead of "Q Q" or similar.)
+                dbgln("ignoring unknown operator \"{}\"", operator_string);
+                continue;
+            }
             auto operator_type = maybe_operator_type.release_value();
 
             if (operator_type == OperatorType::InlineImageBegin) {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -625,9 +625,13 @@ PDFErrorOr<void> Renderer::set_font(NonnullRefPtr<DictObject> font_dictionary, f
 RENDERER_HANDLER(text_set_font)
 {
     auto resources = extra_resources.value_or(m_page.resources);
+    if (!resources->contains(CommonNames::Font))
+        return Error::malformed_error("Font resource dictionary missing");
     auto fonts_dictionary = MUST(resources->get_dict(m_document, CommonNames::Font));
 
     auto target_font_name = MUST(m_document->resolve_to<NameObject>(args[0]))->name();
+    if (!fonts_dictionary->contains(target_font_name))
+        return Error::malformed_error("Font resource dictionary does not contain {}", target_font_name);
     auto font_dictionary = MUST(fonts_dictionary->get_dict(m_document, target_font_name));
 
     return set_font(font_dictionary, args[1].to_float());
@@ -1056,13 +1060,13 @@ RENDERER_HANDLER(paint_xobject)
     auto resources = extra_resources.value_or(m_page.resources);
     if (!resources->contains(CommonNames::XObject))
         return Error::malformed_error("XObject resource dictionary missing");
+    auto xobjects_dict = TRY(resources->get_dict(m_document, CommonNames::XObject));
 
     auto xobject_name = args[0].get<NonnullRefPtr<Object>>()->cast<NameObject>()->name();
-    auto xobjects_dict = TRY(resources->get_dict(m_document, CommonNames::XObject));
     if (!xobjects_dict->contains(xobject_name))
         return Error::malformed_error("XObject resource dictionary does not contain {}", xobject_name);
-
     auto xobject = TRY(xobjects_dict->get_stream(m_document, xobject_name));
+
     auto subtype = MUST(xobject->dict()->get_name(m_document, CommonNames::Subtype))->name();
     if (subtype == CommonNames::Image) {
         TRY(paint_image_xobject(xobject));
@@ -1835,11 +1839,11 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_resources(V
             return ColorSpace::create(color_space_name, *this, resources);
         }
     }
+    if (!resources->contains(CommonNames::ColorSpace))
+        return Error::malformed_error("ColorSpace resource dictionary missing");
     auto color_space_resource_dict = TRY(resources->get_dict(m_document, CommonNames::ColorSpace));
-    if (!color_space_resource_dict->contains(color_space_name)) {
-        dbgln("missing key {}", color_space_name);
-        return Error::rendering_unsupported_error("Missing entry for color space name");
-    }
+    if (!color_space_resource_dict->contains(color_space_name))
+        return Error::malformed_error("ColorSpace resource dictionary does not contain {}", color_space_name);
     return get_color_space_from_document(TRY(color_space_resource_dict->get_object(m_document, color_space_name)));
 }
 


### PR DESCRIPTION
See commit message and included test files for details.

For page 2 of BCM2837-ARM-Peripherals.-.Revised.-.V2-1.pdf, we now produce correct output instead of crashing. (Other pages look fine too.)