### PR TITLE
LibPDF: Add support for text rendering modes

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -102,9 +102,8 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::append_text_path(Gfx::Path& path, Gfx::F
 
 PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
 {
-    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
     // Fast path: Use cached bitmap glyphs.
-    if (text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes))
+    if (!renderer.needs_vector_glyphs_for_current_text())
         return draw_axis_aligned_glyphs(painter, position, string, renderer);
     // Slow path: Create a Gfx::Path for the string, transform it, then draw it. This handles arbitrary transforms.
     if (auto end_position = draw_transformed_glyphs(position, string, renderer); !end_position.is_error())

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -107,16 +107,15 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::
     if (text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes))
         return draw_axis_aligned_glyphs(painter, position, string, renderer);
     // Slow path: Create a Gfx::Path for the string, transform it, then draw it. This handles arbitrary transforms.
-    if (auto end_position = draw_transformed_glyphs(painter, position, string, renderer); !end_position.is_error())
+    if (auto end_position = draw_transformed_glyphs(position, string, renderer); !end_position.is_error())
         return end_position;
     // Fallback to axis aligned glyphs in case `append_path` is unimplemented. This won't look correct.
     return draw_axis_aligned_glyphs(painter, position, string, renderer);
 }
 
-PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_transformed_glyphs(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
+PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_transformed_glyphs(Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
 {
     Gfx::Path text_path;
-    Gfx::AntiAliasingPainter aa_painter(painter);
     auto horizontal_scaling = renderer.text_state().horizontal_scaling;
     auto text_rendering_matrix = renderer.calculate_text_rendering_matrix();
     auto end_position = TRY(append_text_path(text_path, position, string, renderer));
@@ -126,14 +125,7 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_transformed_glyphs(Gfx::Painter& pa
         Gfx::AffineTransform {}
             .set_scale(1 / text_rendering_matrix.x_scale() * horizontal_scaling,
                 -1 / text_rendering_matrix.x_scale() * horizontal_scaling)));
-    TRY(renderer.state().paint_color.visit(
-        [&](Color const& color) -> PDFErrorOr<void> {
-            Renderer::fill_path_with_color(aa_painter, text_path, color);
-            return {};
-        },
-        [&](NonnullRefPtr<Pattern> const&) -> PDFErrorOr<void> {
-            return Error::rendering_unsupported_error("Cannot draw text with a pattern yet");
-        }));
+    TRY(const_cast<Renderer&>(renderer).paint_text_glyphs(text_path));
     return end_position;
 }
 

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -35,7 +35,7 @@ private:
     PDFErrorOr<Gfx::FloatPoint> for_each_glyph_position(Gfx::FloatPoint, ByteString const&, Renderer const&, Callback callback);
 
     PDFErrorOr<Gfx::FloatPoint> append_text_path(Gfx::Path&, Gfx::FloatPoint, ByteString const&, Renderer const&);
-    PDFErrorOr<Gfx::FloatPoint> draw_transformed_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
+    PDFErrorOr<Gfx::FloatPoint> draw_transformed_glyphs(Gfx::FloatPoint, ByteString const&, Renderer const&);
     PDFErrorOr<Gfx::FloatPoint> draw_axis_aligned_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
 
     RefPtr<Encoding> m_encoding;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -143,7 +143,8 @@ PDFErrorOr<void> TrueTypePainter::draw_glyph(Gfx::Painter& painter, Gfx::FloatPo
                 return {};
             },
             [&](NonnullRefPtr<Pattern> const&) -> PDFErrorOr<void> {
-                return Error::rendering_unsupported_error("Cannot draw TrueType glyph with a pattern yet");
+                // Renderer::needs_vector_glyphs_for_current_text() should always return true for pattern text fills.
+                VERIFY_NOT_REACHED();
             }));
     }
     return {};

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -575,11 +575,6 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::F
     // Fast path: Use cached bitmap glyphs.
     if (text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes))
         return draw_axis_aligned_glyphs(painter, position, string, renderer);
