### PR TITLE
LibPDF: Clear arguments of unknown operators

### DIFF
--- a/Tests/LibPDF/TestPDF.cpp
+++ b/Tests/LibPDF/TestPDF.cpp
@@ -152,7 +152,7 @@ TEST_CASE(invalid_operator)
     auto page_size = Gfx::IntSize { 612, 792 };
     auto bitmap = TRY_OR_FAIL(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, page_size));
     auto result = PDF::Renderer::render(document, page, bitmap, Color::White, PDF::RenderingPreferences {});
-    // Shouldn't crash.
+    EXPECT(!result.is_error());
 }
 
 TEST_CASE(invalid_paint_objects)

--- a/Tests/LibPDF/invalid-operator.pdf
+++ b/Tests/LibPDF/invalid-operator.pdf
@@ -14,10 +14,13 @@ endobj
 endobj
 
 4 0 obj
-<</Length 5>>
+<</Length 52>>
 stream
 q
 QQ
+
+() anotherunknownopwithanarg
+0 0 100 100 re f
 
 endstream
 endobj
@@ -33,5 +36,5 @@ xref
 trailer
 <</Size 5/Root 1 0 R>>
 startxref
-248
+296
 %%EOF

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -602,6 +602,7 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
                 //        but we ignore them everywhere. All other engines seem to do that too, so some files depend on it.
                 //        (Usually accidentally, e.g. containing "QQ" instead of "Q Q" or similar.)
                 dbgln("ignoring unknown operator \"{}\"", operator_string);
+                operator_args.clear();
                 continue;
             }
             auto operator_type = maybe_operator_type.release_value();


### PR DESCRIPTION
This is a follow-up to https://github.com/SerenityOS/serenity/pull/26905: If an unknown operator had arguments,
we used to not clear them, causing the next known operator to
receive them.

To test, call an unknown operator with a non-number arg,
followed by `re`.