### PR TITLE
LibC: Do not create files in truncate

### DIFF
--- a/Tests/LibC/TestTruncate.cpp
+++ b/Tests/LibC/TestTruncate.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteString.h>
+#include <LibTest/TestCase.h>
+#include <unistd.h>
+
+TEST_CASE(truncate_no_file)
+{
+    int rc = truncate("/tmp/i_do_not_exist", 42);
+    EXPECT(rc < 0);
+    EXPECT(errno == ENOENT);
+}

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -896,7 +896,7 @@ int ftruncate(int fd, off_t length)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/truncate.html
 int truncate(char const* path, off_t length)
 {
-    int fd = open(path, O_RDWR | O_CREAT, 0666);
+    int fd = open(path, O_RDWR, 0666);
     if (fd < 0)
         return fd;
     int rc = ftruncate(fd, length);


### PR DESCRIPTION
This is not required by POSIX, and ENOENT seems more natural here. This fixes a libcxx test.

---

This fixes std/input.output/filesystems/fs.op.funcs/fs.op.resize_file/resize_file.pass.cpp, note that the test also require #26960 to pass.