### PR TITLE
LibCore: Remove use after free in ArgsParser

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -95,7 +95,7 @@ public:
             .help_string = help_string,
             .long_name = long_name,
             .short_name = short_name,
-            .accept_value = [&](StringView) {
+            .accept_value = [&value, new_value](StringView) {
                 value = new_value;
                 return true;
             },


### PR DESCRIPTION
Was testing `ls`, after making some changes to add more pretty colors to it, and noticed that when setting the `-F` or `-p` option it would some times not display the file type indicators for the entries. 

Turned out that the `ArgsParser::add_option` function for setting enums options contained a use after free in the accept_value lambda due to it capturing a local variable by reference instead of by value.