### PR TITLE
Kernel: Add a WaitQueue::wait_until() overload that doesn't need a lock

### DIFF
--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -466,8 +466,7 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
 
     if (descriptor.status == 0) {
         // Someone is still using the descriptor, let's wait until it's free.
-        Spinlock<LockRank::None> dummy;
-        m_wait_queue.wait_until(dummy, [&descriptor]() {
+        m_wait_queue.wait_until([&descriptor]() {
                         return descriptor.status == 0;
                     })
             .release_value_but_fixme_should_propagate_errors();

--- a/Kernel/Tasks/WaitQueue.h
+++ b/Kernel/Tasks/WaitQueue.h
@@ -19,6 +19,43 @@ class WaitQueue {
     friend class Waiter;
     class Waiter {
     public:
+        template<CallableAs<bool> F>
+        ErrorOr<void> wait_until(WaitQueue& wait_queue, F should_wake)
+        {
+            bool was_interrupted = false;
+
+            SpinlockLocker scheduler_lock(g_scheduler_lock);
+
+            while (true) {
+                prepare(wait_queue);
+
+                if (should_wake())
+                    break;
+                if (was_interrupted = Thread::current()->was_interrupted(); was_interrupted)
+                    break;
+
+                scheduler_lock.unlock();
+
+                maybe_block();
+
+                scheduler_lock.lock();
+            }
+
+            clear();
+
+            scheduler_lock.unlock();
+
+            // This is always cleared since the thread might have been both interrupted and woken up.
+            // If both of those occurred during the same cycle, then we won't report the interrupt,
+            // but we still need to clear it.
+            Thread::current()->clear_interrupted();
+            if (was_interrupted) {
+                return EINTR;
+            }
+
+            return {};
+        }
+
         template<LockRank Rank, CallableAs<bool> F>
         ErrorOr<void> wait_until(WaitQueue& wait_queue, Spinlock<Rank>& lock, F should_wake)
         {
@@ -123,6 +160,13 @@ class WaitQueue {
 public:
     void notify_all();
     void notify_one();
+
+    template<CallableAs<bool> F>
+    ErrorOr<void> wait_until(F should_wake)
+    {
+        Waiter waiter;
+        return waiter.wait_until(*this, move(should_wake));
+    }
 
     template<LockRank Rank, CallableAs<bool> F>
     ErrorOr<void> wait_until(Spinlock<Rank>& lock, F should_wake)


### PR DESCRIPTION
Unlike condition variables, our WaitQueue implementation works correctly without requiring a lock. Users of this overload just need to be sure that the `should_wake` callback is done in an atomic way. See https://read.seas.harvard.edu/cs1610/2026/doc/wait-queues/ (the site we used as an implementation reference) for a good explanation why this is the case, especially the "Synchronization" section.

This allows us to remove a dummy spinlock from the WaitQueue in the E1000 driver.