### PR TITLE
route: Don't error on deleting a nonexistent route

### DIFF
--- a/Userland/Utilities/route.cpp
+++ b/Userland/Utilities/route.cpp
@@ -212,8 +212,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (action_add)
             TRY(Core::System::ioctl(fd, SIOCADDRT, &rt));
 
-        if (action_del)
-            TRY(Core::System::ioctl(fd, SIOCDELRT, &rt));
+        if (action_del) {
+            auto maybe_error = Core::System::ioctl(fd, SIOCDELRT, &rt);
+            if (maybe_error.is_error() && maybe_error.error().code() != ESRCH)
+                return maybe_error.release_error();
+        }
     }
 
     return 0;


### PR DESCRIPTION
…xist

route del previously exited with an ioctl ESRCH error whenever the target route didn't exist in the kernel's routing table. NetworkServer hits this on every boot when disabling interfaces before applying config, since a fresh routing table has nothing to remove.

Treat ESRCH on SIOCDELRT as a no-op instead of a fatal error, while leaving SIOCADDRT and all other error codes strict.

Fixes #16879