-
-    // FIXME: Make the vector path work for vertical writing mode, see e.g. 0000552.pdf.
-    if (m_cmap->writing_mode() == WritingMode::Vertical)
-        return draw_axis_aligned_glyphs(painter, position, string, renderer);
-
     // Slow path: Create a Gfx::Path for the string, transform it, then draw it. This handles arbitrary transforms.
     if (auto end_position = draw_transformed_glyphs(painter, position, string, renderer); !end_position.is_error())
         return end_position;
@@ -589,6 +584,10 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::F
 
 PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_transformed_glyphs(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
 {
+    // FIXME: Make the vector path work for vertical writing mode, see e.g. 0000552.pdf.
+    if (m_cmap->writing_mode() == WritingMode::Vertical)
+        return Error::rendering_unsupported_error("Type0 font: getting vector path for vertical writing mode not yet implemented");
+
     Gfx::Path text_path;
     Gfx::AntiAliasingPainter aa_painter(painter);
     auto horizontal_scaling = renderer.text_state().horizontal_scaling;

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -576,20 +576,19 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::F
     if (text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes))
         return draw_axis_aligned_glyphs(painter, position, string, renderer);
     // Slow path: Create a Gfx::Path for the string, transform it, then draw it. This handles arbitrary transforms.
-    if (auto end_position = draw_transformed_glyphs(painter, position, string, renderer); !end_position.is_error())
+    if (auto end_position = draw_transformed_glyphs(position, string, renderer); !end_position.is_error())
         return end_position;
     // Fallback to axis aligned glyphs in case `append_path` is unimplemented. This won't look correct.
     return draw_axis_aligned_glyphs(painter, position, string, renderer);
 }
 
-PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_transformed_glyphs(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
+PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_transformed_glyphs(Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
 {
     // FIXME: Make the vector path work for vertical writing mode, see e.g. 0000552.pdf.
     if (m_cmap->writing_mode() == WritingMode::Vertical)
         return Error::rendering_unsupported_error("Type0 font: getting vector path for vertical writing mode not yet implemented");
 
     Gfx::Path text_path;
-    Gfx::AntiAliasingPainter aa_painter(painter);
     auto horizontal_scaling = renderer.text_state().horizontal_scaling;
     auto text_rendering_matrix = renderer.calculate_text_rendering_matrix();
     auto end_position = TRY(append_text_path(text_path, position, string, renderer));
@@ -599,14 +598,7 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_transformed_glyphs(Gfx::Painter& pai
         Gfx::AffineTransform {}
             .set_scale(1 / text_rendering_matrix.x_scale() * horizontal_scaling,
                 -1 / text_rendering_matrix.x_scale() * horizontal_scaling)));
-    TRY(renderer.state().paint_color.visit(
-        [&](Color const& color) -> PDFErrorOr<void> {
-            Renderer::fill_path_with_color(aa_painter, text_path, color);
-            return {};
-        },
-        [&](NonnullRefPtr<Pattern> const&) -> PDFErrorOr<void> {
-            return Error::rendering_unsupported_error("Cannot draw text with a pattern yet");
-        }));
+    TRY(const_cast<Renderer&>(renderer).paint_text_glyphs(text_path));
     return end_position;
 }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -571,9 +571,8 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::append_text_path(Gfx::Path& path, Gfx::Fl
 
 PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::FloatPoint position, ByteString const& string, Renderer const& renderer)
 {
-    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
     // Fast path: Use cached bitmap glyphs.
-    if (text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes))
+    if (!renderer.needs_vector_glyphs_for_current_text())
         return draw_axis_aligned_glyphs(painter, position, string, renderer);
     // Slow path: Create a Gfx::Path for the string, transform it, then draw it. This handles arbitrary transforms.
     if (auto end_position = draw_transformed_glyphs(position, string, renderer); !end_position.is_error())

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -67,7 +67,7 @@ private:
     PDFErrorOr<Gfx::FloatPoint> for_each_glyph_position(Gfx::FloatPoint, ByteString const&, Renderer const&, Callback callback);
 
     PDFErrorOr<Gfx::FloatPoint> append_text_path(Gfx::Path&, Gfx::FloatPoint, ByteString const&, Renderer const&);
-    PDFErrorOr<Gfx::FloatPoint> draw_transformed_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
+    PDFErrorOr<Gfx::FloatPoint> draw_transformed_glyphs(Gfx::FloatPoint, ByteString const&, Renderer const&);
     PDFErrorOr<Gfx::FloatPoint> draw_axis_aligned_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
 
     DeprecatedFlyString m_base_font_name;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -121,7 +121,8 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
             return color;
         },
         [&](NonnullRefPtr<Pattern> const&) -> PDFErrorOr<Color> {
-            return Error::rendering_unsupported_error("Cannot draw type1 glyph with a pattern yet");
+            // Renderer::needs_vector_glyphs_for_current_text() should always return true for pattern text fills.
+            VERIFY_NOT_REACHED();
         }));
 
     if (!m_font_program)

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1905,6 +1905,9 @@ Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const
 
 bool Renderer::needs_vector_glyphs_for_current_text() const
 {
+    if (!state().paint_color.has<Color>())
+        return true;
+
     auto const& text_rendering_matrix = calculate_text_rendering_matrix();
     // Fast path: Use cached bitmap glyphs.
     return !text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes);
