### PR TITLE
Kernel/Net: Fix two regressions

### DIFF
--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -149,8 +149,8 @@ private:
     Mutex m_write_lock;
     WaitQueue m_wait_queue;
 
-    u32 m_rx_tail { 0 }; // Only used in the interrupt, no lock required.
-    u32 m_tx_tail { 0 }; // Guarded by m_write_lock.
+    u32 m_rx_tail { number_of_rx_descriptors - 1 }; // Only used in the interrupt, no lock required.
+    u32 m_tx_tail { 0 };                            // Guarded by m_write_lock.
 
     OwnPtr<InterruptHandler> m_interrupt_handler;
     RefPtr<Process> m_mdio_handling_process;

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -120,11 +120,12 @@ void NetworkTask_main(void*)
 
         size_t pending_packets = 0;
 
-        MUST(packet_wait_queue.wait_until(wait_state, [&pending_packets](WaitState& state) {
+        MUST(packet_wait_queue.wait_until(wait_state, [&pending_packets, &timer](WaitState& state) {
             if (state.pending_packets > 0 || state.timeout_expired) {
                 pending_packets = state.pending_packets;
                 state.pending_packets = 0;
                 state.timeout_expired = false;
+                TimerQueue::the().cancel_timer(*timer);
                 return true;
             }
 


### PR DESCRIPTION
The NetworkTask issue was introduced by #26935 and the E1000 one by #26913