### PR TITLE
LibPDF: Improve tiled pattern rendering a tiny bit

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -883,8 +883,8 @@ PDFErrorOr<ColorOrStyle> PatternColorSpace::style(ReadonlySpan<Value> arguments)
     auto device_space_lower_left = initial_ctm.map(pattern_transform.map(pattern_space_lower_left));
     auto device_space_upper_right = initial_ctm.map(pattern_transform.map(pattern_space_upper_right));
 
-    auto bitmap_width = (int)device_space_upper_right.x() - (int)device_space_lower_left.x();
-    auto bitmap_height = (int)device_space_upper_right.y() - (int)device_space_lower_left.y();
+    auto bitmap_width = abs((int)device_space_upper_right.x() - (int)device_space_lower_left.x());
+    auto bitmap_height = abs((int)device_space_upper_right.y() - (int)device_space_lower_left.y());
 
     auto pattern_cell = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { bitmap_width, bitmap_height }));
     auto page = Page(m_renderer.m_page);

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1844,12 +1844,12 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_resources(V
     auto color_space_resource_dict = TRY(resources->get_dict(m_document, CommonNames::ColorSpace));
     if (!color_space_resource_dict->contains(color_space_name))
         return Error::malformed_error("ColorSpace resource dictionary does not contain {}", color_space_name);
-    return get_color_space_from_document(TRY(color_space_resource_dict->get_object(m_document, color_space_name)));
+    return get_color_space_from_document(TRY(color_space_resource_dict->get_object(m_document, color_space_name)), resources);
 }
 
-PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_document(NonnullRefPtr<Object> color_space_object)
+PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_document(NonnullRefPtr<Object> color_space_object, Optional<NonnullRefPtr<DictObject>> resources)
 {
-    return ColorSpace::create(m_document, color_space_object, *this);
+    return ColorSpace::create(m_document, color_space_object, *this, resources);
 }
 
 Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -228,7 +228,7 @@ private:
     PDFErrorOr<void> paint_image_xobject(NonnullRefPtr<StreamObject>);
     void paint_empty_image(Gfx::IntSize);
     PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_resources(Value const&, NonnullRefPtr<DictObject>);
-    PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_document(NonnullRefPtr<Object>);
+    PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_document(NonnullRefPtr<Object>, Optional<NonnullRefPtr<DictObject>> = {});
 
     static ColorOrStyle style_with_alpha(ColorOrStyle style, float alpha)
     {


### PR DESCRIPTION
I've been working on a local branch to move tiling patterns to the new pattern system in #26915, but they don't work in most files I try. This makes them work a bit better.