### PR TITLE
LibC: Support the 'x' mode in the fopen family

### DIFF
--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -1059,6 +1059,9 @@ static int parse_mode(char const* mode)
         case 't':
             // Ok...
             break;
+        case 'x':
+            flags |= O_EXCL;
+            break;
         default:
             dbgln("Potentially unsupported fopen mode _{}_ (because of '{}')", mode, *ptr);
         }


### PR DESCRIPTION
This fixes the following libcxx tests:
std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp