### PR TITLE
LibPDF: Implement glyph path for type0 fonts

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -96,7 +96,7 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::append_text_path(Gfx::Path& path, Gfx::F
     return for_each_glyph_position(position, string, renderer, [&](Gfx::FloatPoint glyph_position, float glyph_width, u8 char_code) {
         // The glyph position is in terms of the `renderer.text_state().font_size`, so we need to scale it to the requested font size.
         glyph_width *= text_rendering_matrix.x_scale() / horizontal_scaling;
-        return append_glyph_path(path, glyph_position.scaled(text_rendering_matrix.x_scale() / horizontal_scaling, 1), glyph_width, char_code, renderer);
+        return append_glyph_path(path, glyph_position.scaled(text_rendering_matrix.x_scale() / horizontal_scaling, 1), glyph_width, char_code);
     });
 }
 

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -20,7 +20,7 @@ protected:
     virtual Optional<float> get_glyph_width(u8 char_code) const = 0;
     virtual PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) = 0;
 
-    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u8, Renderer const&)
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u8)
     {
         return Error { Error::Type::RenderingUnsupported, "append_glyph_path not implemented for font" };
     }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -149,7 +149,7 @@ PDFErrorOr<void> TrueTypePainter::draw_glyph(Gfx::Painter& painter, Gfx::FloatPo
     return {};
 }
 
-PDFErrorOr<void> TrueTypePainter::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const&)
+PDFErrorOr<void> TrueTypePainter::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code)
 {
     auto glyph_id = TRY(resolve_glyph_id_for_char_code(char_code));
     if (glyph_id.has_value()) {
@@ -219,9 +219,9 @@ PDFErrorOr<void> TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
     return m_font_painter->draw_glyph(painter, point, char_code, renderer);
 }
 
-PDFErrorOr<void> TrueTypeFont::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float, u8 char_code, Renderer const& renderer)
+PDFErrorOr<void> TrueTypeFont::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float, u8 char_code)
 {
-    return m_font_painter->append_glyph_path(path, point, char_code, renderer);
+    return m_font_painter->append_glyph_path(path, point, char_code);
 }
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -20,7 +20,7 @@ public:
     Optional<float> get_glyph_width(u8 char_code) const;
     void set_font_size(float font_size);
 
-    PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint point, u8 char_code, Renderer const&);
+    PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint point, u8 char_code);
 
 private:
     TrueTypePainter(AK::NonnullRefPtr<Gfx::ScaledFont>, NonnullRefPtr<Encoding>, bool encoding_is_mac_roman_or_win_ansi, bool is_nonsymbolic, Optional<u8> high_byte, bool is_zapf_dingbats);
@@ -42,7 +42,7 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Renderer const&) override;
 
-    PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint point, float, u8 char_code, Renderer const&) override;
+    PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint point, float, u8 char_code) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -111,9 +111,18 @@ PDFErrorOr<void> CIDFontType0::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
     return {};
 }
 
-PDFErrorOr<void> CIDFontType0::append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u32)
+PDFErrorOr<void> CIDFontType0::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float width, u32 cid)
 {
-    return Error::rendering_unsupported_error("Type0 font CIDFontType0: append_glyph_path not yet implemented");
+    if (!m_font_program) {
+        // FIXME: Should we use a fallback font? How common is this for type 0 fonts?
+        return Error::malformed_error("CIDFontType0: missing FontFile3");
+    }
+
+    // FIXME: The FIXMEs in draw_glyph() also apply here.
+    auto char_name = ByteString::formatted("{}", cid);
+    path.move_to(point);
+    m_font_program->append_glyph_path_to(path, char_name, width);
+    return {};
 }
 
 class CIDFontType2 : public CIDFontType {

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -451,7 +451,8 @@ void Type0Font::set_font_size(float font_size)
     m_cid_font_type->set_font_size(font_size);
 }
 
-PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, ByteString const& string, Renderer const& renderer)
+template<typename Callback>
+PDFErrorOr<Gfx::FloatPoint> Type0Font::for_each_glyph_position(Gfx::FloatPoint glyph_position, ByteString const& string, Renderer const& renderer, Callback callback)
 {
     // Type0 fonts map bytes to character IDs ("CIDs"), and then CIDs to glyphs.
 
@@ -462,14 +463,7 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::F
     //  if no match is found, a second byte shall be extracted, and the 2-byte code shall be matched against 2-byte
     //  codespace ranges [...]"
 
-    auto horizontal_scaling = renderer.text_state().horizontal_scaling;
-
-    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
-
-    // TrueType fonts are prescaled to text_rendering_matrix.x_scale() * text_state().font_size / horizontal_scaling,
-    // cf `Renderer::text_set_font()`. That's the width we get back from `get_glyph_width()` if we use a fallback
-    // (or built-in) font. Scale the width size too, so the m_width.get() codepath is consistent.
-    auto const font_size = text_rendering_matrix.x_scale() * renderer.text_state().font_size / horizontal_scaling;
+    auto const font_size = renderer.text_state().font_size;
 
     auto character_spacing = renderer.text_state().character_spacing;
     auto word_spacing = renderer.text_state().word_spacing;
@@ -497,27 +491,22 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::F
         if (writing_mode == WritingMode::Vertical) {
             if (auto metric = m_vertical_metrics.get(cid); metric.has_value()) {
                 vertical_metric = metric.value();
-                vertical_displacement_vector_y = renderer.text_state().font_size * vertical_metric.vertical_displacement_vector_y / 1000.0f;
+                vertical_displacement_vector_y = font_size * vertical_metric.vertical_displacement_vector_y / 1000.0f;
                 position_vector_x = vertical_metric.position_vector_x / 1000.0f;
                 position_vector_y = vertical_metric.position_vector_y / 1000.0f;
             } else {
-                vertical_displacement_vector_y = renderer.text_state().font_size * m_default_displacement_vector_y / 1000.0f;
+                vertical_displacement_vector_y = font_size * m_default_displacement_vector_y / 1000.0f;
                 position_vector_x = glyph_width / 2.0f / font_size;
                 position_vector_y = m_default_position_vector_y / 1000.0f;
             }
         }
 
-        if (renderer.text_state().rendering_mode != TextRenderingMode::Invisible || renderer.show_hidden_text()) {
-            Gfx::FloatPoint glyph_render_position = text_rendering_matrix.map(glyph_position - Gfx::FloatPoint { position_vector_x, position_vector_y });
-            TRY(m_cid_font_type->draw_glyph(painter, glyph_render_position, glyph_width, cid, renderer));
-        }
+        if (renderer.text_state().rendering_mode != TextRenderingMode::Invisible || renderer.show_hidden_text())
+            TRY(callback(glyph_position - Gfx::FloatPoint { position_vector_x, position_vector_y }, glyph_width, cid));
 
-        // glyph_width is scaled by `text_rendering_matrix.x_scale() * renderer.text_state().font_size / horizontal_scaling`,
-        // but it should only be scaled by `renderer.text_state().font_size`.
-        // FIXME: Having to divide here isn't pretty. Refactor things so that this isn't needed.
         float displacement;
         if (writing_mode == WritingMode::Horizontal)
-            displacement = glyph_width / text_rendering_matrix.x_scale() * horizontal_scaling;
+            displacement = glyph_width;
         else
             displacement = vertical_displacement_vector_y;
         displacement += character_spacing;
@@ -537,6 +526,37 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::F
             glyph_position += { 0.0f, displacement };
     }
     return glyph_position;
+}
+
+PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
+{
+    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
+    // Fast path: Use cached bitmap glyphs.
+    if (text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes))
+        return draw_axis_aligned_glyphs(painter, position, string, renderer);
+    // Slow path: Create a Gfx::Path for the string, transform it, then draw it. This handles arbitrary transforms.
+    if (auto end_position = draw_transformed_glyphs(painter, position, string, renderer); !end_position.is_error())
+        return end_position;
+    // Fallback to axis aligned glyphs in case `append_path` is unimplemented. This won't look correct.
+    return draw_axis_aligned_glyphs(painter, position, string, renderer);
+}
+
+PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_transformed_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&)
+{
+    // FIXME: Implement.
+    return Error::rendering_unsupported_error("Type0 font: drawing transformed glyphs not yet implemented");
+}
+
+PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_axis_aligned_glyphs(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
+{
+    auto horizontal_scaling = renderer.text_state().horizontal_scaling;
+    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
+    return for_each_glyph_position(position, string, renderer, [&](Gfx::FloatPoint glyph_position, float glyph_width, u32 cid) {
+        Gfx::FloatPoint glyph_render_position = text_rendering_matrix.map(glyph_position);
+        // Glyph width is in terms of the `renderer.text_state().font_size`, so we need to scale it to the render size.
+        glyph_width *= text_rendering_matrix.x_scale() / horizontal_scaling;
+        return m_cid_font_type->draw_glyph(painter, glyph_render_position, glyph_width, cid, renderer);
+    });
 }
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -17,6 +17,7 @@ class CIDFontType {
 public:
     virtual ~CIDFontType() = default;
     virtual PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float width, u32 cid, Renderer const&) = 0;
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u32 cid) = 0;
     virtual void set_font_size(float) = 0;
 };
 
