### PR TITLE
LibLine+Shell: Random fixes

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2021-2026, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -207,10 +207,11 @@ void Editor::ensure_free_lines_from_origin(size_t count)
         // FIXME: Implement paging
     }
 
-    if (m_origin_row + count <= m_num_lines)
+    // Ignore requests asking to go beyond the bottom of the terminal.
+    if (m_origin_row + count - 1 <= m_num_lines)
         return;
 
-    auto diff = m_origin_row + count - m_num_lines - 1;
+    auto diff = m_origin_row + count - 1 - m_num_lines;
     out(stderr, "\x1b[{}S", diff);
     fflush(stderr);
     m_origin_row -= diff;
@@ -974,6 +975,10 @@ ErrorOr<void> Editor::handle_read_event()
             case '[':
                 m_state = InputState::CSIExpectParameter;
                 continue;
+            case 'O':
+                // ^[O: single-shift 3; DECCKM mode ends up spewing these when the terminal is in application cursor keys mode.
+                m_state = InputState::SS3ExpectFinal;
+                continue;
             default: {
                 m_callback_machine.key_pressed(*this, { code_point, Key::Alt });
                 m_state = InputState::Free;
@@ -981,6 +986,40 @@ ErrorOr<void> Editor::handle_read_event()
                 continue;
             }
             }
+        case InputState::SS3ExpectFinal: {
+            m_state = m_previous_free_state;
+            if (m_state == InputState::Paste) {
+                // Not an actual control sequence; treat it as pasted data.
+                insert('\x1b');
+                insert('O');
+                insert(code_point);
+                continue;
+            }
+            TRY(cleanup_suggestions());
+            switch (code_point) {
+            case 'A': // ^[OA: arrow up
+                search_backwards();
+                continue;
+            case 'B': // ^[OB: arrow down
+                search_forwards();
+                continue;
+            case 'C': // ^[OC: arrow right
+                cursor_right_character();
+                continue;
+            case 'D': // ^[OD: arrow left
+                cursor_left_character();
+                continue;
+            case 'H': // ^[OH: home
+                go_home();
+                continue;
+            case 'F': // ^[OF: end
+                go_end();
+                continue;
+            default:
+                dbgln("LibLine: Unhandled SS3: {:02x} ({:c})", code_point, code_point);
+                continue;
+            }
+        }
         case InputState::CSIExpectParameter:
             if (code_point >= 0x30 && code_point <= 0x3f) { // '0123456789:;<=>?'
                 csi_parameter_bytes.append(code_point);
@@ -1290,13 +1329,10 @@ ErrorOr<void> Editor::handle_read_event()
         insert(code_point);
     }
 
-    if (consumed_code_points == valid_bytes) {
-        m_incomplete_data.clear();
-    } else {
-        auto bytes_to_drop = input_view.byte_offset_of(consumed_code_points + 1);
-        for (size_t i = 0; i < bytes_to_drop; ++i)
-            m_incomplete_data.take_first();
-    }
+    // Drop whatever we've just consumed.
+    auto bytes_to_drop = input_view.byte_offset_of(consumed_code_points);
+    for (size_t i = 0; i < bytes_to_drop; ++i)
+        m_incomplete_data.take_first();
 
     if (!m_incomplete_data.is_empty() && !m_finish)
         deferred_invoke([&] { try_update_once().release_value_but_fixme_should_propagate_errors(); });
@@ -1656,7 +1692,8 @@ ErrorOr<void> Editor::reposition_cursor(Stream& stream, bool to_end)
     auto line = cursor_line() - 1;
     auto column = offset_in_line();
 
-    ensure_free_lines_from_origin(line);
+    // The cursor is 0-based, so we need _line + 1_ lines available.
+    ensure_free_lines_from_origin(line + 1);
 
     VERIFY(column + m_origin_column <= m_num_columns);
     TRY(VT::move_absolute(line + m_origin_row, column + m_origin_column, stream));

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -2137,7 +2137,7 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
     if (m_input_error.has_value())
         return m_input_error.value();
 
-    fputs("\033[6n\n", stderr);
+    fputs("\033[6n", stderr);
     fflush(stderr);
 
     // Parse the DSR response

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -490,6 +490,7 @@ private:
         Verbatim,
         Paste,
         GotEscape,
+        SS3ExpectFinal,
         CSIExpectParameter,
         CSIExpectIntermediate,
         CSIExpectFinal,

--- a/Userland/Libraries/LibShell/Builtin.cpp
+++ b/Userland/Libraries/LibShell/Builtin.cpp
@@ -838,8 +838,11 @@ ErrorOr<int> Shell::builtin_fg(Main::Arguments arguments)
     job->set_running_in_background(false);
     job->set_shell_did_continue(true);
 
-    dbgln("Resuming {} ({})", job->pid(), job->cmd());
     warnln("Resuming job {} - {}", job->job_id(), job->cmd());
+
+    // Restore the terminal state the program expects to be in.
+    if (auto const& termios = job->saved_termios(); termios.has_value())
+        tcsetattr(0, TCSANOW, &termios.value());
 
     tcsetpgrp(STDOUT_FILENO, job->pgid());
     tcsetpgrp(STDIN_FILENO, job->pgid());

--- a/Userland/Libraries/LibShell/Job.h
+++ b/Userland/Libraries/LibShell/Job.h
@@ -16,6 +16,7 @@
 #include <AK/OwnPtr.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/EventReceiver.h>
+#include <termios.h>
 
 namespace Shell {
 
@@ -73,6 +74,9 @@ public:
     void set_is_suspended(bool value) const { m_is_suspended = value; }
     void set_shell_did_continue(bool value) const { m_shell_did_continue = value; }
 
+    Optional<struct termios> const& saved_termios() const { return m_saved_termios; }
+    void set_saved_termios(struct termios const& value) const { m_saved_termios = value; }
+
     void set_running_in_background(bool running_in_background)
     {
         m_running_in_background = running_in_background;
@@ -108,6 +112,7 @@ private:
     mutable bool m_active { true };
     mutable bool m_is_suspended { false };
     mutable bool m_shell_did_continue { false };
+    mutable Optional<struct termios> m_saved_termios;
     bool m_should_be_disowned { false };
     OwnPtr<AST::Command> m_command;
 };

--- a/Userland/Libraries/LibShell/Shell.cpp
+++ b/Userland/Libraries/LibShell/Shell.cpp
@@ -63,6 +63,9 @@ void Shell::setup_signals()
             auto job = current_job();
             kill_job(job, SIGTSTP);
             if (job) {
+                struct termios job_termios;
+                if (tcgetattr(0, &job_termios) == 0)
+                    job->set_saved_termios(job_termios);
                 job->set_is_suspended(true);
                 job->unblock();
             }
@@ -2291,6 +2294,9 @@ void Shell::notify_child_event()
                 } else if (WIFEXITED(wstatus)) {
                     job.set_has_exit(WEXITSTATUS(wstatus));
                 } else if (WIFSTOPPED(wstatus)) {
+                    struct termios job_termios;
+                    if (tcgetattr(0, &job_termios) == 0)
+                        job.set_saved_termios(job_termios);
                     job.unblock();
                     job.set_is_suspended(true);
                 }


### PR DESCRIPTION
Is that? a Shell bug? nah can't be.

- No more broken prompts when typing past the column limit or ^C'ing on the bottom row
- programs that annoyingly leave DECCKM on no longer destroy the terminal
- Stop putting junk after DSR request so we can stop crashing ourselves in ghostty.