### PR TITLE
LibPDF: Implement Type1Font::append_glyph_path()

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -95,6 +95,7 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::append_text_path(Gfx::Path& path, Gfx::F
     auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
     return for_each_glyph_position(position, string, renderer, [&](Gfx::FloatPoint glyph_position, float glyph_width, u8 char_code) {
         // The glyph position is in terms of the `renderer.text_state().font_size`, so we need to scale it to the requested font size.
+        glyph_width *= text_rendering_matrix.x_scale() / horizontal_scaling;
         return append_glyph_path(path, glyph_position.scaled(text_rendering_matrix.x_scale() / horizontal_scaling, 1), glyph_width, char_code, renderer);
     });
 }

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -93,9 +93,9 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::append_text_path(Gfx::Path& path, Gfx::F
 {
     auto horizontal_scaling = renderer.text_state().horizontal_scaling;
     auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
-    return for_each_glyph_position(position, string, renderer, [&](Gfx::FloatPoint glyph_position, float, u8 char_code) {
+    return for_each_glyph_position(position, string, renderer, [&](Gfx::FloatPoint glyph_position, float glyph_width, u8 char_code) {
         // The glyph position is in terms of the `renderer.text_state().font_size`, so we need to scale it to the requested font size.
-        return append_glyph_path(path, glyph_position.scaled(text_rendering_matrix.x_scale() / horizontal_scaling, 1), char_code, renderer);
+        return append_glyph_path(path, glyph_position.scaled(text_rendering_matrix.x_scale() / horizontal_scaling, 1), glyph_width, char_code, renderer);
     });
 }
 

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -20,7 +20,7 @@ protected:
     virtual Optional<float> get_glyph_width(u8 char_code) const = 0;
     virtual PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) = 0;
 
-    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, u8, Renderer const&)
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u8, Renderer const&)
     {
         return Error { Error::Type::RenderingUnsupported, "append_glyph_path not implemented for font" };
     }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -219,7 +219,7 @@ PDFErrorOr<void> TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
     return m_font_painter->draw_glyph(painter, point, char_code, renderer);
 }
 
-PDFErrorOr<void> TrueTypeFont::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const& renderer)
+PDFErrorOr<void> TrueTypeFont::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float, u8 char_code, Renderer const& renderer)
 {
     return m_font_painter->append_glyph_path(path, point, char_code, renderer);
 }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -42,7 +42,7 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Renderer const&) override;
 
-    PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint point, u8 char_code, Renderer const&) override;
+    PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint point, float, u8 char_code, Renderer const&) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -127,15 +127,15 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
     point = point.translated(translation);
 
     auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(point);
-    Type1GlyphCacheKey index { char_code, glyph_position.subpixel_offset, width };
+    CachedGlyphBitmapsKey index { char_code, glyph_position.subpixel_offset, width };
 
     RefPtr<Gfx::Bitmap> bitmap;
-    auto maybe_bitmap = m_glyph_cache.get(index);
+    auto maybe_bitmap = m_cached_glyph_bitmaps.get(index);
     if (maybe_bitmap.has_value()) {
         bitmap = maybe_bitmap.value();
     } else {
         bitmap = m_font_program->rasterize_glyph(char_name, width, glyph_position.subpixel_offset);
-        m_glyph_cache.set(index, bitmap);
+        m_cached_glyph_bitmaps.set(index, bitmap);
     }
 
     painter.blit_filtered(glyph_position.blit_position, *bitmap, bitmap->rect(), [color](Color pixel) -> Color {

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -149,11 +149,15 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
     return {};
 }
 
-PDFErrorOr<void> Type1Font::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float, u8 char_code, Renderer const& renderer)
+PDFErrorOr<void> Type1Font::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float width, u8 char_code, Renderer const& renderer)
 {
     if (!m_font_program)
         return m_fallback_font_painter->append_glyph_path(path, point, char_code, renderer);
-    return Error { Error::Type::RenderingUnsupported, "append_glyph_path not implemented for font" };
+
+    auto char_name = char_name_for_char_code(char_code);
+    path.move_to(point);
+    m_font_program->append_glyph_path_to(path, char_name, width);
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -149,7 +149,7 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
     return {};
 }
 
-PDFErrorOr<void> Type1Font::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const& renderer)
+PDFErrorOr<void> Type1Font::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float, u8 char_code, Renderer const& renderer)
 {
     if (!m_font_program)
         return m_fallback_font_painter->append_glyph_path(path, point, char_code, renderer);

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -143,4 +143,12 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
     });
     return {};
 }
+
+PDFErrorOr<void> Type1Font::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const& renderer)
+{
+    if (!m_font_program)
+        return m_fallback_font_painter->append_glyph_path(path, point, char_code, renderer);
+    return Error { Error::Type::RenderingUnsupported, "append_glyph_path not implemented for font" };
+}
+
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -104,6 +104,16 @@ void Type1Font::set_font_size(float font_size)
         m_fallback_font_painter->set_font_size(font_size);
 }
 