@@ -25,6 +26,7 @@ public:
     static PDFErrorOr<NonnullOwnPtr<CIDFontType0>> create(Document*, NonnullRefPtr<DictObject> const& descendant);
 
     virtual PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float width, u32 cid, Renderer const&) override;
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u32 cid) override;
 
     virtual void set_font_size(float) override { }
 
@@ -109,11 +111,17 @@ PDFErrorOr<void> CIDFontType0::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
     return {};
 }
 
+PDFErrorOr<void> CIDFontType0::append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u32)
+{
+    return Error::rendering_unsupported_error("Type0 font CIDFontType0: append_glyph_path not yet implemented");
+}
+
 class CIDFontType2 : public CIDFontType {
 public:
     static PDFErrorOr<NonnullOwnPtr<CIDFontType2>> create(Document*, NonnullRefPtr<DictObject> const& descendant, float font_size);
 
     virtual PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float width, u32 cid, Renderer const&) override;
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u32 cid) override;
 
     virtual void set_font_size(float) override;
 
@@ -223,6 +231,11 @@ PDFErrorOr<void> CIDFontType2::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
 
     painter.draw_glyph(position, char_code, *m_font, color);
     return {};
+}
+
+PDFErrorOr<void> CIDFontType2::append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u32)
+{
+    return Error::rendering_unsupported_error("Type0 font CIDFontType0: append_glyph_path not yet implemented");
 }
 
 void CIDFontType2::set_font_size(float font_size)
@@ -528,12 +541,28 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::for_each_glyph_position(Gfx::FloatPoint g
     return glyph_position;
 }
 
+PDFErrorOr<Gfx::FloatPoint> Type0Font::append_text_path(Gfx::Path& path, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
+{
+    auto horizontal_scaling = renderer.text_state().horizontal_scaling;
+    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
+    return for_each_glyph_position(position, string, renderer, [&](Gfx::FloatPoint glyph_position, float glyph_width, u32 cid) {
+        // The glyph position is in terms of the `renderer.text_state().font_size`, so we need to scale it to the requested font size.
+        glyph_width *= text_rendering_matrix.x_scale() / horizontal_scaling;
+        return m_cid_font_type->append_glyph_path(path, glyph_position.scaled(text_rendering_matrix.x_scale() / horizontal_scaling, 1), glyph_width, cid);
+    });
+}
+
 PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
 {
     auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
     // Fast path: Use cached bitmap glyphs.
     if (text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes))
         return draw_axis_aligned_glyphs(painter, position, string, renderer);
+
+    // FIXME: Make the vector path work for vertical writing mode, see e.g. 0000552.pdf.
+    if (m_cmap->writing_mode() == WritingMode::Vertical)
+        return draw_axis_aligned_glyphs(painter, position, string, renderer);
+
     // Slow path: Create a Gfx::Path for the string, transform it, then draw it. This handles arbitrary transforms.
     if (auto end_position = draw_transformed_glyphs(painter, position, string, renderer); !end_position.is_error())
         return end_position;
@@ -541,10 +570,28 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::F
     return draw_axis_aligned_glyphs(painter, position, string, renderer);
 }
 
-PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_transformed_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&)
+PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_transformed_glyphs(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
 {
-    // FIXME: Implement.
-    return Error::rendering_unsupported_error("Type0 font: drawing transformed glyphs not yet implemented");
+    Gfx::Path text_path;
+    Gfx::AntiAliasingPainter aa_painter(painter);
+    auto horizontal_scaling = renderer.text_state().horizontal_scaling;
+    auto text_rendering_matrix = renderer.calculate_text_rendering_matrix();
+    auto end_position = TRY(append_text_path(text_path, position, string, renderer));
+    // FIXME: This is a bit janky, but the font is already scaled by `m_text_rendering_matrix.x_scale() / horizontal_scaling`,
+    // which is included in `m_text_rendering_matrix`. So, we must scale it by the reciprocal. Also, the y-axis is flipped.
+    text_path.transform(text_rendering_matrix.multiply(
+        Gfx::AffineTransform {}
+            .set_scale(1 / text_rendering_matrix.x_scale() * horizontal_scaling,
+                -1 / text_rendering_matrix.x_scale() * horizontal_scaling)));
+    TRY(renderer.state().paint_color.visit(
+        [&](Color const& color) -> PDFErrorOr<void> {
+            Renderer::fill_path_with_color(aa_painter, text_path, color);
+            return {};
+        },
+        [&](NonnullRefPtr<Pattern> const&) -> PDFErrorOr<void> {
+            return Error::rendering_unsupported_error("Cannot draw text with a pattern yet");
+        }));
+    return end_position;
 }
 
 PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_axis_aligned_glyphs(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -242,9 +242,17 @@ PDFErrorOr<void> CIDFontType2::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
     return {};
 }
 
-PDFErrorOr<void> CIDFontType2::append_glyph_path(Gfx::Path&, Gfx::FloatPoint, float, u32)
+PDFErrorOr<void> CIDFontType2::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float, u32 code_point)
 {
-    return Error::rendering_unsupported_error("Type0 font CIDFontType0: append_glyph_path not yet implemented");
+    if (!m_font) {
+        // FIXME: Should we use a fallback font? How common is this for type 0 fonts?
+        return Error::malformed_error("CIDFontType2: missing FontFile2");
+    }
+
+    auto glyph_id = m_font->glyph_id_for_code_point(code_point);
+    path.move_to(point.translated(m_font->glyph_metrics(glyph_id).left_side_bearing, -m_font->pixel_metrics().ascent));
+    m_font->append_glyph_path_to(path, glyph_id);
+    return {};
 }
 
 void CIDFontType2::set_font_size(float font_size)

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -63,6 +63,12 @@ protected:
 private:
     float get_char_width(u16 char_code) const;
 
+    template<typename Callback>
+    PDFErrorOr<Gfx::FloatPoint> for_each_glyph_position(Gfx::FloatPoint, ByteString const&, Renderer const&, Callback callback);
+
+    PDFErrorOr<Gfx::FloatPoint> draw_transformed_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
+    PDFErrorOr<Gfx::FloatPoint> draw_axis_aligned_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
+
     DeprecatedFlyString m_base_font_name;
     CIDSystemInfo m_system_info;
     HashMap<u16, u16> m_widths;

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -66,6 +66,7 @@ private:
     template<typename Callback>
     PDFErrorOr<Gfx::FloatPoint> for_each_glyph_position(Gfx::FloatPoint, ByteString const&, Renderer const&, Callback callback);
 
+    PDFErrorOr<Gfx::FloatPoint> append_text_path(Gfx::Path&, Gfx::FloatPoint, ByteString const&, Renderer const&);
     PDFErrorOr<Gfx::FloatPoint> draw_transformed_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
     PDFErrorOr<Gfx::FloatPoint> draw_axis_aligned_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -149,10 +149,10 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
     return {};
 }
 
-PDFErrorOr<void> Type1Font::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float width, u8 char_code, Renderer const& renderer)
+PDFErrorOr<void> Type1Font::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float width, u8 char_code)
 {
     if (!m_font_program)
-        return m_fallback_font_painter->append_glyph_path(path, point, char_code, renderer);
+        return m_fallback_font_painter->append_glyph_path(path, point, char_code);
 
     auto char_name = char_name_for_char_code(char_code);
     path.move_to(point);

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -27,7 +27,7 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) override;
 
-    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) override;
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, float width, u8 char_code) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 


### PR DESCRIPTION
This does for Type0 what a subset of commits 2 and 3 of https://github.com/SerenityOS/serenity/pull/26292
(https://github.com/SerenityOS/serenity/commit/1892b09b9f6b0e9d442a60fbe8cba13be343fe16 / https://github.com/SerenityOS/serenity/commit/4bd3d4bf954b526c6a85647c3965debefb8ea580) did for SimpleFont:

The core logic of Type0Font::draw_string() moves into a new
method Type0Font::for_each_glyph_position(), and the existing
code calls that from a new `Type0Font::draw_axis_aligned_glyphs()`.

for_each_glyph_position() no longer works in prescaled units,
since SimpleFont no longer does that after https://github.com/SerenityOS/serenity/pull/26292 either.
(SimpleFont had to keep `font_scale` for fallback widths or
built-in fonts, but it rescaled units to limit that to a small
corner case, and that corner case does not exist in Type0 fonts,
so we get to simplify more.)

Type0Font::draw_transformed_glyphs delegates to CIDFontType::append_glyph_path().

CIDFontType0::append_glyph_path is very similar to the Type1 implementation in
0ac7f5228f6bce from #26954.

CIDFontType2::append_glyph_path calls the TrueType codepath, see #26292.

Except for vertical type0 fonts, we can now draw rotated or skewed fonts for all font types :^)