### PR TITLE
Toolchain: Fix nix shell prettier package

### DIFF
--- a/Toolchain/default.nix
+++ b/Toolchain/default.nix
@@ -42,7 +42,7 @@ mkShell.override { stdenv = gccStdenv; } {
     #       adds extra include and resource directories that conflict with serenity's custom toolchain.
     # FIXME: Go back to the `clang-tools` package once https://github.com/NixOS/nixpkgs/pull/354755 is merged.
     llvmPackages_20.clang-unwrapped
-    nodePackages.prettier
+    prettier
     pre-commit
   ]
   ++ lib.optionals stdenv.isLinux [


### PR DESCRIPTION
As of NixOS 26.05:

> error: nodePackages has been removed. Many packages are now available at the top level (e.g. `pkgs.package-name`). Check on https://search.nixos.org to see if the package is still available.

See: https://github.com/NixOS/nixpkgs/pull/496365