### PR TITLE
AK+ls: Prettier colors

### DIFF
--- a/AK/ANSIStyle.cpp
+++ b/AK/ANSIStyle.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026, Eduardo Casadei <educasadei@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ANSIStyle.h>
+#include <AK/StringBuilder.h>
+
+static bool is_color_enabled = true;
+
+namespace AK {
+
+void set_color_enabled(bool value) { is_color_enabled = value; }
+
+ErrorOr<void> Formatter<ANSIStyle>::format(FormatBuilder& builder, ANSIStyle value)
+{
+    bool first = true;
+    auto attribute_separator = [&]() -> ErrorOr<void> {
+        if (!first)
+            TRY(builder.put_literal(";"sv));
+        else
+            first = false;
+
+        return {};
+    };
+
+    if (!value.has_style())
+        return {};
+
+    TRY(builder.put_literal("\e["sv));
+    if (value.m_style != ANSIStyle::Style::None) {
+        if (has_flag(value.m_style, ANSIStyle::Style::Reset)) {
+            TRY(attribute_separator());
+            TRY(builder.put_literal("0"sv));
+        }
+        if (has_flag(value.m_style, ANSIStyle::Style::Bold)) {
+            TRY(attribute_separator());
+            TRY(builder.put_literal("1"sv));
+        }
+        if (has_flag(value.m_style, ANSIStyle::Style::Italic)) {
+            TRY(attribute_separator());
+            TRY(builder.put_literal("3"sv));
+        }
+        if (has_flag(value.m_style, ANSIStyle::Style::Underline)) {
+            TRY(attribute_separator());
+            TRY(builder.put_literal("4"sv));
+        }
+        if (has_flag(value.m_style, ANSIStyle::Style::Blink)) {
+            TRY(attribute_separator());
+            TRY(builder.put_literal("5"sv));
+        }
+        if (has_flag(value.m_style, ANSIStyle::Style::Negative)) {
+            TRY(attribute_separator());
+            TRY(builder.put_literal("7"sv));
+        }
+        if (has_flag(value.m_style, ANSIStyle::Style::Concealed)) {
+            TRY(attribute_separator());
+            TRY(builder.put_literal("8"sv));
+        }
+    }
+    if (value.m_foreground.has_value()) {
+        TRY(attribute_separator());
+        TRY(builder.put_u64(value.m_foreground.value()));
+    }
+    if (value.m_background.has_value()) {
+        TRY(attribute_separator());
+        TRY(builder.put_u64(value.m_background.value() + 10));
+    }
+    TRY(builder.put_literal("m"sv));
+
+    return {};
+}
+
+void ANSIStyle::apply(StringBuilder& builder) const
+{
+    if (is_color_enabled) {
+        builder.appendff("{}", *this);
+    }
+}
+
+void ANSIStyle::apply(FILE* file) const
+{
+    if (is_color_enabled) {
+        out(file, "{}", *this);
+    }
+}
+
+void vout(FILE* file, ANSIStyle ansi_style, StringView fmtstr, TypeErasedFormatParams& params, bool newline)
+{
+    StringBuilder builder;
+    ansi_style.apply(builder);
+    MUST(vformat(builder, fmtstr, params));
+    style(ANSIStyle::Reset).apply(builder);
+
+    if (newline)
+        builder.append('\n');
+
+    auto const string = builder.string_view();
+    auto const retval = ::fwrite(string.characters_without_null_termination(), 1, string.length(), file);
+    if (static_cast<size_t>(retval) != string.length()) {
+        auto error = ferror(file);
+        dbgln("vout() failed ({} written out of {}), error was {} ({})", retval, string.length(), error, strerror(error));
+    }
+}
+}