+DeprecatedFlyString Type1Font::char_name_for_char_code(u8 char_code) const
+{
+    auto effective_encoding = encoding();
+    if (!effective_encoding)
+        effective_encoding = m_font_program->encoding();
+    if (!effective_encoding)
+        effective_encoding = Encoding::standard_encoding();
+    return effective_encoding->get_name(char_code);
+}
+
 PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const& renderer)
 {
     auto color = TRY(renderer.state().paint_color.visit(
@@ -117,12 +127,7 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
     if (!m_font_program)
         return m_fallback_font_painter->draw_glyph(painter, point, char_code, renderer);
 
-    auto effective_encoding = encoding();
-    if (!effective_encoding)
-        effective_encoding = m_font_program->encoding();
-    if (!effective_encoding)
-        effective_encoding = Encoding::standard_encoding();
-    auto char_name = effective_encoding->get_name(char_code);
+    auto char_name = char_name_for_char_code(char_code);
     auto translation = m_font_program->glyph_translation(char_name, width);
     point = point.translated(translation);
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -27,7 +27,7 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) override;
 
-    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const& renderer) override;
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -13,12 +13,12 @@
 
 namespace PDF {
 
-struct Type1GlyphCacheKey {
+struct CachedGlyphBitmapsKey {
     u32 glyph_id;
     Gfx::GlyphSubpixelOffset subpixel_offset;
     float width;
 
-    bool operator==(Type1GlyphCacheKey const&) const = default;
+    bool operator==(CachedGlyphBitmapsKey const&) const = default;
 };
 
 class Type1Font : public SimpleFont {
@@ -38,7 +38,7 @@ private:
     DeprecatedFlyString m_base_font_name;
     RefPtr<Type1FontProgram> m_font_program;
     OwnPtr<TrueTypePainter> m_fallback_font_painter;
-    HashMap<Type1GlyphCacheKey, RefPtr<Gfx::Bitmap>> m_glyph_cache;
+    HashMap<CachedGlyphBitmapsKey, RefPtr<Gfx::Bitmap>> m_cached_glyph_bitmaps;
 };
 
 }
@@ -46,8 +46,8 @@ private:
 namespace AK {
 
 template<>
-struct Traits<PDF::Type1GlyphCacheKey> : public DefaultTraits<PDF::Type1GlyphCacheKey> {
-    static unsigned hash(PDF::Type1GlyphCacheKey const& index)
+struct Traits<PDF::CachedGlyphBitmapsKey> : public DefaultTraits<PDF::CachedGlyphBitmapsKey> {
+    static unsigned hash(PDF::CachedGlyphBitmapsKey const& index)
     {
         return pair_int_hash(pair_int_hash(index.glyph_id, (index.subpixel_offset.x << 8) | index.subpixel_offset.y), int_hash(bit_cast<u32>(index.width)));
     }

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -27,12 +27,7 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) override;
 
-    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const& renderer) override
-    {
-        if (!m_font_program)
-            return m_fallback_font_painter->append_glyph_path(path, point, char_code, renderer);
-        return Error { Error::Type::RenderingUnsupported, "append_glyph_path not implemented for font" };
-    }
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const& renderer) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -35,6 +35,8 @@ protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;
 
 private:
+    DeprecatedFlyString char_name_for_char_code(u8 char_code) const;
+
     DeprecatedFlyString m_base_font_name;
     RefPtr<Type1FontProgram> m_font_program;
     OwnPtr<TrueTypePainter> m_fallback_font_painter;

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -71,6 +71,18 @@ RefPtr<Gfx::Bitmap> Type1FontProgram::rasterize_glyph(DeprecatedFlyString const&
     return bitmap;
 }
 
+bool Type1FontProgram::append_glyph_path_to(Gfx::Path& path, DeprecatedFlyString const& char_name, float width)
+{
+    auto maybe_glyph = m_glyph_map.get(char_name);
+    if (!maybe_glyph.has_value())
+        return false;
+
+    auto const& glyph = maybe_glyph.value();
+    auto transform = glyph_transform_to_device_space(glyph, width);
+    path.append_path(glyph.path().copy_transformed(transform), Gfx::Path::AppendRelativeToLastPoint::Yes);
+    return true;
+}
+
 Gfx::Path Type1FontProgram::build_char(DeprecatedFlyString const& char_name, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
 {
     auto maybe_glyph = m_glyph_map.get(char_name);

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -25,6 +25,7 @@ public:
     };
 
     RefPtr<Gfx::Bitmap> rasterize_glyph(DeprecatedFlyString const& char_name, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
+    bool append_glyph_path_to(Gfx::Path&, DeprecatedFlyString const& char_name, float width);
     Gfx::FloatPoint glyph_translation(DeprecatedFlyString const& char_name, float width) const;
     RefPtr<Encoding> encoding() const { return m_encoding; }
 


### PR DESCRIPTION
With this, we can draw rotated type1 text.

The `glyph_width` multiplication in SimpleFont::append_text_path
corresponds to the same in SimpleFont::draw_axis_aligned_glyphs.

Type1FontProgram::append_glyph_to() uses AppendRelativeToLastPoint::Yes
like ScaledFont::append_glyph_path_to().

Type1FontProgram::append_glyph_to() is like build_char() in the same
class, except it does no subpixel translation, and it doesn't move
the origin to the top left corner.

---

This builds on @MacDue's fantastic #26292 and adds type1 support.