### PR TITLE
Ports: Try unzip before bsdtar for .zip files

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -361,7 +361,7 @@ fetch_simple() {
                 run touch ".${filename}_extracted"
                 ;;
             *.zip)
-                run_nocd bsdtar xf "${PORT_META_DIR}/${filename}" || run_nocd unzip -qo "${PORT_META_DIR}/${filename}"
+                run_nocd unzip -qo "${PORT_META_DIR}/${filename}" || run_nocd bsdtar xf "${PORT_META_DIR}/${filename}"
                 run touch ".${filename}_extracted"
                 ;;
             *.exe|*.htm)


### PR DESCRIPTION
It's been in this order for a long time (e5e0924), but unzip seems like the more likely candidate to me. It's what the nix shell installs, at least.