--- a/AK/ANSIStyle.h
+++ b/AK/ANSIStyle.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026, Eduardo Casadei <educasadei@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/EnumBits.h>
+#include <AK/Format.h>
+#include <AK/Optional.h>
+
+namespace AK {
+
+class ANSIStyle {
+public:
+    enum Color : u8 {
+        Black = 30,
+        Red = 31,
+        Green = 32,
+        Yellow = 33,
+        Blue = 34,
+        Magenta = 35,
+        Cyan = 36,
+        White = 37,
+        Default = 39,
+        BrightBlack = 90,
+        BrightRed = 91,
+        BrightGreen = 92,
+        BrightYellow = 93,
+        BrightBlue = 94,
+        BrightMagenta = 95,
+        BrightCyan = 96,
+        BrightWhite = 97,
+    };
+
+    enum Style : u8 {
+        None = 0,
+        Reset = 1 << 0,
+        Bold = 1 << 1,
+        Italic = 1 << 2,
+        Underline = 1 << 3,
+        Blink = 1 << 4,
+        Negative = 1 << 5,
+        Concealed = 1 << 6
+    };
+    AK_ENUM_BITWISE_FRIEND_OPERATORS(Style);
+
+    constexpr ANSIStyle() = default;
+
+    constexpr ANSIStyle operator|(ANSIStyle other) const
+    {
+        ANSIStyle result = *this;
+        if (other.m_foreground.has_value())
+            result.m_foreground = other.m_foreground;
+        if (other.m_background.has_value())
+            result.m_background = other.m_background;
+
+        result.m_style |= other.m_style;
+
+        return result;
+    }
+
+    bool has_style() const
+    {
+        if (m_style != Style::None)
+            return true;
+        if (m_foreground.has_value())
+            return true;
+        if (m_background.has_value())
+            return true;
+
+        return false;
+    }
+
+    void apply(StringBuilder& file) const;
+    void apply(FILE* file) const;
+
+private:
+    Optional<Color> m_foreground = {};
+    Optional<Color> m_background = {};
+    Style m_style = Style::None;
+
+    friend constexpr ANSIStyle foreground(Color);
+    friend constexpr ANSIStyle background(Color);
+    friend constexpr ANSIStyle style(Style);
+    friend struct AK::Formatter<ANSIStyle>;
+};
+
+constexpr ANSIStyle foreground(ANSIStyle::Color value)
+{
+    ANSIStyle ansi_style;
+    ansi_style.m_foreground = value;
+    return ansi_style;
+}
+
+constexpr ANSIStyle background(ANSIStyle::Color value)
+{
+    ANSIStyle ansi_style;
+    ansi_style.m_background = value;
+    return ansi_style;
+}
+
+constexpr ANSIStyle style(ANSIStyle::Style value)
+{
+    ANSIStyle ansi_style;
+    ansi_style.m_style = value;
+    return ansi_style;
+}
+
+template<>
+struct Formatter<ANSIStyle> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, ANSIStyle value);
+};
+
+void set_color_enabled(bool);
+
+void vout(FILE*, ANSIStyle ansi_style, StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
+
+template<typename... Parameters>
+void out(FILE* file, ANSIStyle ansi_style, CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    VariadicFormatParams<AllowDebugOnlyFormatters::Yes, Parameters...> variadic_format_params { parameters... };
+    vout(file, ansi_style, fmtstr.view(), variadic_format_params);
+}
+
+template<typename... Parameters>
+void outln(FILE* file, ANSIStyle ansi_style, CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    VariadicFormatParams<AllowDebugOnlyFormatters::Yes, Parameters...> variadic_format_params { parameters... };
+    vout(file, ansi_style, fmtstr.view(), variadic_format_params, true);
+}
+
+template<typename... Parameters>
+void out(ANSIStyle ansi_style, CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    out(stdout, ansi_style, move(fmtstr), parameters...);
+}
+
+template<typename... Parameters>
+void outln(ANSIStyle ansi_style, CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    outln(stdout, ansi_style, move(fmtstr), parameters...);
+}
+}
+
+#if USING_AK_GLOBALLY
+using AK::ANSIStyle;
+using AK::out;
+using AK::outln;
+#endif

--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(AK_SOURCES
+    ANSIStyle.cpp
     Assertions.cpp
     Base64.cpp
     ByteString.cpp

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ANSIStyle.h>
 #include <AK/Assertions.h>
 #include <AK/ByteString.h>
 #include <AK/HashMap.h>
@@ -87,7 +88,6 @@ static bool flag_recursive = false;
 static bool flag_force_newline = false;
 
 static size_t terminal_columns = 0;
-static bool output_is_terminal = false;
 
 static HashMap<uid_t, ByteString> users;
 static HashMap<gid_t, ByteString> groups;
@@ -102,7 +102,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     int rc = ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
     if (rc == 0) {
         terminal_columns = ws.ws_col;
-        output_is_terminal = true;
     }
 
     is_a_tty = isatty(STDOUT_FILENO);
@@ -141,6 +140,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_force_newline, "List one file per line", nullptr, '1');
     args_parser.add_positional_argument(paths, "Directory to list", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
+
+    AK::set_color_enabled(flag_colorize);
 
     if (flag_print_numeric || flag_hide_group || flag_hide_owner)
         flag_long = true;
@@ -223,26 +224,40 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     return status;
 }
 
