### PR TITLE
chmod: Don't treat unnamed symlinks as errors

### DIFF
--- a/Userland/Utilities/chmod.cpp
+++ b/Userland/Utilities/chmod.cpp
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (S_ISLNK(stat.st_mode)) {
             // Symlinks don't get processed unless they are explicitly listed on the command line.
             if (!paths.contains_slow(path))
-                return false;
+                return true;
 
             // The chmod syscall changes the file that a link points to, so we will have to get
             // the correct mode to base our modifications on.


### PR DESCRIPTION
chmod ignore symlinks if they are not explicitly listed in the input files. With this commit we don't consider non-listed symlinks as an error anymore.

This behavior is not specified by POSIX, but if we trust a libcxx comment, only AIX is returning an error in this case. So this aligns us with other UNIXs.

This functionality is used by libcxx's test suite harness. Changing this behavior makes us pass 48 more tests in the input.output/filesystems folder.

---

These are the tests that we now pass:

<details>
<summary>Test list</summary>

std/input.output/filesystems/class.directory_entry/directory_entry.cons/path.pass.cpp
std/input.output/filesystems/class.directory_entry/directory_entry.mods/assign.pass.cpp
std/input.output/filesystems/class.directory_entry/directory_entry.mods/replace_filename.pass.cpp
std/input.output/filesystems/class.directory_entry/directory_entry.obs/file_size.pass.cpp
std/input.output/filesystems/class.directory_entry/directory_entry.obs/file_type_obs.pass.cpp
std/input.output/filesystems/class.directory_entry/directory_entry.obs/last_write_time.pass.cpp
std/input.output/filesystems/class.directory_entry/directory_entry.obs/status.pass.cpp
std/input.output/filesystems/class.directory_entry/directory_entry.obs/symlink_status.pass.cpp
std/input.output/filesystems/class.directory_iterator/directory_iterator.members/copy.pass.cpp
std/input.output/filesystems/class.directory_iterator/directory_iterator.members/copy_assign.pass.cpp
std/input.output/filesystems/class.directory_iterator/directory_iterator.members/ctor.pass.cpp
std/input.output/filesystems/class.directory_iterator/directory_iterator.members/increment.pass.cpp
std/input.output/filesystems/class.directory_iterator/directory_iterator.members/move.pass.cpp
std/input.output/filesystems/class.directory_iterator/directory_iterator.members/move_assign.pass.cpp
std/input.output/filesystems/class.directory_iterator/directory_iterator.nonmembers/begin_end.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/cache_refresh_iter.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/copy.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/copy_assign.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/ctor.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/depth.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/disable_recursion_pending.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/increment.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/move.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/move_assign.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/pop.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.members/recursion_pending.pass.cpp
std/input.output/filesystems/class.rec.dir.itr/rec.dir.itr.nonmembers/begin_end.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.canonical/canonical.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.copy_symlink/copy_symlink.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.create_directory/create_directory.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.create_directory/create_directory_with_attributes.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.create_directory_symlink/create_directory_symlink.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.create_symlink/create_symlink.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.current_path/current_path.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.equivalent/equivalent.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_block_file/is_block_file.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_char_file/is_character_file.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_directory/is_directory.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_empty/is_empty.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_fifo/is_fifo.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_other/is_other.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_regular_file/is_regular_file.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_socket/is_socket.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.is_symlink/is_symlink.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.read_symlink/read_symlink.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.relative/relative.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.symlink_status/symlink_status.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.weakly_canonical/weakly_canonical.pass.cpp
</details>