@@ -1912,14 +1915,7 @@ bool Renderer::needs_vector_glyphs_for_current_text() const
 
 PDFErrorOr<void> Renderer::paint_text_glyphs(Gfx::Path const& text_path)
 {
-    TRY(state().paint_color.visit(
-        [&](Color const& color) -> PDFErrorOr<void> {
-            Renderer::fill_path_with_color(anti_aliasing_painter(), text_path, color);
-            return {};
-        },
-        [&](NonnullRefPtr<Pattern> const&) -> PDFErrorOr<void> {
-            return Error::rendering_unsupported_error("Cannot draw text with a pattern yet");
-        }));
+    TRY(fill_path(text_path, Gfx::WindingRule::Nonzero));
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -602,6 +602,7 @@ RENDERER_HANDLER(path_intersect_clip_evenodd)
 
 RENDERER_HANDLER(text_begin)
 {
+    m_clip_from_text.clear();
     m_text_matrix = Gfx::AffineTransform();
     m_text_line_matrix = Gfx::AffineTransform();
     m_text_rendering_matrix_is_dirty = true;
@@ -610,7 +611,10 @@ RENDERER_HANDLER(text_begin)
 
 RENDERER_HANDLER(text_end)
 {
-    // FIXME: Do we need to do anything here?
+    // See comment in paint_text_glyphs().
+    if (!m_clip_from_text.is_empty())
+        TRY(add_clip_path(m_clip_from_text, Gfx::WindingRule::Nonzero));
+    m_clip_from_text.clear();
     return {};
 }
 
@@ -1905,7 +1909,7 @@ Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const
 
 bool Renderer::needs_vector_glyphs_for_current_text() const
 {
-    if (!state().paint_color.has<Color>())
+    if (text_state().rendering_mode != TextRenderingMode::Fill || !state().paint_color.has<Color>())
         return true;
 
     auto const& text_rendering_matrix = calculate_text_rendering_matrix();
@@ -1915,7 +1919,24 @@ bool Renderer::needs_vector_glyphs_for_current_text() const
 
 PDFErrorOr<void> Renderer::paint_text_glyphs(Gfx::Path const& text_path)
 {
-    TRY(fill_path(text_path, Gfx::WindingRule::Nonzero));
+    // 5.2.5 Text Rendering Mode
+    auto const mode = text_state().rendering_mode;
+    using enum TextRenderingMode;
+    if (mode == Fill || mode == FillAndClip)
+        TRY(fill_path(text_path, Gfx::WindingRule::Nonzero));
+    else if (mode == Stroke || mode == StrokeAndClip)
+        TRY(stroke_path(text_path));
+    else if (mode == FillThenStroke || mode == FillStrokeAndClip)
+        TRY(fill_and_stroke_path(text_path, Gfx::WindingRule::Nonzero));
+
+    // "The behavior of the clipping modes requires further explanation. Glyph outlines
+    //  begin accumulating if a BT operator is executed while the text rendering mode is
+    //  set to a clipping mode or if it is set to a clipping mode within a text object. Glyphs
+    //  accumulate until the text object is ended by an ET operator; the text rendering
+    //  mode must not be changed back to a nonclipping mode before that point."
+    if (mode == Clip || mode == FillAndClip || mode == StrokeAndClip || mode == FillStrokeAndClip)
+        m_clip_from_text.append_path(text_path);
+
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1903,6 +1903,13 @@ Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const
     return m_text_rendering_matrix;
 }
 
+bool Renderer::needs_vector_glyphs_for_current_text() const
+{
+    auto const& text_rendering_matrix = calculate_text_rendering_matrix();
+    // Fast path: Use cached bitmap glyphs.
+    return !text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes);
+}
+
 PDFErrorOr<void> Renderer::paint_text_glyphs(Gfx::Path const& text_path)
 {
     TRY(state().paint_color.visit(

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1888,6 +1888,19 @@ Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const
     return m_text_rendering_matrix;
 }
 
+PDFErrorOr<void> Renderer::paint_text_glyphs(Gfx::Path const& text_path)
+{
+    TRY(state().paint_color.visit(
+        [&](Color const& color) -> PDFErrorOr<void> {
+            Renderer::fill_path_with_color(anti_aliasing_painter(), text_path, color);
+            return {};
+        },
+        [&](NonnullRefPtr<Pattern> const&) -> PDFErrorOr<void> {
+            return Error::rendering_unsupported_error("Cannot draw text with a pattern yet");
+        }));
+    return {};
+}
+
 PDFErrorOr<void> Renderer::render_type3_glyph(Gfx::FloatPoint point, StreamObject const& glyph_data, Gfx::AffineTransform const& font_matrix, Optional<NonnullRefPtr<DictObject>> resources)
 {
     ScopedState scoped_state { *this };

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -458,38 +458,48 @@ PDFErrorOr<void> Renderer::fill_path_with_pattern(Gfx::Path const& path, Nonnull
     return pattern->draw(painter(), m_userspace_matrix);
 }
 
-PDFErrorOr<void> Renderer::stroke_current_path()
+PDFErrorOr<void> Renderer::stroke_path(Gfx::Path const& path)
 {
     TRY(state().stroke_color.visit(
         [&](Color const& color) -> PDFErrorOr<void> {
-            anti_aliasing_painter().stroke_path(m_current_path, color, stroke_style());
+            anti_aliasing_painter().stroke_path(path, color, stroke_style());
             return {};
         },
         [&](NonnullRefPtr<Pattern> const& pattern) -> PDFErrorOr<void> {
-            auto stroke_path = m_current_path.stroke_to_fill(stroke_style());
+            auto stroke_path = path.stroke_to_fill(stroke_style());
             return fill_path_with_pattern(stroke_path, pattern, state().stroke_alpha_constant, Gfx::WindingRule::Nonzero);
         }));
     return {};
 }
 
-PDFErrorOr<void> Renderer::fill_current_path(Gfx::WindingRule winding_rule)
+PDFErrorOr<void> Renderer::stroke_current_path()
 {
-    auto path_end = m_current_path.end();
-    m_current_path.close_all_subpaths();
+    return stroke_path(m_current_path);
+}
+
+PDFErrorOr<void> Renderer::fill_path(Gfx::Path const& path, Gfx::WindingRule winding_rule)
+{
+    auto path_end = path.end();
+    const_cast<Gfx::Path&>(path).close_all_subpaths();
     TRY(state().paint_color.visit(
         [&](Color const& color) -> PDFErrorOr<void> {
-            fill_path_with_color(anti_aliasing_painter(), m_current_path, color, winding_rule);
+            fill_path_with_color(anti_aliasing_painter(), path, color, winding_rule);
             return {};
         },
         [&](NonnullRefPtr<Pattern> const& pattern) -> PDFErrorOr<void> {
-            return fill_path_with_pattern(m_current_path, pattern, state().paint_alpha_constant, winding_rule);
+            return fill_path_with_pattern(path, pattern, state().paint_alpha_constant, winding_rule);
         }));
     // .close_all_subpaths() only adds to the end of the path, so we can .trim() the path to remove any changes.
-    m_current_path.trim(path_end);
+    const_cast<Gfx::Path&>(path).trim(path_end);
     return {};
 }
 
-PDFErrorOr<void> Renderer::fill_and_stroke_current_path(Gfx::WindingRule winding_rule)
+PDFErrorOr<void> Renderer::fill_current_path(Gfx::WindingRule winding_rule)
+{
+    return fill_path(m_current_path, winding_rule);
+}
+
+PDFErrorOr<void> Renderer::fill_and_stroke_path(Gfx::Path const& path, Gfx::WindingRule winding_rule)
 {
     // Note: Just drawing the stroke on top of the fill is incorrect if the stroke is not opaque.
     // See "Special Path-Painting Considerations" on page 569 of the PDF 1.7 spec:
@@ -497,9 +507,14 @@ PDFErrorOr<void> Renderer::fill_and_stroke_current_path(Gfx::WindingRule winding
     // (The spec says this in the language of knockout groups.)
     // Having said that, while Acrobat Reader and PDFium get this right, PDF.js and Preview.app do not.
     // FIXME: Once we have support for transparency groups, do this per spec.
-    TRY(fill_current_path(winding_rule));
-    TRY(stroke_current_path());
+    TRY(fill_path(path, winding_rule));
+    TRY(stroke_path(path));
     return {};
+}
+
+PDFErrorOr<void> Renderer::fill_and_stroke_current_path(Gfx::WindingRule winding_rule)
+{
+    return fill_and_stroke_path(m_current_path, winding_rule);
 }
 
 RENDERER_HANDLER(path_stroke)

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -177,6 +177,7 @@ public:
 
     Gfx::AffineTransform const& calculate_text_rendering_matrix() const;
 
+    PDFErrorOr<void> paint_text_glyphs(Gfx::Path const&);
     PDFErrorOr<void> render_type3_glyph(Gfx::FloatPoint, StreamObject const&, Gfx::AffineTransform const&, Optional<NonnullRefPtr<DictObject>>);
 
     bool show_hidden_text() const { return m_rendering_preferences.show_hidden_text; }

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -214,8 +214,11 @@ private:
     void begin_path_paint();
     PDFErrorOr<void> end_path_paint();
     PDFErrorOr<void> fill_path_with_pattern(Gfx::Path const& path, NonnullRefPtr<Pattern> const& pattern, float opacity, Gfx::WindingRule winding_rule);
+    PDFErrorOr<void> stroke_path(Gfx::Path const&);
     PDFErrorOr<void> stroke_current_path();
+    PDFErrorOr<void> fill_path(Gfx::Path const&, Gfx::WindingRule);
     PDFErrorOr<void> fill_current_path(Gfx::WindingRule);
+    PDFErrorOr<void> fill_and_stroke_path(Gfx::Path const&, Gfx::WindingRule);
     PDFErrorOr<void> fill_and_stroke_current_path(Gfx::WindingRule);
     PDFErrorOr<GraphicsState::SMask> read_smask_dict(NonnullRefPtr<DictObject> dict);
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -177,6 +177,7 @@ public:
 
     Gfx::AffineTransform const& calculate_text_rendering_matrix() const;
 
+    bool needs_vector_glyphs_for_current_text() const;
     PDFErrorOr<void> paint_text_glyphs(Gfx::Path const&);
     PDFErrorOr<void> render_type3_glyph(Gfx::FloatPoint, StreamObject const&, Gfx::AffineTransform const&, Optional<NonnullRefPtr<DictObject>>);
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -300,6 +300,7 @@ private:
 
     Gfx::AffineTransform m_userspace_matrix;
     Vector<GraphicsState> m_graphics_state_stack;
+    Gfx::Path m_clip_from_text;
     Gfx::AffineTransform m_text_matrix;
     Gfx::AffineTransform m_text_line_matrix;
 


### PR DESCRIPTION
We can now clip to text paths, and stroke and fill text paths with patterns.

This is fairly straightforward after the vector text work for transforms: The fonts call back into the renderer to do the actual vector path painting (see that commit for some tradeoffs), they ask the renderer which text should use vectors, and the renderer then uses its existing normal clip-to-path and fill-path on the paths generated from text.

With a rebased version of #26133, this gets us from `755 files without issues (75.5%)` to `849 files without issues (84.9%)
` :^)
