### PR TITLE
LibC: Make Dr. Posix happy with stdio.h

### DIFF
--- a/Userland/Libraries/LibC/stdio.h
+++ b/Userland/Libraries/LibC/stdio.h
@@ -21,6 +21,7 @@
 
 #define FILENAME_MAX 1024
 #define FOPEN_MAX 1024
+#define TMP_MAX 1000
 
 __BEGIN_DECLS
 #ifndef EOF

--- a/Userland/Libraries/LibC/stdio.h
+++ b/Userland/Libraries/LibC/stdio.h
@@ -35,9 +35,16 @@ __BEGIN_DECLS
 #define L_tmpnam 256
 #define P_tmpdir "/tmp"
 
+// "The <stdio.h> header shall define the following macros which shall expand to expressions
+// of type "pointer to FILE" that point to the FILE objects associated, respectively, with
+// the standard error, input, and output streams:"
 extern FILE* stdin;
 extern FILE* stdout;
 extern FILE* stderr;
+
+#define stdin stdin
+#define stdout stdout
+#define stderr stderr
 
 typedef off_t fpos_t;
 


### PR DESCRIPTION
See individual commits for details.

Fixes libcxx's std/input.output/file.streams/c.files/cstdio.pass.cpp