### PR TITLE
SSHServer: Allow logging in as a different user

### DIFF
--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -11,6 +11,7 @@
 #include <AK/ScopeGuard.h>
 #include <LibCore/Account.h>
 #include <LibCore/Directory.h>
+#include <LibCore/Environment.h>
 #include <LibCore/System.h>
 #include <LibCore/UmaskScope.h>
 #include <errno.h>
@@ -179,6 +180,8 @@ ErrorOr<void> Account::login() const
     TRY(Core::System::setgroups(m_extra_gids));
     TRY(Core::System::setgid(m_gid));
     TRY(Core::System::setuid(m_uid));
+
+    TRY(Core::Environment::set("HOME"sv, m_home_directory, Core::Environment::Overwrite::Yes));
 
     return {};
 }

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -183,6 +183,11 @@ ErrorOr<void> Account::login() const
     return {};
 }
 
+bool Account::is_self() const
+{
+    return getuid() == m_uid;
+}
+
 ErrorOr<void> Account::set_password(SecretString const& password)
 {
     m_password_hash = crypt(password.characters(), TRY(get_salt()).characters());

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -40,6 +40,8 @@ public:
     bool authenticate(SecretString const& password) const;
     ErrorOr<void> login() const;
 
+    bool is_self() const;
+
     ByteString username() const { return m_username; }
     ByteString password_hash() const { return m_password_hash.value_or(ByteString::empty()); }
 

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -10,6 +10,7 @@
 
 namespace Core {
 
+class Account;
 class AnonymousBuffer;
 class ArgsParser;
 class BufferedSocketBase;

--- a/Userland/Services/LoginServer/main.cpp
+++ b/Userland/Services/LoginServer/main.cpp
@@ -47,7 +47,6 @@ static void child_process(Core::Account const& account)
         exit(1);
     }
 
-    setenv("HOME", account.home_directory().characters(), true);
     dbgln("login with sid={}", rc);
 
     execlp("/bin/SystemServer", "SystemServer", "--user", nullptr);

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -333,7 +333,10 @@ ErrorOr<void> SSHClient::handle_user_authentication(GenericMessage message)
     auto service_name = TRY(decode_string(message.payload));
     auto method_name = TRY(decode_string(message.payload));
 
-    if (username != TRY(Core::Account::self(Core::Account::Read::PasswdOnly)).username())
+    auto self = TRY(Core::Account::self(Core::Account::Read::PasswdOnly));
+    auto need_to_change_user = username != self.username();
+
+    if (getuid() != 0 && need_to_change_user)
         return Error::from_string_literal("Can't authenticate for another user account");
 
     // "The 'service name' specifies the service to start after authentication. There may
@@ -344,8 +347,19 @@ ErrorOr<void> SSHClient::handle_user_authentication(GenericMessage message)
     if (service_name != "ssh-connection"sv.bytes())
         return Error::from_string_literal("Unknown service name.");
 
-    if (method_name == "publickey"sv.bytes())
-        return handle_publickey_message(message, username, service_name);
+    Optional<Core::Account> user {};
+    if (need_to_change_user) {
+        auto maybe_user = Core::Account::from_name(username, Core::Account::Read::PasswdOnly);
+        if (!maybe_user.is_error())
+            user = maybe_user.release_value();
+    } else {
+        user = self;
+    }
+
+    if (user.has_value()) {
+        if (method_name == "publickey"sv.bytes())
+            return handle_publickey_message(message, *user, service_name);
+    }
 
     TRY(send_available_authentication_methods());
     // FIXME: Disconnect the client after too many attempts.
@@ -384,7 +398,7 @@ ErrorOr<ByteBuffer> make_authentication_message(
 // https://datatracker.ietf.org/doc/html/rfc4252#section-7
 ErrorOr<void> SSHClient::handle_publickey_message(
     GenericMessage& message,
-    ReadonlyBytes user_name,
+    Core::Account const& user,
     ReadonlyBytes service_name)
 {
     bool contains_signature = TRY(message.payload.read_value<bool>());
@@ -400,8 +414,8 @@ ErrorOr<void> SSHClient::handle_publickey_message(
 
     auto signature = TRY(TypedBlob::decode(message.payload));
 
-    auto authorized_keys = []() -> Vector<TypedBlob> {
-        auto maybe_keys = ServerConfiguration::the().get_authorized_keys_for_user();
+    auto authorized_keys = [&user] -> Vector<TypedBlob> {
+        auto maybe_keys = ServerConfiguration::the().get_authorized_keys_for_user(user);
         if (maybe_keys.is_error()) {
             dbgln("warning: Impossible to load authorized keys: {}", maybe_keys.release_error());
             return {};
@@ -413,9 +427,10 @@ ErrorOr<void> SSHClient::handle_publickey_message(
         if (algorithm_name != TypedBlob::type_to_string(public_key.type).bytes())
             continue;
 
+        auto username = user.username();
         auto authentication_message = TRY(make_authentication_message(
             session_id(),
-            user_name,
+            username.bytes(),
             service_name,
             algorithm_name,
             public_key));
@@ -432,7 +447,10 @@ ErrorOr<void> SSHClient::handle_publickey_message(
         m_state = State::Authentified;
         TRY(send_user_authentication_success());
 
-        outln("Successful authentication for: {:s}", user_name);
+        if (!user.is_self())
+            TRY(user.login());
+
+        outln("Successful authentication for: {:s}", user.username());
 
         // FIXME: Also send a cool banner :^)
         return {};

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -72,7 +72,7 @@ private:
     ErrorOr<void> send_service_accept(StringView);
 
     ErrorOr<void> handle_user_authentication(GenericMessage data);
-    ErrorOr<void> handle_publickey_message(GenericMessage&, ReadonlyBytes user_name, ReadonlyBytes service_name);
+    ErrorOr<void> handle_publickey_message(GenericMessage&, Core::Account const& user, ReadonlyBytes service_name);
     ErrorOr<void> send_available_authentication_methods();
     ErrorOr<void> send_publickey_ok_message(ReadonlyBytes algorithm_name, ReadonlyBytes blob);
     ErrorOr<void> send_user_authentication_success();

--- a/Userland/Services/SSHServer/ServerConfiguration.cpp
+++ b/Userland/Services/SSHServer/ServerConfiguration.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "ServerConfiguration.h"
+#include <LibCore/Account.h>
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCrypto/Curves/Ed25519.h>
@@ -57,9 +58,9 @@ void ServerConfiguration::ensure_ssh_ed25519_keys() const
     }
 }
 
-ErrorOr<Vector<TypedBlob>> ServerConfiguration::get_authorized_keys_for_user() const
+ErrorOr<Vector<TypedBlob>> ServerConfiguration::get_authorized_keys_for_user(Core::Account const& user) const
 {
-    auto raw_file = TRY(Core::File::open(TRY(user_authorized_keys_file()), Core::File::OpenMode::Read));
+    auto raw_file = TRY(Core::File::open(TRY(user_authorized_keys_file(user)), Core::File::OpenMode::Read));
     auto file = TRY(Core::InputBufferedFile::create(move(raw_file)));
 
     Vector<TypedBlob> blobs;
@@ -74,13 +75,16 @@ ErrorOr<Vector<TypedBlob>> ServerConfiguration::get_authorized_keys_for_user() c
     return blobs;
 }
 
-ErrorOr<StringView> ServerConfiguration::user_authorized_keys_file() const
+ErrorOr<StringView> ServerConfiguration::user_authorized_keys_file([[maybe_unused]] Core::Account const& user) const
 {
     if (!m_user_authorized_keys_file.is_empty())
         return m_user_authorized_keys_file;
 
 #ifdef AK_OS_SERENITY
-    static auto default_path = ByteString::formatted("{}/{}", Core::StandardPaths::config_directory(), "ssh/authorized_keys"sv);
+    static auto default_path = ByteString::formatted(
+        "{}/{}",
+        user.home_directory(),
+        "/.config/ssh/authorized_keys"sv);
     return default_path;
 #endif
 

--- a/Userland/Services/SSHServer/ServerConfiguration.h
+++ b/Userland/Services/SSHServer/ServerConfiguration.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <LibCore/Forward.h>
 #include <LibSSH/DataTypes.h>
 
 namespace SSH::Server {
@@ -34,10 +35,10 @@ public:
     void set_keylog_file(StringView path) { m_keylog_file = path; }
     Optional<ByteString> keylog_file() const { return m_keylog_file; }
 
-    ErrorOr<Vector<TypedBlob>> get_authorized_keys_for_user() const;
+    ErrorOr<Vector<TypedBlob>> get_authorized_keys_for_user(Core::Account const&) const;
 
 private:
-    ErrorOr<StringView> user_authorized_keys_file() const;
+    ErrorOr<StringView> user_authorized_keys_file(Core::Account const&) const;
 
     mutable TypedBlob m_ssh_ed25519_server_public_key;
     mutable TypedBlob m_ssh_ed25519_server_private_key;

--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -61,7 +61,7 @@ ErrorOr<void> accept_connection()
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
-    TRY(Core::System::pledge("stdio accept inet unix rpath wpath cpath proc exec sigaction"));
+    TRY(Core::System::pledge("stdio accept inet unix rpath wpath cpath proc exec sigaction id"));
 
     // FIXME: Audit the server architecture and add veils wherever possible.
 
@@ -127,6 +127,6 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     outln("Listening on {}:{}", g_tcp_server->local_address().value(), g_tcp_server->local_port());
 
-    TRY(Core::System::pledge("stdio accept rpath wpath cpath proc exec sigaction"));
+    TRY(Core::System::pledge("stdio accept rpath wpath cpath proc exec sigaction id"));
     return loop.exec();
 }

--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -63,6 +63,29 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 {
     TRY(Core::System::pledge("stdio accept inet unix rpath wpath cpath proc exec sigaction id"));
 
+    // FIXME: Make the server use more low-privilege processes.
+    //        When receiving a connection, the main server forks and the child handles
+    //        the request. As an SSH server needs to perform many powerful actions, the
+    //        child remains a high-privilege process. This design is quite dangerous as
+    //        the probably easily abusable network code is done by this same high-privilege
+    //        process. When running the server as root a simple bug in the network handling
+    //        code can result in a compromised root-running binary.
+    //        Splitting the server in more low-privilege processes should solve this
+    //        safety hazard. What is proposed here is similar to the OpenSSH
+    //        architecture:
+    //         - The main process (this file) should first set up the PrivilegedWorker,
+    //           and then only accept connections and spawn NetworkParser processes for
+    //           them.
+    //         - NetworkParser processes should only parse SSH packets and defer any
+    //           privileged actions to the PrivilegedWorker.
+    //         - The PrivilegedWorker should be responsible for performing privileged
+    //           actions requested by the NetworkParser processes (reading configuration
+    //           files, authentification, spawning child processes etc…).
+    //        After setup, the privileges of the processes should be as follow:
+    //         - Main process: pledge(stdio accept spawn), unveil(NetworkParser binary)
+    //         - NetworkParser: pledge(stdio recvfd unix), unveil()
+    //         - PrivilegedWorker: pledge(stdio rpath wpath cpath sendfd id proc exec sigaction unix), veil-free.
+
     // FIXME: Audit the server architecture and add veils wherever possible.
 
     Optional<u32> port {};

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -140,7 +140,6 @@ ErrorOr<void> Service::change_privileges()
             dbgln("Failed to drop privileges (tried to change to GID={}, UID={}), due to {}\n", account.gid(), account.uid(), error_or_void.error());
             exit(1);
         }
-        TRY(Core::Environment::set("HOME"sv, account.home_directory(), Core::Environment::Overwrite::Yes));
     }
     return {};
 }

--- a/Userland/Utilities/su.cpp
+++ b/Userland/Utilities/su.cpp
@@ -61,8 +61,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio exec"));
 
-    TRY(Core::Environment::set("HOME"sv, account.home_directory(), Core::Environment::Overwrite::Yes));
-
     if (command.is_null()) {
         TRY(Core::System::exec(account.shell(), Array<StringView, 1> { account.shell().view() }, Core::System::SearchInPath::No));
     } else {


### PR DESCRIPTION
With a public key set up for both anon and nona but not for root (with the appropriate key, logging in as root also works):

```bash
lucas@itxub:~$ ssh -p 2222 nona@127.0.0.1 whoami
nona
lucas@itxub:~$ ssh -p 2222 anon@127.0.0.1 whoami
anon
lucas@itxub:~$ ssh -p 2222 root@127.0.0.1 whoami
root@127.0.0.1: Permission denied (publickey).
lucas@itxub:~$ ssh -p 2222 fdsaf@127.0.0.1 whoami
fdsaf@127.0.0.1: Permission denied (publickey).
```