### PR TITLE
Kernel/Net: Avoid a bunch of MMIO accesses in the E1000 driver

### DIFF
--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -410,14 +410,13 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
 
     Processor::load_fpu_state(to_thread->fpu_state());
 
-    if (from_thread->process().is_traced())
+    if (from_thread->process().is_traced()) {
         read_debug_registers_into(from_thread->debug_register_state());
-
-    if (to_thread->process().is_traced()) {
-        write_debug_registers_from(to_thread->debug_register_state());
-    } else {
         clear_debug_registers();
     }
+
+    if (to_thread->process().is_traced())
+        write_debug_registers_from(to_thread->debug_register_state());
 }
 
 StringView ProcessorBase::platform_string()

--- a/Kernel/Arch/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86_64/Processor.cpp
@@ -1225,14 +1225,13 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
 
     Processor::store_fpu_state(from_thread->fpu_state());
 
-    if (from_thread->process().is_traced())
+    if (from_thread->process().is_traced()) {
         read_debug_registers_into(from_thread->debug_register_state());
-
-    if (to_thread->process().is_traced()) {
-        write_debug_registers_from(to_thread->debug_register_state());
-    } else {
         clear_debug_registers();
     }
+
+    if (to_thread->process().is_traced())
+        write_debug_registers_from(to_thread->debug_register_state());
 
     auto& processor = Processor::current();
     Processor::set_fs_base(to_thread->arch_specific_data().fs_base);

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -453,9 +453,8 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
 {
     MutexLocker locker { m_write_lock };
 
-    size_t tx_current = in32(REG_TXDESCTAIL) % number_of_tx_descriptors;
     dbgln_if(E1000_DEBUG, "E1000: Sending packet ({} bytes)", payload.size());
-    auto& descriptor = m_tx_descriptors[tx_current];
+    auto& descriptor = m_tx_descriptors[m_tx_tail];
 
     if (descriptor.status == 0) {
         // Someone is still using the descriptor, let's wait until it's free.
@@ -467,34 +466,33 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
     }
 
     VERIFY(payload.size() <= tx_buffer_size);
-    auto* vptr = (void*)m_tx_buffers[tx_current];
+    void* vptr = m_tx_buffers[m_tx_tail];
     memcpy(vptr, payload.data(), payload.size());
     descriptor.length = payload.size();
     descriptor.status = 0;
     descriptor.cmd = CMD_EOP | CMD_IFCS | CMD_RS;
-    dbgln_if(E1000_DEBUG, "E1000: Using tx descriptor {} (head is at {})", tx_current, in32(REG_TXDESCHEAD));
-    tx_current = (tx_current + 1) % number_of_tx_descriptors;
-    out32(REG_TXDESCTAIL, tx_current);
+    dbgln_if(E1000_DEBUG, "E1000: Using tx descriptor {} (head is at {})", m_tx_tail, in32(REG_TXDESCHEAD));
+    m_tx_tail = (m_tx_tail + 1) % number_of_tx_descriptors;
+    out32(REG_TXDESCTAIL, m_tx_tail);
 
     dbgln_if(E1000_DEBUG, "E1000: Sent packet, status is now {:#02x}!", (u8)descriptor.status);
 }
 
 void E1000NetworkAdapter::receive()
 {
-    u32 rx_current;
     for (;;) {
-        rx_current = in32(REG_RXDESCTAIL) % number_of_rx_descriptors;
-        rx_current = (rx_current + 1) % number_of_rx_descriptors;
-        if (!(m_rx_descriptors[rx_current].status & 1))
+        u32 next_rx = (m_rx_tail + 1) % number_of_rx_descriptors;
+        if (!(m_rx_descriptors[next_rx].status & 1))
             break;
-        auto* buffer = m_rx_buffers[rx_current];
-        u16 length = m_rx_descriptors[rx_current].length;
+        m_rx_tail = next_rx;
+        auto* buffer = m_rx_buffers[m_rx_tail];
+        u16 length = m_rx_descriptors[m_rx_tail].length;
         VERIFY(length <= rx_buffer_size);
         dbgln_if(E1000_DEBUG, "E1000: Received 1 packet @ {:p} ({} bytes)", buffer, length);
         did_receive({ buffer, length });
-        m_rx_descriptors[rx_current].status = 0;
-        out32(REG_RXDESCTAIL, rx_current);
+        m_rx_descriptors[m_rx_tail].status = 0;
     }
+    out32(REG_RXDESCTAIL, m_rx_tail);
 }
 
 i32 E1000NetworkAdapter::link_speed()

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -149,6 +149,9 @@ private:
     Mutex m_write_lock;
     WaitQueue m_wait_queue;
 
+    u32 m_rx_tail { 0 }; // Only used in the interrupt, no lock required.
+    u32 m_tx_tail { 0 }; // Guarded by m_write_lock.
+
     OwnPtr<InterruptHandler> m_interrupt_handler;
     RefPtr<Process> m_mdio_handling_process;
 };


### PR DESCRIPTION
When transferring my 800MiB test case over scp, this brings the download
speed from 13.6MB/s to 18.9MB/s.

