### PR TITLE
LibGfx: Reject BMPs with an unrepresentable height

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -82,6 +82,20 @@ TEST_CASE(test_bmp_top_down)
     TRY_OR_FAIL(expect_single_frame(*plugin_decoder));
 }
 
+TEST_CASE(test_bmp_rejects_minimum_height)
+{
+    constexpr auto bitmap = "\x42\x4d\x37\x00\x00\x00\x00\x00"
+                            "\x00\x00\x36\x00\x00\x00\x28\x00"
+                            "\x00\x00\x01\x00\x00\x00\x00\x00"
+                            "\x00\x80\x01\x00\x08\x00\x00\x00"
+                            "\x00\x00\x00\x00\x00\x00\x00\x00"
+                            "\x00\x00\x00\x00\x00\x00\x00\x00"
+                            "\x00\x00\x00\x00\x00\x00\x00"sv;
+    static_assert(bitmap.length() == 55);
+
+    EXPECT(Gfx::BMPImageDecoderPlugin::create(bitmap.bytes()).is_error());
+}
+
 TEST_CASE(test_bmp_1bpp)
 {
     auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("bmp/bitmap.bmp"sv)));

--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
@@ -10,6 +10,7 @@
 #include <AK/Debug.h>
 #include <AK/Error.h>
 #include <AK/Function.h>
+#include <AK/NumericLimits.h>
 #include <AK/Try.h>
 #include <AK/Vector.h>
 #include <LibGfx/ImageFormats/BMPLoader.h>
@@ -554,6 +555,10 @@ static bool decode_bmp_core_dib(BMPLoadingContext& context, InputStreamer& strea
         dbgln("BMP has a negative width: {}", core.width);
         return false;
     }
+    if (core.height == NumericLimits<i32>::min()) {
+        dbgln("BMP has an invalid height: {}", core.height);
+        return false;
+    }
 
     auto color_planes = streamer.read_u16();
     if (color_planes != 1) {
@@ -602,6 +607,10 @@ static bool decode_bmp_osv2_dib(BMPLoadingContext& context, InputStreamer& strea
 
     if (core.width < 0) {
         dbgln("BMP has a negative width: {}", core.width);
+        return false;
+    }
+    if (core.height == NumericLimits<i32>::min()) {
+        dbgln("BMP has an invalid height: {}", core.height);
         return false;
     }
 


### PR DESCRIPTION
## Summary

- reject the minimum signed DIB height while parsing Windows and OS/2 BMP headers
- keep `abs()` away from the one signed value it cannot represent
- add a regression using the exact 55-byte BMP shape from #26957

## Testing

- `ctest --test-dir Build/lagom-ubsan -R ^TestImageDecoder$ --output-on-failure` (127 image-decoder cases)
- `Meta/lint-ci.sh --no-ports Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp Tests/LibGfx/TestImageDecoder.cpp`

Fixes #26957