### PR TITLE
AK: Variant the union thing [2/N]

### DIFF
--- a/AK/TypeList.h
+++ b/AK/TypeList.h
@@ -41,6 +41,41 @@ struct TypeList {
     using Type = typename TypeListElement<N, TypeList<Types...>>::Type;
 };
 
+// Set of ordered unique types
+template<typename Result, typename...>
+struct TypeSet;
+
+template<typename... RT>
+struct TypeSet<TypeList<RT...>> {
+    using Types = TypeList<RT...>;
+};
+
+template<typename... RT, typename T, typename... Ts>
+struct TypeSet<TypeList<RT...>, T, Ts...> {
+    using Types = Conditional<(IsSame<T, RT> || ...),
+        TypeSet<TypeList<RT...>, Ts...>,
+        TypeSet<TypeList<RT..., T>, Ts...>>::Types;
+};
+
+#if __has_builtin(__builtin_dedup_pack)
+template<typename... Ts>
+consteval auto dedup_types() -> TypeSet<TypeList<__builtin_dedup_pack<Ts...>...>>::Types { return {}; }
+#else
+template<typename... Ts>
+consteval auto dedup_types() -> TypeSet<TypeList<>, Ts...>::Types { return {}; }
+#endif
+
+template<template<typename...> typename V, typename L, typename... Ts>
+struct DedupAndApplyHelper;
+
+template<template<typename...> typename V, typename... Ts>
+struct DedupAndApplyHelper<V, TypeList<Ts...>> {
+    using Type = V<Ts...>;
+};
+
+template<template<typename...> typename V, typename... Ts>
+using DedupAndApply = DedupAndApplyHelper<V, decltype(dedup_types<Ts...>())>::Type;
+
 template<typename T>
 struct TypeWrapper {
     using Type = T;

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -7,9 +7,11 @@
 #pragma once
 
 #include <AK/Array.h>
-#include <AK/BitCast.h>
+#include <AK/Assertions.h>
+#include <AK/Concepts.h>
 #include <AK/StdLibExtraDetails.h>
 #include <AK/StdLibExtras.h>
+#include <AK/StdShim.h>
 #include <AK/TypeList.h>
 
 namespace AK::Detail {
@@ -25,41 +27,193 @@ consteval IndexType index_of()
     return static_cast<IndexType>(sizeof...(Ts));
 }
 
-template<typename IndexType, IndexType CurrentIndex, typename... Ts>
-struct Variant;
-
-template<typename IndexType, IndexType CurrentIndex, typename F, typename... Ts>
-struct Variant<IndexType, CurrentIndex, F, Ts...> {
-    ALWAYS_INLINE static void delete_(IndexType id, void* data)
-    {
-        if (id == CurrentIndex)
-            bit_cast<F*>(data)->~F();
-        else
-            Variant<IndexType, CurrentIndex + 1, Ts...>::delete_(id, data);
-    }
-
-    ALWAYS_INLINE static void move_(IndexType old_id, void* old_data, void* new_data)
-    {
-        if (old_id == CurrentIndex)
-            new (new_data) F(move(*bit_cast<F*>(old_data)));
-        else
-            Variant<IndexType, CurrentIndex + 1, Ts...>::move_(old_id, old_data, new_data);
-    }
-
-    ALWAYS_INLINE static void copy_(IndexType old_id, void const* old_data, void* new_data)
-    {
-        if (old_id == CurrentIndex)
-            new (new_data) F(*bit_cast<F const*>(old_data));
-        else
-            Variant<IndexType, CurrentIndex + 1, Ts...>::copy_(old_id, old_data, new_data);
-    }
+// How this works in constexpr:
+// For construction we use a sentinel value (`VariantIndex`)
+// to pass along the desired depth/type into the constructor chain.
+// This is done as we can't easily start the lifetime of the alternatives
+// after the union was instantiated.
+// Upcoming c++26 features should fix this
+// (see trivial unions (P3074R7) and std::start_lifetime (P3726R2))
+// For move and copy assignment we destroy the active member,
+// and then replace the whole storage,
+// trivial unions may also make this nicer
+template<size_t Index>
+struct VariantIndex {
+    static constexpr size_t Value = Index;
 };
 
-template<typename IndexType, IndexType CurrentIndex>
-struct Variant<IndexType, CurrentIndex> {
-    ALWAYS_INLINE static void delete_(IndexType, void*) { }
-    ALWAYS_INLINE static void move_(IndexType, void*, void*) { }
-    ALWAYS_INLINE static void copy_(IndexType, void const*, void*) { }
+template<size_t CurrentIndex, typename... Ts>
+union VariantStorage;
+
+template<size_t CurrentIndex, typename F, typename... Ts>
+union VariantStorage<CurrentIndex, F, Ts...> {
+    using ElementType = F;
+    static constexpr size_t Index = CurrentIndex;
+    using Rest = VariantStorage<CurrentIndex + 1, Ts...>;
+
+    constexpr VariantStorage() { }
+
+    template<size_t Idx, typename... Us>
+    requires(Idx == CurrentIndex)
+    constexpr VariantStorage(VariantIndex<Idx>, Us&&... args)
+        : value(forward<Us>(args)...)
+    {
+    }
+
+    template<size_t Idx, typename... Us>
+    requires(Idx > CurrentIndex)
+    constexpr VariantStorage(VariantIndex<Idx>, Us&&... args)
+        : rest(VariantIndex<Idx> {}, forward<Us>(args)...)
+    {
+    }
+
+    constexpr VariantStorage(VariantStorage const&) = default;
+    constexpr VariantStorage(VariantStorage const&)
+    requires(!IsTriviallyCopyConstructible<F> || (!IsTriviallyCopyConstructible<Ts> || ...))
+    {
+    }
+
+    constexpr VariantStorage(VariantStorage&&) = default;
+    constexpr VariantStorage(VariantStorage&&)
+    requires(!IsTriviallyMoveConstructible<F> || (!IsTriviallyMoveConstructible<Ts> || ...))
+    {
+    }
+    constexpr VariantStorage& operator=(VariantStorage const&) = default;
+    constexpr VariantStorage& operator=(VariantStorage const&)
+    requires(!IsTriviallyCopyAssignable<F> || (!IsTriviallyCopyAssignable<Ts> || ...))
+    {
+    }
+
+    constexpr VariantStorage& operator=(VariantStorage&&) = default;
+    constexpr VariantStorage& operator=(VariantStorage&&)
+    requires(!IsTriviallyMoveAssignable<F> || (!IsTriviallyMoveAssignable<Ts> || ...))
+    {
+    }
+
+    constexpr ~VariantStorage() = default;
+    constexpr ~VariantStorage()
+    requires(!IsTriviallyDestructible<F> || (!IsTriviallyDestructible<Ts> || ...))
+    {
+    }
+
+    template<size_t I, typename Self>
+    constexpr auto& get(this Self& self)
+    {
+        if constexpr (I == CurrentIndex) {
+            return self.value;
+        } else {
+            return self.rest.template get<I>();
+        }
+    }
+
+    // Note: STL impls seem to wrap this into its own struct, which just forwards the constructor
+    //       not sure why though
+    F value;
+    Rest rest;
+};
+
+template<size_t CurrentIndex, typename F>
+union VariantStorage<CurrentIndex, F> {
+    using ElementType = F;
+    static constexpr size_t Index = CurrentIndex;
+
+    constexpr VariantStorage() { }
+
+    template<size_t Idx, typename... Us>
+    requires(Idx == CurrentIndex)
+    constexpr VariantStorage(VariantIndex<Idx>, Us&&... args)
+        : value(forward<Us>(args)...)
+    {
+    }
+    // Note: Non default/trivial versions of the copy/move
+    //       constructors/assignment operators should never be called,
+    //       as those are handled by the Variant propper
+    constexpr VariantStorage(VariantStorage const&) = default;
+    constexpr VariantStorage(VariantStorage const&)
+    requires(!IsTriviallyCopyConstructible<F>)
+    {
+        VERIFY_NOT_REACHED();
+    }
+
+    constexpr VariantStorage(VariantStorage&&) = default;
+    constexpr VariantStorage(VariantStorage&&)
+    requires(!IsTriviallyMoveConstructible<F>)
+    {
+        VERIFY_NOT_REACHED();
+    }
+    constexpr VariantStorage& operator=(VariantStorage const&) = default;
+    constexpr VariantStorage& operator=(VariantStorage const&)
+    requires(!IsTriviallyCopyAssignable<F>)
+    {
+        VERIFY_NOT_REACHED();
+    }
+
+    constexpr VariantStorage& operator=(VariantStorage&&) = default;
+    constexpr VariantStorage& operator=(VariantStorage&&)
+    requires(!IsTriviallyMoveAssignable<F>)
+    {
+        VERIFY_NOT_REACHED();
+    }
+
+    constexpr ~VariantStorage() = default;
+    constexpr ~VariantStorage()
+    requires(!IsTriviallyDestructible<F>)
+    {
+    }
+
+    template<size_t I, typename Self>
+    constexpr auto& get(this Self& self)
+    {
+        static_assert(I == CurrentIndex);
+        return self.value;
+    }
+
+    F value;
+};
+
+struct VariantHelper {
+    template<size_t TargetIndex, typename Variant, typename... Us>
+    static constexpr void construct(Variant& variant, Us&&... args)
+    {
+        construct_at<Variant>(&variant, VariantIndex<TargetIndex> {}, forward<Us>(args)...);
+    }
+
+    template<typename Variant>
+    static constexpr void delete_(Variant& variant, size_t id)
+    {
+        if (id == Variant::Index) {
+            using F = Variant::ElementType;
+            variant.value.~F();
+        } else if constexpr (requires { variant.rest; }) {
+            delete_(variant.rest, id);
+        } else {
+            __builtin_unreachable();
+        }
+    }
+
+    template<typename From, typename To>
+    static constexpr void move_to(From& from, size_t id, To& to)
+    {
+        if (id == From::Index) {
+            construct<From::Index>(to, move(from.value));
+        } else if constexpr (requires { from.rest; }) {
+            move_to(from.rest, id, to);
+        } else {
+            __builtin_unreachable();
+        }
+    }
+
+    template<typename From, typename To>
+    static constexpr void copy_to(From const& from, size_t id, To& to)
+    {
+        if (id == From::Index) {
+            construct<From::Index>(to, from.value);
+        } else if constexpr (requires { from.rest; }) {
+            copy_to(from.rest, id, to);
+        } else {
+            __builtin_unreachable();
+        }
+    }
 };
 
 template<typename IndexType, typename... Ts>
@@ -112,8 +266,10 @@ struct VariantConstructTag {
     explicit VariantConstructTag() = default;
 };
 
-template<typename T>
+template<size_t I, typename T>
 struct Overload {
+    using Type = T;
+    static constexpr size_t Index = I;
     // This Overload for <T> can be chosen, if the passed fully qualified type <U&&>, can be used to construct a <T>.
     // The compiler will choose the best overload from the overload set (AllOverloads<...>), in case of ambiguity.
     // NOTE: We always allow narrowing conversions here,
@@ -121,19 +277,22 @@ struct Overload {
     //       A point of allowing those is allowing instantiations with literal 0s.
     template<typename U, typename = T>
     requires(IsConstructible<T, U>)
-    static auto operator()(T, U&&) -> T;
+    static auto operator()(T, U&&) -> Overload;
 };
 
-template<typename... Ts>
-struct AllOverloads : public Overload<Ts>... {
+template<typename Is, typename... Ts>
+struct AllOverloads;
+
+template<size_t... Indices, typename... Ts>
+struct AllOverloads<IndexSequence<Indices...>, Ts...> : public Overload<Indices, Ts>... {
     // If you are here because of a long list of redeclarations of this functions
     // your Variant likely contains duplicate types.
     // Use DedupAndApply<Variant, Ts...> if you want duplicates in your type list
-    using Overload<Ts>::operator()...;
+    using Overload<Indices, Ts>::operator()...;
 };
 
 template<typename... Types>
-using MakeOverloads = AllOverloads<Types...>;
+using MakeOverloads = AllOverloads<MakeIndexSequence<sizeof...(Types)>, Types...>;
 }
 
 namespace AK {
@@ -143,7 +302,6 @@ concept NotLvalueReference = !IsLvalueReference<T>;
 
 template<NotLvalueReference... Ts>
 struct Variant {
-    // FIXME: Can we get this to return the index as well?
     using OverloadFinder = Detail::MakeOverloads<Ts...>;
     template<typename T>
     using BestMatch = InvokeResult<OverloadFinder, T, T>;
@@ -156,19 +314,21 @@ private:
     template<typename T>
     static constexpr IndexType index_of() { return Detail::index_of<T, IndexType, Ts...>(); }
 
+    using Storage = Detail::VariantStorage<0, Ts...>;
+
 public:
     template<typename T>
-    static constexpr bool can_contain() { return IsOneOf<T, Ts...>; }
+    static consteval bool can_contain() { return IsOneOf<T, Ts...>; }
 
     template<typename... NewTs>
-    Variant(Variant<NewTs...>&& old)
+    constexpr Variant(Variant<NewTs...>&& old)
     requires((can_contain<NewTs>() && ...))
         : Variant(move(old).template downcast<Ts...>())
     {
     }
 
     template<typename... NewTs>
-    Variant(Variant<NewTs...> const& old)
+    constexpr Variant(Variant<NewTs...> const& old)
     requires((can_contain<NewTs>() && ...))
         : Variant(old.template downcast<Ts...>())
     {
@@ -181,13 +341,15 @@ public:
     template<typename T>
     requires(!IsSame<RemoveCVReference<T>, Variant>
         && (IsConstructible<Ts, T> || ...))
-    Variant(T&& t)
+    constexpr Variant(T&& t)
     {
         using BestOverload = BestMatch<T>;
-        constexpr IndexType BestOverloadIndex = index_of<BestOverload>();
 
-        new (m_data) BestOverload(forward<T>(t));
+        constexpr IndexType BestOverloadIndex = BestOverload::Index;
         m_index = BestOverloadIndex;
+        // FIXME: Is this replacement over the trivial empty union/dummy initialized union
+        //        free, and should we try to do it directly
+        Helper::template construct<BestOverloadIndex>(m_data, forward<T>(t));
     }
 
     template<NotLvalueReference... NewTs>
@@ -196,7 +358,7 @@ public:
     Variant()
     requires(!can_contain<Empty>())
     = delete;
-    Variant()
+    constexpr Variant()
     requires(can_contain<Empty>())
         : Variant(Empty())
     {
@@ -205,140 +367,163 @@ public:
     Variant(Variant const&)
     requires(!(IsCopyConstructible<Ts> && ...))
     = delete;
-    Variant(Variant const&) = default;
+    constexpr Variant(Variant const&) = default;
 
     Variant(Variant&&)
     requires(!(IsMoveConstructible<Ts> && ...))
     = delete;
-    Variant(Variant&&) = default;
+    constexpr Variant(Variant&&) = default;
 
     ~Variant()
     requires(!(IsDestructible<Ts> && ...))
     = delete;
-    ~Variant() = default;
+    constexpr ~Variant() = default;
 
     Variant& operator=(Variant const&)
     requires(!(IsCopyConstructible<Ts> && ...) || !(IsDestructible<Ts> && ...))
     = delete;
-    Variant& operator=(Variant const&) = default;
+    constexpr Variant& operator=(Variant const&) = default;
 
     Variant& operator=(Variant&&)
     requires(!(IsMoveConstructible<Ts> && ...) || !(IsDestructible<Ts> && ...))
     = delete;
-    Variant& operator=(Variant&&) = default;
+    constexpr Variant& operator=(Variant&&) = default;
 
-    ALWAYS_INLINE Variant(Variant const& old)
+    constexpr Variant(Variant const& old)
     requires(!(IsTriviallyCopyConstructible<Ts> && ...))
         : m_data {}
         , m_index(old.m_index)
     {
-        Helper::copy_(old.m_index, old.m_data, m_data);
+        Helper::copy_to(old.m_data, old.m_index, m_data);
     }
 
     // Note: A moved-from variant emulates the state of the object it contains
     //       so if a variant containing an int is moved from, it will still contain that int
     //       and if a variant with a nontrivial move ctor is moved from, it may or may not be valid
     //       but it will still contain the "moved-from" state of the object it previously contained.
-    ALWAYS_INLINE Variant(Variant&& old)
+    ALWAYS_INLINE constexpr Variant(Variant&& old)
     requires(!(IsTriviallyMoveConstructible<Ts> && ...))
         : m_index(old.m_index)
     {
-        Helper::move_(old.m_index, old.m_data, m_data);
+        Helper::move_to(old.m_data, old.m_index, m_data);
     }
 
-    ALWAYS_INLINE ~Variant()
+    ALWAYS_INLINE constexpr ~Variant()
     requires(!(IsTriviallyDestructible<Ts> && ...))
     {
-        Helper::delete_(m_index, m_data);
+        Helper::delete_(m_data, m_index);
     }
 
-    ALWAYS_INLINE Variant& operator=(Variant const& other)
+    ALWAYS_INLINE constexpr Variant& operator=(Variant const& other)
     requires(!(IsTriviallyCopyConstructible<Ts> && ...) || !(IsTriviallyDestructible<Ts> && ...))
     {
         if (this != &other) {
             if constexpr (!(IsTriviallyDestructible<Ts> && ...)) {
-                Helper::delete_(m_index, m_data);
+                Helper::delete_(m_data, m_index);
             }
             m_index = other.m_index;
-            Helper::copy_(other.m_index, other.m_data, m_data);
+            Helper::copy_to(other.m_data, other.m_index, m_data);
         }
         return *this;
     }
 
-    ALWAYS_INLINE Variant& operator=(Variant&& other)
+    template<typename T>
+    requires(!IsSame<RemoveCVReference<T>, Variant>
+        && (IsConstructible<Ts, T> || ...))
+    ALWAYS_INLINE constexpr Variant& operator=(T&& value)
+    {
+        // FIXME: Use move/copy assign if appropriate
+        if constexpr (!(IsTriviallyDestructible<Ts> && ...)) {
+            Helper::delete_(m_data, m_index);
+        }
+        using BestOverload = BestMatch<T>;
+
+        constexpr IndexType BestOverloadIndex = BestOverload::Index;
+        m_index = BestOverloadIndex;
+
+        Helper::construct<BestOverloadIndex>(m_data, forward<T>(value));
+
+        return *this;
+    }
+
+    ALWAYS_INLINE constexpr Variant& operator=(Variant&& other)
     requires(!(IsTriviallyMoveConstructible<Ts> && ...) || !(IsTriviallyDestructible<Ts> && ...))
     {
         if (this != &other) {
             if constexpr (!(IsTriviallyDestructible<Ts> && ...)) {
-                Helper::delete_(m_index, m_data);
+                Helper::delete_(m_data, m_index);
             }
             m_index = other.m_index;
-            Helper::move_(other.m_index, other.m_data, m_data);
+            Helper::move_to(other.m_data, other.m_index, m_data);
         }
         return *this;
     }
 
     template<typename T, typename StrippedT = RemoveCVReference<T>>
-    void set(T&& t)
+    constexpr void set(T&& t)
     requires(can_contain<StrippedT>() && requires { StrippedT(forward<T>(t)); })
     {
         constexpr auto new_index = index_of<StrippedT>();
-        Helper::delete_(m_index, m_data);
-        new (m_data) StrippedT(forward<T>(t));
+        Helper::delete_(m_data, m_index);
         m_index = new_index;
+        Helper::template construct<new_index>(m_data, forward<T>(t));
     }
 
     template<typename T, typename StrippedT = RemoveCVReference<T>>
-    void set(T&& t, Detail::VariantNoClearTag)
+    constexpr void set(T&& t, Detail::VariantNoClearTag)
     requires(can_contain<StrippedT>() && requires { StrippedT(forward<T>(t)); })
     {
         constexpr auto new_index = index_of<StrippedT>();
-        new (m_data) StrippedT(forward<T>(t));
         m_index = new_index;
+        Helper::template construct<new_index>(m_data, forward<T>(t));
     }
 
     template<typename T>
-    T* get_pointer()
+    constexpr T* get_pointer()
     requires(can_contain<T>())
     {
-        if (index_of<T>() == m_index)
-            return bit_cast<T*>(&m_data);
+        constexpr IndexType I = index_of<T>();
+        if (I == m_index)
+            return &m_data.template get<I>();
         return nullptr;
     }
 
     template<typename T>
-    T& get()
+    constexpr T& get()
     requires(can_contain<T>())
     {
         VERIFY(has<T>());
-        return *bit_cast<T*>(&m_data);
+        constexpr IndexType I = index_of<T>();
+        return m_data.template get<I>();
     }
 
     template<typename T>
-    T const* get_pointer() const
+    constexpr T const* get_pointer() const
     requires(can_contain<T>())
     {
-        if (index_of<T>() == m_index)
-            return bit_cast<T const*>(&m_data);
+        constexpr IndexType I = index_of<T>();
+        if (I == m_index)
+            return &m_data.template get<I>();
         return nullptr;
     }
 
     template<typename T>
-    T const& get() const
+    constexpr T const& get() const
     requires(can_contain<T>())
     {
         VERIFY(has<T>());
-        return *bit_cast<T const*>(&m_data);
+        constexpr IndexType I = index_of<T>();
+        return m_data.template get<I>();
     }
 
     template<typename T>
-    [[nodiscard]] bool has() const
+    [[nodiscard]] constexpr bool has() const
     requires(can_contain<T>())
     {
         return index_of<T>() == m_index;
     }
 
-    bool operator==(Variant const& other) const
+    constexpr bool operator==(Variant const& other) const
     {
         return this->visit([&]<typename T>(T const& self) {
             if (auto const* p = other.get_pointer<T>())
@@ -348,21 +533,21 @@ public:
     }
 
     template<typename... Fs>
-    ALWAYS_INLINE decltype(auto) visit(Fs&&... functions)
+    ALWAYS_INLINE constexpr decltype(auto) visit(Fs&&... functions)
     {
         Visitor<Fs...> visitor { forward<Fs>(functions)... };
         return VisitHelper::visit(*this, move(visitor));
     }
 
     template<typename... Fs>
-    ALWAYS_INLINE decltype(auto) visit(Fs&&... functions) const
+    ALWAYS_INLINE constexpr decltype(auto) visit(Fs&&... functions) const
     {
         Visitor<Fs...> visitor { forward<Fs>(functions)... };
         return VisitHelper::visit(*this, move(visitor));
     }
 
     template<typename... NewTs>
-    decltype(auto) downcast() &&
+    constexpr decltype(auto) downcast() &&
     {
         if constexpr (sizeof...(NewTs) == 1 && (IsSpecializationOf<NewTs, Variant> && ...)) {
             return move(*this).template downcast_variant<NewTs...>();
@@ -378,7 +563,7 @@ public:
     }
 
     template<typename... NewTs>
-    decltype(auto) downcast() const&
+    constexpr decltype(auto) downcast() const&
     {
         if constexpr (sizeof...(NewTs) == 1 && (IsSpecializationOf<NewTs, Variant> && ...)) {
             return (*this).downcast_variant(TypeWrapper<NewTs...> {});
@@ -393,24 +578,22 @@ public:
         }
     }
 
-    auto index() const { return m_index; }
+    constexpr auto index() const { return m_index; }
 
 private:
     template<typename... NewTs>
-    Variant<NewTs...> downcast_variant(TypeWrapper<Variant<NewTs...>>) &&
+    constexpr Variant<NewTs...> downcast_variant(TypeWrapper<Variant<NewTs...>>) &&
     {
         return move(*this).template downcast<NewTs...>();
     }
 
     template<typename... NewTs>
-    Variant<NewTs...> downcast_variant(TypeWrapper<Variant<NewTs...>>) const&
+    constexpr Variant<NewTs...> downcast_variant(TypeWrapper<Variant<NewTs...>>) const&
     {
         return (*this).template downcast<NewTs...>();
     }
 
-    static constexpr auto data_size = Detail::integer_sequence_generate_array<size_t>(0, IntegerSequence<size_t, sizeof(Ts)...>()).max();
-    static constexpr auto data_alignment = Detail::integer_sequence_generate_array<size_t>(0, IntegerSequence<size_t, alignof(Ts)...>()).max();
-    using Helper = Detail::Variant<IndexType, 0, Ts...>;
+    using Helper = Detail::VariantHelper;
     using VisitHelper = Detail::VisitImpl<IndexType, Ts...>;
 
     explicit Variant(IndexType index, Detail::VariantConstructTag)
@@ -418,17 +601,11 @@ private:
     {
     }
 
-    ALWAYS_INLINE void clear_without_destruction()
-    {
-        __builtin_memset(m_data, 0, data_size);
-        m_index = invalid_index;
-    }
-
     template<typename... Fs>
     struct Visitor : Fs... {
         using Types = TypeList<Fs...>;
 
-        Visitor(Fs&&... args)
+        constexpr Visitor(Fs&&... args)
             : Fs(forward<Fs>(args))...
         {
         }
@@ -436,10 +613,7 @@ private:
         using Fs::operator()...;
     };
 
-    // Note: Make sure not to default-initialize!
-    //       VariantConstructors::VariantConstructors(T) will set this to the correct value
-    //       So default-constructing to anything will leave the first initialization with that value instead of the correct one.
-    alignas(data_alignment) u8 m_data[data_size];
+    Storage m_data;
     IndexType m_index;
 };
 

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -112,64 +112,6 @@ struct VariantConstructTag {
     explicit VariantConstructTag() = default;
 };
 
-// Type list deduplication
-// Since this is a big template mess, each template is commented with how and why it works.
-struct ParameterPackTag {
-};
-
-// Pack<Ts...> is just a way to pass around the type parameter pack Ts
-template<typename... Ts>
-struct ParameterPack : ParameterPackTag {
-};
-
-// Blank<T> is a unique replacement for T, if T is a duplicate type.
-template<typename T>
-struct Blank {
-    void operator()() const;
-};
-
-template<typename A, typename P>
-inline constexpr bool IsTypeInPack = false;
-
-// IsTypeInPack<T, Pack<Ts...>> will just return whether 'T' exists in 'Ts'.
-template<typename T, typename... Ts>
-inline constexpr bool IsTypeInPack<T, ParameterPack<Ts...>> = (IsSame<T, Ts> || ...);
-
-// Replaces T with Blank<T> if it exists in Qs.
-template<typename T, typename... Qs>
-using BlankIfDuplicate = Conditional<(IsTypeInPack<T, Qs> || ...), Blank<T>, T>;
-
-template<size_t I, typename...>
-struct InheritFromUniqueEntries;
-
-// InheritFromUniqueEntries will inherit from both Qs and Ts, but only scan entries going *forwards*
-// that is to say, if it's scanning from index I in Qs, it won't scan for duplicates for entries before I
-// as that has already been checked before.
-// This makes sure that the search is linear in time (like the 'merge' step of merge sort).
-template<size_t I, typename... Ts, size_t... Js, typename... Qs>
-struct InheritFromUniqueEntries<I, ParameterPack<Ts...>, IndexSequence<Js...>, Qs...>
-    : public BlankIfDuplicate<Ts, Conditional<Js <= I, ParameterPack<>, Qs>...>... {
-
-    using BlankIfDuplicate<Ts, Conditional<Js <= I, ParameterPack<>, Qs>...>::BlankIfDuplicate...;
-    using BlankIfDuplicate<Ts, Conditional<Js <= I, ParameterPack<>, Qs>...>::operator()...;
-};
-
-template<typename...>
-struct InheritFromPacks;
-
-// InheritFromPacks will attempt to 'merge' the pack 'Ps' with *itself*, but skip the duplicate entries
-// (via InheritFromUniqueEntries).
-template<size_t... Is, typename... Ps>
-struct InheritFromPacks<IndexSequence<Is...>, Ps...>
-    : public InheritFromUniqueEntries<Is, Ps, IndexSequence<Is...>, Ps...>... {
-
-    using InheritFromUniqueEntries<Is, Ps, IndexSequence<Is...>, Ps...>::operator()...;
-};
-
-// Just a nice wrapper around InheritFromPacks, which will wrap any parameter packs in ParameterPack (unless it already is one).
-template<typename... Ps>
-using MergeAndDeduplicatePacks = InheritFromPacks<MakeIndexSequence<sizeof...(Ps)>, Conditional<IsBaseOf<ParameterPackTag, Ps>, Ps, ParameterPack<Ps>>...>;
-
 template<typename T>
 struct Overload {
     // This Overload for <T> can be chosen, if the passed fully qualified type <U&&>, can be used to construct a <T>.
@@ -182,22 +124,16 @@ struct Overload {
     static auto operator()(T, U&&) -> T;
 };
 
-template<typename... Bases>
-struct AllOverloads : MergeAndDeduplicatePacks<ParameterPack<Bases>...> {
-    using MergeAndDeduplicatePacks<ParameterPack<Bases>...>::operator();
-};
-
-template<typename IndexSequence>
-struct MakeOverloadsImpl;
-
-template<size_t... Indices>
-struct MakeOverloadsImpl<IndexSequence<Indices...>> {
-    template<typename... Types>
-    using Apply = AllOverloads<Overload<Types>...>;
+template<typename... Ts>
+struct AllOverloads : public Overload<Ts>... {
+    // If you are here because of a long list of redeclarations of this functions
+    // your Variant likely contains duplicate types.
+    // Use DedupAndApply<Variant, Ts...> if you want duplicates in your type list
+    using Overload<Ts>::operator()...;
 };
 
 template<typename... Types>
-using MakeOverloads = typename MakeOverloadsImpl<MakeIndexSequence<sizeof...(Types)>>::template Apply<Types...>;
+using MakeOverloads = AllOverloads<Types...>;
 }
 
 namespace AK {

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -189,13 +189,6 @@ TEST_CASE(moved_from_state)
     EXPECT(same_contents);
 }
 
-TEST_CASE(duplicated_types)
-{
-    Variant<int, int, int, int> its_just_an_int { 42 };
-    EXPECT(its_just_an_int.has<int>());
-    EXPECT_EQ(its_just_an_int.get<int>(), 42);
-}
-
 TEST_CASE(return_values)
 {
     using MyVariant = Variant<int, ByteString, float>;

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -325,3 +325,79 @@ TEST_CASE(variant_equality)
         EXPECT_EQ(variant1, variant2);
     }
 }
+
+static_assert(([]() consteval -> bool {
+    Variant<float, int> my_var { 1337 };
+
+    if (!my_var.has<int>())
+        return false;
+    if (my_var.get<int>() != 1337)
+        return false;
+    my_var = 3.141f;
+    if (!my_var.has<float>())
+        return false;
+    if (my_var.get<float>() != 3.141f)
+        return false;
+
+    Variant<float, int> my_var2 = 1337;
+    if (!my_var2.has<int>())
+        return false;
+    my_var2 = my_var;
+    if (!my_var.has<float>() || my_var.get<float>() != 3.141f)
+        return false;
+    if (!my_var2.has<float>())
+        return false;
+    if (my_var2.get<float>() != 3.141f)
+        return false;
+
+    return true;
+})());
+
+static_assert(([]() consteval -> bool {
+    struct CopyAble {
+        constexpr CopyAble(int a)
+            : v(a)
+        {
+        }
+        constexpr CopyAble(CopyAble const&) = default;
+        int v;
+    };
+
+    Variant<float, int, CopyAble> my_var { CopyAble { 1337 } };
+
+    Variant<float, int, CopyAble> my_var2 = 5;
+    my_var2 = my_var;
+    my_var = 1;
+    if (!my_var.has<int>() || !my_var2.has<CopyAble>())
+        return false;
+
+    my_var = my_var2;
+
+    return (
+        my_var.get<CopyAble>().v == 1337 && my_var2.get<CopyAble>().v == 1337);
+})());
+
+static_assert(([]() consteval -> bool {
+    struct NonTrivial {
+        constexpr NonTrivial() { }
+        constexpr NonTrivial(NonTrivial const&) { }
+        constexpr NonTrivial(NonTrivial&&) { }
+        constexpr ~NonTrivial() { }
+    };
+    struct NonTrivial2 {
+        constexpr NonTrivial2() { }
+        constexpr NonTrivial2(NonTrivial2 const&) { }
+        constexpr NonTrivial2(NonTrivial2&&) { }
+        constexpr ~NonTrivial2() { }
+    };
+    Variant<NonTrivial, NonTrivial2, int> a = NonTrivial {};
+    Variant<NonTrivial, NonTrivial2, int> b = NonTrivial2 {};
+    auto c = a;
+    c = b;
+    b = move(a);
+    a = 2;
+
+    a.visit([](auto&&) {});
+
+    return true;
+})());

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -448,7 +448,7 @@ private:
             Variant<TupleTypeForArgumentListOf<Fns>...> arguments;
         };
 
-        using FunctionsAndArgs = FunctionAndArgs<
+        using FunctionsAndArgs = AK::DedupAndApply<FunctionAndArgs,
             decltype(&GLContext::gl_begin),
             decltype(&GLContext::gl_clear),
             decltype(&GLContext::gl_clear_color),


### PR DESCRIPTION
This does two things:
1. Deduplicate Variant Member types before they reach variant proper
    This allows stripping some extra logic from the overload resolution and makes the next step easier
    On clang this might also be a bit nicer on the compiler 
2. Make Variant union based and constexpr capable