### PR TITLE
LibC: Add missing definitions in stdint.h and inttypes.h

### DIFF
--- a/Userland/Libraries/LibC/bits/stdint.h
+++ b/Userland/Libraries/LibC/bits/stdint.h
@@ -138,4 +138,21 @@ typedef __INTMAX_TYPE__ intmax_t;
 #define PTRDIFF_MAX __PTRDIFF_MAX__
 #define PTRDIFF_MIN (-__PTRDIFF_MAX__ - 1)
 
+// "If sig_atomic_t (see the <signal.h> header) is defined as a signed integer type,
+// the value of {SIG_ATOMIC_MIN} shall be no greater than -127 and the value of {SIG_ATOMIC_MAX}
+// shall be no less than 127; otherwise, sig_atomic_t shall be defined as an unsigned integer
+// type, and the value of {SIG_ATOMIC_MIN} shall be 0 and the value of {SIG_ATOMIC_MAX} shall
+// be no less than 255.
+
+#define SIG_ATOMIC_MIN 0
+#define SIG_ATOMIC_MAX UINT32_MAX
+
+// "If wint_t (see the <wchar.h> header) is defined as a signed integer type, the value
+// of {WINT_MIN} shall be no greater than -32767 and the value of {WINT_MAX} shall be no
+// less than 32767; otherwise, wint_t shall be defined as an unsigned integer type, and
+// the value of {WINT_MIN} shall be 0 and the value of {WINT_MAX} shall be no less than 65535.
+
+#define WINT_MIN 0
+#define WINT_MAX UINT32_MAX
+
 __END_DECLS

--- a/Userland/Libraries/LibC/inttypes.cpp
+++ b/Userland/Libraries/LibC/inttypes.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
+#include <AK/Format.h>
 #include <AK/NumericLimits.h>
 #include <errno.h>
 #include <inttypes.h>
@@ -58,5 +60,17 @@ uintmax_t strtoumax(char const* str, char** endptr, int base)
     }
 
     return ulong_value;
+}
+
+intmax_t wcstoimax(wchar_t const*, wchar_t**, int)
+{
+    dbgln("FIXME: Implement wcstoimax()");
+    TODO();
+}
+
+uintmax_t wcstoumax(wchar_t const*, wchar_t**, int)
+{
+    dbgln("FIXME: Implement wcstoumax()");
+    TODO();
 }
 }

--- a/Userland/Libraries/LibC/inttypes.h
+++ b/Userland/Libraries/LibC/inttypes.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <bits/stdint.h>
+#include <stddef.h>
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
@@ -201,5 +202,7 @@ imaxdiv_t imaxdiv(intmax_t, intmax_t);
 
 intmax_t strtoimax(char const*, char** endptr, int base);
 uintmax_t strtoumax(char const*, char** endptr, int base);
+intmax_t wcstoimax(wchar_t const*, wchar_t**, int);
+uintmax_t wcstoumax(wchar_t const*, wchar_t**, int);
 
 __END_DECLS


### PR DESCRIPTION
This fixes libcxx's
std/input.output/file.streams/c.files/cinttypes.pass.cpp