### PR TITLE
Ports/SDL2: Clear g_app on VideoQuit

### DIFF
--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -910,10 +910,10 @@ index 0000000000000000000000000000000000000000..039f0361b3d1b248e218ea69495f58e5
 +/* vi: set ts=4 sw=4 expandtab: */
 diff --git a/src/video/serenity/SDL_serenityvideo.cpp b/src/video/serenity/SDL_serenityvideo.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..9299649cfa64e256c1cee8d138c49cb5fd68cbd8
+index 0000000000000000000000000000000000000000..4f29a7d0bd144feca75a898f148001c1eec75a63
 --- /dev/null
 +++ b/src/video/serenity/SDL_serenityvideo.cpp
-@@ -0,0 +1,658 @@
+@@ -0,0 +1,659 @@
 +/*
 +  Simple DirectMedia Layer
 +  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
@@ -1244,6 +1244,7 @@ index 0000000000000000000000000000000000000000..9299649cfa64e256c1cee8d138c49cb5
 +{
 +    dbgln("SERENITY_VideoQuit");
 +    SERENITY_QuitMouse(_this);
++    g_app = nullptr;
 +}
 +
 +SerenitySDLWidget::SerenitySDLWidget(SDL_Window* sdl_window)


### PR DESCRIPTION
We initialize a static GUI::Application in VideoInit that is never explicitly destructed. Because we don't do so, SDL2 applications can crash on exit since static destruction of the application will try to destruct its owned event loop, which was thread-local and already destroyed.

By clearing the RefPtr in VideoQuit, we prevent crashing directly afterwards in Serenity's `exit()`.