### PR TITLE
Toolchain: Build libcxx and libcxxabi with exceptions disabled

### DIFF
--- a/Toolchain/CMake/LLVMConfig.cmake
+++ b/Toolchain/CMake/LLVMConfig.cmake
@@ -64,6 +64,8 @@ foreach(target x86_64-serenity;aarch64-serenity;riscv64-serenity)
     set(RUNTIMES_${target}_LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
 
     set(RUNTIMES_${target}_LIBCXX_ENABLE_STATIC_ABI_LIBRARY ON CACHE BOOL "")
+    set(RUNTIMES_${target}_LIBCXX_ENABLE_EXCEPTIONS OFF CACHE BOOL "")
+    set(RUNTIMES_${target}_LIBCXXABI_ENABLE_EXCEPTIONS OFF CACHE BOOL "")
     set(RUNTIMES_${target}_LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
 
     # Hardcode autodetection results for libm, libdl, and libpthread.


### PR DESCRIPTION
We don't support them anyway, so let's disable them upfront rather than building a half-broken library.

---

This commit won't trigger a toolchain rebuild, so you have to manually run `./Toolchain/BuildClang.sh` to make it effective.

---

I've always been testing with exceptions disabled, but I just realized that we built libcxx with exceptions enabled (the default), and this caused hard-to-debug issues in some tests. Notably these are now expectingly failing when everyone get compiled with exceptions disabled:
std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.replace.indirect.pass.cpp
std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp
std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.replace.indirect.pass.cpp
std/language.support/support.dynamic/new.delete/new.delete.single/new.size_nothrow.replace.indirect.pass.cpp