### PR TITLE
LibPDF+pdf: Add a --strict option

### DIFF
--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -91,16 +91,18 @@ ErrorOr<String> Document::text_string_to_utf8(ByteString const& text_string)
     return TRY(TextCodec::decoder_for_exact_name("PDFDocEncoding"sv)->to_utf8(text_string));
 }
 
-PDFErrorOr<NonnullRefPtr<Document>> Document::create(ReadonlyBytes bytes)
+PDFErrorOr<NonnullRefPtr<Document>> Document::create(ReadonlyBytes bytes, Document::Strictness strictness)
 {
     size_t offset_to_start = TRY(DocumentParser::scan_for_header_start(bytes));
     if (offset_to_start != 0) {
+        if (strictness == Strictness::Strict)
+            return Error::malformed_error("PDF header not at start of file");
         dbgln("warning: PDF header not at start of file, skipping {} bytes", offset_to_start);
         bytes = bytes.slice(offset_to_start);
     }
 
     auto parser = adopt_ref(*new DocumentParser({}, bytes));
-    auto document = adopt_ref(*new Document(parser));
+    auto document = adopt_ref(*new Document(parser, strictness));
 
     document->m_version = TRY(parser->initialize());
     document->m_trailer = parser->trailer();
@@ -119,8 +121,9 @@ PDFErrorOr<NonnullRefPtr<Document>> Document::create(ReadonlyBytes bytes)
     return document;
 }
 
-Document::Document(NonnullRefPtr<DocumentParser> const& parser)
-    : m_parser(parser)
+Document::Document(NonnullRefPtr<DocumentParser> const& parser, Strictness strictness)
+    : m_strictness(strictness)
+    , m_parser(parser)
 {
     m_parser->set_document(this);
 }

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -105,12 +105,18 @@ public:
     // Converts a text string (PDF 1.7 spec, 3.8.1. "String Types") to UTF-8.
     static ErrorOr<String> text_string_to_utf8(ByteString const&);
 
-    static PDFErrorOr<NonnullRefPtr<Document>> create(ReadonlyBytes bytes);
+    enum class Strictness {
+        Permissive,
+        Strict,
+    };
+    static PDFErrorOr<NonnullRefPtr<Document>> create(ReadonlyBytes bytes, Strictness strictness = Strictness::Permissive);
 
     // If a security handler is present, it is the caller's responsibility to ensure
     // this document is unencrypted before calling this function. The user does not
     // need to handle the case where the user password is the empty string.
     PDFErrorOr<void> initialize();
+
+    Strictness strictness() const { return m_strictness; }
 
     Version version() const { return m_version; }
 
@@ -159,7 +165,7 @@ public:
     PDFErrorOr<void> unfilter_stream(NonnullRefPtr<StreamObject> stream) { return m_parser->unfilter_stream(move(stream)); }
 
 private:
-    explicit Document(NonnullRefPtr<DocumentParser> const& parser);
+    explicit Document(NonnullRefPtr<DocumentParser> const& parser, Strictness);
 
     // FIXME: Currently, to improve performance, we don't load any pages at Document
     // construction, rather we just load the page structure and populate
@@ -185,6 +191,7 @@ private:
     PDFErrorOr<NonnullRefPtr<Object>> find_in_name_tree_nodes(NonnullRefPtr<ArrayObject> siblings, DeprecatedFlyString name);
     PDFErrorOr<NonnullRefPtr<Object>> find_in_key_value_array(NonnullRefPtr<ArrayObject> key_value_array, DeprecatedFlyString name);
 
+    Strictness m_strictness { Strictness::Permissive };
     NonnullRefPtr<DocumentParser> m_parser;
     Version m_version;
     RefPtr<DictObject> m_catalog;

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -28,6 +28,8 @@ PDFErrorOr<Version> DocumentParser::initialize()
 
     auto maybe_version = parse_header();
     if (maybe_version.is_error()) {
+        if (m_document->strictness() == Document::Strictness::Strict)
+            return maybe_version.release_error();
         warnln("{}", maybe_version.error().message());
         warnln("No valid PDF header detected, continuing anyway.");
         maybe_version = Version { 1, 6 }; // ¯\_(ツ)_/¯

--- a/Userland/Utilities/pdf.cpp
+++ b/Userland/Utilities/pdf.cpp
@@ -217,11 +217,14 @@ static PDF::PDFErrorOr<int> pdf_main(Main::Arguments arguments)
     u32 render_repeats = 1;
     args_parser.add_option(render_repeats, "Number of times to render page (for profiling)", "render-repeats", {}, "N");
 
+    bool strict = false;
+    args_parser.add_option(strict, "Error out on technically invalid PDFs", "strict", {});
+
     args_parser.parse(arguments);
 
     auto file = TRY(Core::MappedFile::map(in_path));
 
-    auto document = TRY(PDF::Document::create(file->bytes()));
+    auto document = TRY(PDF::Document::create(file->bytes(), strict ? PDF::Document::Strictness::Strict : PDF::Document::Strictness::Permissive));
 
     if (auto handler = document->security_handler(); handler && !handler->has_user_password()) {
         if (password.is_empty()) {


### PR DESCRIPTION
Real-life PDFs don't adhere to the spec, so we need to be lax about this by default. But it's nice to optionally be more strict.

The main motivation is that we'll have to relax more things, and this way they're easy to find.

For now, this adds just a handful checks. There will be more later.