### PR TITLE
Kernel/Net: Re-add custom E1000 destructor

### DIFF
--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -295,7 +295,15 @@ UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(StringView interface_n
 {
 }
 
-UNMAP_AFTER_INIT E1000NetworkAdapter::~E1000NetworkAdapter() = default;
+UNMAP_AFTER_INIT E1000NetworkAdapter::~E1000NetworkAdapter()
+{
+    if (m_mdio_handling_process) {
+        m_mdio_handling_process->die();
+        // Block until all threads exited to prevent UAF
+        ErrorOr<siginfo_t> result = siginfo_t {};
+        (void)Thread::current()->block<Thread::WaitBlocker>({}, WEXITED, m_mdio_handling_process.release_nonnull(), result);
+    }
+}
 
 bool E1000NetworkAdapter::handle_interrupt()
 {


### PR DESCRIPTION
I forgot to move the E1000E destructor into the E1000 driver in e22c1f2df8b. This should prevent UAFs when the E1000 driver is destroyed (because initialization failed) after the MDIO handling task was already spawned.