-static int print_escaped(StringView name)
+static int print_escaped(StringView name, ANSIStyle ansi_style)
 {
-    int printed = 0;
+    int nprinted = Utf8View(name).length();
 
-    Utf8View utf8_name(name);
-    if (utf8_name.validate()) {
-        out("{}", name);
-        return utf8_name.length();
-    }
+    ansi_style.apply(stdout);
 
     for (auto c : name) {
-        if (is_ascii_printable(c)) {
-            putchar(c);
-            printed++;
-        } else {
-            printed += printf("\\%03d", c);
+        switch (c) {
+        case '\t':
+            out(foreground(ANSIStyle::Red), "\\t");
+            ansi_style.apply(stdout);
+            nprinted++;
+            continue;
+        case '\n':
+            out(foreground(ANSIStyle::Red), "\\n");
+            ansi_style.apply(stdout);
+            nprinted++;
+            continue;
         }
+
+        if (static_cast<u8>(c) < 0x1f) {
+            out(foreground(ANSIStyle::Red), "\\{:#02o}", c);
+            ansi_style.apply(stdout);
+            nprinted += 3;
+            continue;
+        }
+
+        out("{:c}", c);
     }
 
-    return printed;
+    if (ansi_style.has_style())
+        style(ANSIStyle::Reset).apply(stdout);
+
+    return nprinted;
 }
 
 static ByteString& hostname()
@@ -271,31 +286,24 @@ static size_t print_name(const struct stat& st, ByteString const& name, Optional
 
     size_t nprinted = 0;
 
-    if (!flag_colorize || !output_is_terminal) {
-        nprinted = printf("%s", name.characters());
-    } else {
-        char const* begin_color = "";
-        char const* end_color = "\033[0m";
-
-        if (st.st_mode & S_ISVTX)
-            begin_color = "\033[42;30;1m";
-        else if (st.st_mode & S_ISUID)
-            begin_color = "\033[41;1m";
-        else if (st.st_mode & S_ISGID)
-            begin_color = "\033[43;1m";
-        else if (S_ISLNK(st.st_mode))
-            begin_color = "\033[36;1m";
-        else if (S_ISDIR(st.st_mode))
-            begin_color = "\033[34;1m";
-        else if (st.st_mode & 0111)
-            begin_color = "\033[32;1m";
-        else if (S_ISSOCK(st.st_mode))
-            begin_color = "\033[35;1m";
-        else if (S_ISFIFO(st.st_mode) || S_ISCHR(st.st_mode) || S_ISBLK(st.st_mode))
-            begin_color = "\033[33;1m";
-        printf("%s", begin_color);
-        nprinted = print_escaped(name);
-        printf("%s", end_color);
+    if (st.st_mode & S_ISVTX)
+        nprinted = print_escaped(name, background(ANSIStyle::Magenta) | foreground(ANSIStyle::Black) | style(ANSIStyle::Bold));
+    else if (st.st_mode & S_ISUID)
+        nprinted = print_escaped(name, background(ANSIStyle::Red) | style(ANSIStyle::Bold));
+    else if (st.st_mode & S_ISGID)
+        nprinted = print_escaped(name, background(ANSIStyle::Yellow) | foreground(ANSIStyle::Black) | style(ANSIStyle::Bold));
+    else if (S_ISLNK(st.st_mode))
+        nprinted = print_escaped(name, foreground(ANSIStyle::Cyan) | style(ANSIStyle::Bold));
+    else if (S_ISDIR(st.st_mode))
+        nprinted = print_escaped(name, foreground(ANSIStyle::Blue) | style(ANSIStyle::Bold));
+    else if (st.st_mode & 0111)
+        nprinted = print_escaped(name, foreground(ANSIStyle::Green) | style(ANSIStyle::Bold));
+    else if (S_ISSOCK(st.st_mode))
+        nprinted = print_escaped(name, foreground(ANSIStyle::Magenta) | style(ANSIStyle::Bold));
+    else if (S_ISFIFO(st.st_mode) || S_ISCHR(st.st_mode) || S_ISBLK(st.st_mode))
+        nprinted = print_escaped(name, foreground(ANSIStyle::Yellow) | style(ANSIStyle::Bold));
+    else {
+        nprinted = print_escaped(name, ANSIStyle());
     }
 
     if (S_ISLNK(st.st_mode)) {
@@ -304,7 +312,7 @@ static size_t print_name(const struct stat& st, ByteString const& name, Optional
             if (link_destination_or_error.is_error()) {
                 warnln("readlink of {} failed: {}", path_for_link_resolution.value(), link_destination_or_error.error());
             } else {
-                nprinted += printf(" -> ") + print_escaped(link_destination_or_error.value());
+                nprinted += printf(" -> ") + print_escaped(link_destination_or_error.value(), ANSIStyle());
             }
         } else {
             if (has_flag(flag_indicator_style, IndicatorStyle::SymbolicLink))

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -339,6 +339,46 @@ static size_t print_name(const struct stat& st, ByteString const& name, Optional
     return nprinted;
 }
 
+static void print_permissions(mode_t mode, mode_t read_mode, mode_t write_mode, mode_t exec_mode, mode_t special_mode)
+{
+    if (mode & read_mode) {
+        foreground(ANSIStyle::Yellow).apply(stdout);
+        out("r");
+    } else {
+        foreground(ANSIStyle::Default).apply(stdout);
+        out("-");
+    }
+
+    if (mode & write_mode) {
+        foreground(ANSIStyle::Red).apply(stdout);
+        out("w");
+    } else {
+        foreground(ANSIStyle::Default).apply(stdout);
+        out("-");
+    }
+
+    if (mode & special_mode) {
+        foreground(ANSIStyle::Magenta).apply(stdout);
+        switch (special_mode) {
+        case S_ISUID:
+        case S_ISGID:
+            out("{}", mode & exec_mode ? 's' : 'S');
+            return;
+        case S_ISVTX:
+            out("{}", mode & exec_mode ? 't' : 'T');
+            return;
+        }
+    }
+
+    if (mode & exec_mode) {
+        foreground(ANSIStyle::Green).apply(stdout);
+        out("x");
+    } else {
+        foreground(ANSIStyle::Default).apply(stdout);
+        out("-");
+    }
+}
+
 static bool print_filesystem_object(ByteString const& path, ByteString const& name, const struct stat& st, Optional<ino_t> raw_inode_number)
 {
     if (flag_show_inode) {
@@ -350,41 +390,37 @@ static bool print_filesystem_object(ByteString const& path, ByteString const& na
             printf("n/a ");
     }
 
-    if (S_ISDIR(st.st_mode))
-        printf("d");
-    else if (S_ISLNK(st.st_mode))
-        printf("l");
-    else if (S_ISBLK(st.st_mode))
-        printf("b");
-    else if (S_ISCHR(st.st_mode))
-        printf("c");
-    else if (S_ISFIFO(st.st_mode))
-        printf("f");
-    else if (S_ISSOCK(st.st_mode))
-        printf("s");
-    else if (S_ISREG(st.st_mode))
-        printf("-");
-    else
-        printf("?");
+    style(ANSIStyle::Bold).apply(stdout);
 
-    printf("%c%c%c%c%c%c%c%c",
-        st.st_mode & S_IRUSR ? 'r' : '-',
-        st.st_mode & S_IWUSR ? 'w' : '-',
-        st.st_mode & S_ISUID
-            ? (st.st_mode & S_IXUSR ? 's' : 'S')
-            : (st.st_mode & S_IXUSR ? 'x' : '-'),
-        st.st_mode & S_IRGRP ? 'r' : '-',
-        st.st_mode & S_IWGRP ? 'w' : '-',
-        st.st_mode & S_ISGID
-            ? (st.st_mode & S_IXGRP ? 's' : 'S')
-            : (st.st_mode & S_IXGRP ? 'x' : '-'),
-        st.st_mode & S_IROTH ? 'r' : '-',
-        st.st_mode & S_IWOTH ? 'w' : '-');
+    if (S_ISDIR(st.st_mode)) {
+        foreground(ANSIStyle::Blue).apply(stdout);
+        out("d");
+    } else if (S_ISLNK(st.st_mode)) {
+        foreground(ANSIStyle::Cyan).apply(stdout);
+        out("l");
+    } else if (S_ISBLK(st.st_mode)) {
+        foreground(ANSIStyle::Yellow).apply(stdout);
+        out("b");
+    } else if (S_ISCHR(st.st_mode)) {
+        foreground(ANSIStyle::Yellow).apply(stdout);
+        out("c");
+    } else if (S_ISFIFO(st.st_mode)) {
+        foreground(ANSIStyle::Yellow).apply(stdout);
+        out("f");
+    } else if (S_ISSOCK(st.st_mode)) {
+        foreground(ANSIStyle::Magenta).apply(stdout);
+        out("s");
+    } else if (S_ISREG(st.st_mode)) {
+        out("-");
+    } else {
+        out("?");
+    }
 
-    if (st.st_mode & S_ISVTX)
-        printf("%c", st.st_mode & S_IXOTH ? 't' : 'T');
-    else
-        printf("%c", st.st_mode & S_IXOTH ? 'x' : '-');
+    print_permissions(st.st_mode, S_IRUSR, S_IWUSR, S_IXUSR, S_ISUID);
+    print_permissions(st.st_mode, S_IRGRP, S_IWGRP, S_IXGRP, S_ISGID);
+    print_permissions(st.st_mode, S_IROTH, S_IWOTH, S_IXOTH, S_ISVTX);
+
+    style(ANSIStyle::Reset).apply(stdout);
 
     printf(" %3lu", st.st_nlink);
 


### PR DESCRIPTION
Add color to the `ls` permissions column for better and easier identification of the permissions. Together with the addition of the ANSIStyle class to aid in outputting styled text to the terminal.

<img width="589" height="404" alt="Captura de tela 2026-08-24 173654" src="https://github.com/user-attachments/assets/1c18c030-e1d7-42fd-81f5-60aa12adc324" />
