### PR TITLE
Kernel: Pass all user pointers as Userspace<T*> in syscalls

### DIFF
--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
 #ifdef KERNEL
@@ -18,10 +19,28 @@ namespace AK {
 template<typename T>
 concept PointerTypeName = IsPointer<T>;
 
+namespace Detail {
+template<typename T>
+void get_pointee_type_or_void();
+
+template<typename T>
+requires(!IsSameIgnoringCV<RemovePointer<T>, void>)
+RemovePointer<T>& get_pointee_type_or_void();
+
+template<typename T>
+using PointeeTypeOrVoid = decltype(get_pointee_type_or_void<T>());
+}
+
 template<PointerTypeName T>
 class Userspace {
+    using ElementType = RemovePointer<T>;
+    constexpr static bool allow_deref = !IsSameIgnoringCV<ElementType, void>;
+    using Ref = Detail::PointeeTypeOrVoid<T>;
+    using CRef = Detail::AddConstToReferencedType<Ref>;
+
 public:
     Userspace() = default;
+    Userspace(nullptr_t) { }
 
     // Disable default implementations that would use surprising integer promotion.
     bool operator==(Userspace const&) const = delete;
@@ -30,8 +49,10 @@ public:
     bool operator<(Userspace const&) const = delete;
     bool operator>(Userspace const&) const = delete;
 
+    bool operator==(nullptr_t) const { return m_ptr == 0; }
+
 #ifdef KERNEL
-    Userspace(FlatPtr ptr)
+    explicit Userspace(FlatPtr ptr)
         : m_ptr(ptr)
     {
     }
@@ -50,7 +71,44 @@ public:
     explicit operator bool() const { return m_ptr != nullptr; }
 
     T ptr() const { return m_ptr; }
+
+    CRef operator[](size_t i) const
+    requires(allow_deref)
+    {
+        return m_ptr[i];
+    }
+    Ref operator[](size_t i)
+    requires(allow_deref)
+    {
+        return m_ptr[i];
+    }
+    CRef operator*() const
+    requires(allow_deref)
+    {
+        return *m_ptr;
+    }
+    Ref operator*()
+    requires(allow_deref)
+    {
+        return *m_ptr;
+    }
+    CRef operator->() const
+    requires(allow_deref)
+    {
+        return *m_ptr;
+    }
+    Ref operator->()
+    requires(allow_deref)
+    {
+        return *m_ptr;
+    }
+
 #endif
+
+    operator Userspace<ElementType const*>() const
+    {
+        return Userspace<ElementType const*> { m_ptr };
+    }
 
 private:
 #ifdef KERNEL
@@ -61,6 +119,7 @@ private:
 };
 
 template<typename T, typename U>
+requires(requires { static_cast<T>(declval<U>()); })
 inline Userspace<T> static_ptr_cast(Userspace<U> const& ptr)
 {
 #ifdef KERNEL

--- a/Kernel/API/FileSystem/MountSpecificFlags.h
+++ b/Kernel/API/FileSystem/MountSpecificFlags.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <AK/Userspace.h>
 
 #define MOUNT_SPECIFIC_FLAG_KEY_STRING_MAX_LENGTH 64
 
@@ -21,6 +22,6 @@ struct MountSpecificFlag {
     };
 
     ValueType value_type;
-    unsigned char const* key_string_addr;
-    void const* value_addr;
+    Userspace<char const*> key_string_addr;
+    Userspace<void const*> value_addr;
 };

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -219,23 +219,23 @@ enum Function {
 
 #ifdef AK_OS_SERENITY
 struct StringArgument {
-    char const* characters;
+    Userspace<char const*> characters;
     size_t length { 0 };
 };
 
 template<typename DataType, typename SizeType>
 struct MutableBufferArgument {
-    DataType* data { nullptr };
+    Userspace<DataType*> data { nullptr };
     SizeType size { 0 };
 };
 
 struct StringListArgument {
-    StringArgument* strings {};
+    Userspace<StringArgument*> strings { nullptr };
     size_t length { 0 };
 };
 
 struct SC_mmap_params {
-    void* addr;
+    Userspace<void*> addr;
     size_t size;
     size_t alignment;
     int32_t prot;
@@ -246,7 +246,7 @@ struct SC_mmap_params {
 };
 
 struct SC_mremap_params {
-    void* old_address;
+    Userspace<void*> old_address;
     size_t old_size;
     size_t new_size;
     int32_t flags;
@@ -260,7 +260,7 @@ struct SC_open_params {
 };
 
 struct SC_poll_params {
-    struct pollfd* fds;
+    Userspace<struct pollfd*> fds;
     unsigned nfds;
     const struct timespec* timeout;
     u32 const* sigmask;
@@ -269,18 +269,18 @@ struct SC_poll_params {
 struct SC_clock_nanosleep_params {
     int clock_id;
     int flags;
-    const struct timespec* requested_sleep;
+    Userspace<const struct timespec*> requested_sleep;
     struct timespec* remaining_sleep;
 };
 
 struct SC_clock_getres_params {
     int clock_id;
-    struct timespec* result;
+    Userspace<struct timespec*> result;
 };
 
 struct SC_accept4_params {
-    sockaddr* addr;
-    socklen_t* addrlen;
+    Userspace<sockaddr*> addr;
+    Userspace<socklen_t*> addrlen;
     int sockfd;
     int flags;
 };
@@ -289,8 +289,8 @@ struct SC_getsockopt_params {
     int sockfd;
     int level;
     int option;
-    void* value;
-    socklen_t* value_size;
+    Userspace<void*> value;
+    Userspace<socklen_t*> value_size;
 };
 
 struct SC_setsockopt_params {
@@ -303,14 +303,14 @@ struct SC_setsockopt_params {
 
 struct SC_getsockname_params {
     int sockfd;
-    sockaddr* addr;
-    socklen_t* addrlen;
+    Userspace<sockaddr*> addr;
+    Userspace<socklen_t*> addrlen;
 };
 
 struct SC_getpeername_params {
     int sockfd;
-    sockaddr* addr;
-    socklen_t* addrlen;
+    Userspace<sockaddr*> addr;
+    Userspace<socklen_t*> addrlen;
 };
 
 struct SC_socketpair_params {
@@ -321,23 +321,23 @@ struct SC_socketpair_params {
 };
 
 struct SC_futex_params {
-    u32* userspace_address;
+    Userspace<u32 volatile*> userspace_address;
     int futex_op;
     u32 val;
     union {
-        timespec const* timeout;
+        Userspace<timespec const*> timeout;
         uintptr_t val2;
     };
-    u32* userspace_address2;
+    Userspace<u32 volatile*> userspace_address2;
     u32 val3;
 };
 
 struct SC_setkeymap_params {
-    u32 const* map;
-    u32 const* shift_map;
-    u32 const* alt_map;
-    u32 const* altgr_map;
-    u32 const* shift_altgr_map;
+    Userspace<u32 const*> map;
+    Userspace<u32 const*> shift_map;
+    Userspace<u32 const*> alt_map;
+    Userspace<u32 const*> altgr_map;
+    Userspace<u32 const*> shift_altgr_map;
     StringArgument map_name;
 };
 
@@ -356,11 +356,11 @@ struct SC_unshare_enter_params {
 };
 
 struct SC_getkeymap_params {
-    u32* map;
-    u32* shift_map;
-    u32* alt_map;
-    u32* altgr_map;
-    u32* shift_altgr_map;
+    Userspace<u32*> map;
+    Userspace<u32*> shift_map;
+    Userspace<u32*> alt_map;
+    Userspace<u32*> altgr_map;
+    Userspace<u32*> shift_altgr_map;
     MutableBufferArgument<char, size_t> map_name;
 };
 
@@ -374,10 +374,10 @@ struct SC_create_thread_params {
     unsigned int guard_page_size = 0;          // Rounded up to PAGE_SIZE
     unsigned int reported_guard_page_size = 0; // The lie we tell callers
     unsigned int stack_size = 1 * MiB;         // Equal to Thread::default_userspace_stack_size
-    void* stack_location;                      // nullptr means any, o.w. process virtual address
-    void* (*entry)(void*);
-    void* entry_argument;
-    void* tls_pointer;
+    Userspace<void*> stack_location;           // nullptr means any, o.w. process virtual address
+    Userspace<void* (*)(void*)> entry;
+    Userspace<void*> entry_argument;
+    Userspace<void*> tls_pointer;
 };
 
 struct SC_realpath_params {
@@ -386,7 +386,7 @@ struct SC_realpath_params {
 };
 
 struct SC_set_mmap_name_params {
-    void* addr;
+    Userspace<void*> addr;
     size_t size;
     StringArgument name;
 };

--- a/Kernel/FileSystem/MountFile.cpp
+++ b/Kernel/FileSystem/MountFile.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/StdLibExtras.h>
 #include <AK/StringView.h>
+#include <AK/Userspace.h>
 #include <Kernel/API/FileSystem/MountSpecificFlags.h>
 #include <Kernel/API/Ioctl.h>
 #include <Kernel/API/POSIX/errno.h>
@@ -78,7 +79,7 @@ ErrorOr<void> MountFile::ioctl(OpenFileDescription&, unsigned request, Userspace
         auto user_mount_specific_data = static_ptr_cast<MountSpecificFlag const*>(arg);
         auto mount_specific_data = TRY(copy_typed_from_user(user_mount_specific_data));
 
-        Syscall::StringArgument user_key_string { reinterpret_cast<char const*>(mount_specific_data.key_string_addr), static_cast<size_t>(mount_specific_data.key_string_length) };
+        Syscall::StringArgument user_key_string { static_ptr_cast<char const*>(mount_specific_data.key_string_addr), static_cast<size_t>(mount_specific_data.key_string_length) };
         auto key_string = TRY(Process::get_syscall_name_string_fixed_buffer<MOUNT_SPECIFIC_FLAG_KEY_STRING_MAX_LENGTH>(user_key_string));
 
         switch (request) {
@@ -108,7 +109,7 @@ ErrorOr<void> MountFile::ioctl(OpenFileDescription&, unsigned request, Userspace
             // NOTE: This is actually considered as simply boolean flag.
             case MountSpecificFlag::ValueType::Boolean: {
                 VERIFY(m_file_system_initializer.validate_mount_boolean_flag);
-                Userspace<u64*> user_value_addr(reinterpret_cast<FlatPtr>(mount_specific_data.value_addr));
+                auto user_value_addr = static_ptr_cast<u64 const*>(mount_specific_data.value_addr);
                 auto value_integer = TRY(copy_typed_from_user(user_value_addr));
                 if (value_integer != 0 && value_integer != 1)
                     return EDOM;
@@ -121,7 +122,7 @@ ErrorOr<void> MountFile::ioctl(OpenFileDescription&, unsigned request, Userspace
             }
             case MountSpecificFlag::ValueType::UnsignedInteger: {
                 VERIFY(m_file_system_initializer.validate_mount_unsigned_integer_flag);
-                Userspace<u64*> user_value_addr(reinterpret_cast<FlatPtr>(mount_specific_data.value_addr));
+                auto user_value_addr = static_ptr_cast<u64 const*>(mount_specific_data.value_addr);
                 auto value_integer = TRY(copy_typed_from_user(user_value_addr));
                 TRY(m_file_system_initializer.validate_mount_unsigned_integer_flag(key_string.representable_view(), value_integer));
 
@@ -131,7 +132,7 @@ ErrorOr<void> MountFile::ioctl(OpenFileDescription&, unsigned request, Userspace
             }
             case MountSpecificFlag::ValueType::SignedInteger: {
                 VERIFY(m_file_system_initializer.validate_mount_signed_integer_flag);
-                Userspace<i64*> user_value_addr(reinterpret_cast<FlatPtr>(mount_specific_data.value_addr));
+                auto user_value_addr = static_ptr_cast<i64 const*>(mount_specific_data.value_addr);
                 auto value_integer = TRY(copy_typed_from_user(user_value_addr));
                 TRY(m_file_system_initializer.validate_mount_signed_integer_flag(key_string.representable_view(), value_integer));
 

--- a/Kernel/Library/StdLib.cpp
+++ b/Kernel/Library/StdLib.cpp
@@ -62,104 +62,104 @@ ErrorOr<Duration> copy_time_from_user<timespec const>(Userspace<timespec const*>
 template<>
 ErrorOr<Duration> copy_time_from_user<timespec>(Userspace<timespec*> src) { return copy_time_from_user(src.unsafe_userspace_ptr()); }
 
-Optional<u32> user_atomic_fetch_add_relaxed(u32 volatile* var, u32 val)
+Optional<u32> user_atomic_fetch_add_relaxed(Userspace<u32 volatile*> var, u32 val)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return {}; // not aligned!
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return {};
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_fetch_add_relaxed(var, val);
+    return Kernel::safe_atomic_fetch_add_relaxed(var.unsafe_userspace_ptr(), val);
 }
 
-Optional<u32> user_atomic_exchange_relaxed(u32 volatile* var, u32 val)
+Optional<u32> user_atomic_exchange_relaxed(Userspace<u32 volatile*> var, u32 val)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return {}; // not aligned!
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return {};
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_exchange_relaxed(var, val);
+    return Kernel::safe_atomic_exchange_relaxed(var.unsafe_userspace_ptr(), val);
 }
 
-Optional<u32> user_atomic_load_relaxed(u32 volatile* var)
+Optional<u32> user_atomic_load_relaxed(Userspace<u32 volatile*> var)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return {}; // not aligned!
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return {};
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_load_relaxed(var);
+    return Kernel::safe_atomic_load_relaxed(var.unsafe_userspace_ptr());
 }
 
-bool user_atomic_store_relaxed(u32 volatile* var, u32 val)
+bool user_atomic_store_relaxed(Userspace<u32 volatile*> var, u32 val)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return false; // not aligned!
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return false;
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_store_relaxed(var, val);
+    return Kernel::safe_atomic_store_relaxed(var.unsafe_userspace_ptr(), val);
 }
 
-Optional<bool> user_atomic_compare_exchange_relaxed(u32 volatile* var, u32& expected, u32 val)
+Optional<bool> user_atomic_compare_exchange_relaxed(Userspace<u32 volatile*> var, u32& expected, u32 val)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return {}; // not aligned!
     VERIFY(!Kernel::Memory::is_user_range(VirtualAddress(&expected), sizeof(expected)));
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return {};
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_compare_exchange_relaxed(var, expected, val);
+    return Kernel::safe_atomic_compare_exchange_relaxed(var.unsafe_userspace_ptr(), expected, val);
 }
 
-Optional<u32> user_atomic_fetch_and_relaxed(u32 volatile* var, u32 val)
+Optional<u32> user_atomic_fetch_and_relaxed(Userspace<u32 volatile*> var, u32 val)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return {}; // not aligned!
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return {};
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_fetch_and_relaxed(var, val);
+    return Kernel::safe_atomic_fetch_and_relaxed(var.unsafe_userspace_ptr(), val);
 }
 
-Optional<u32> user_atomic_fetch_and_not_relaxed(u32 volatile* var, u32 val)
+Optional<u32> user_atomic_fetch_and_not_relaxed(Userspace<u32 volatile*> var, u32 val)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return {}; // not aligned!
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return {};
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_fetch_and_not_relaxed(var, val);
+    return Kernel::safe_atomic_fetch_and_not_relaxed(var.unsafe_userspace_ptr(), val);
 }
 
-Optional<u32> user_atomic_fetch_or_relaxed(u32 volatile* var, u32 val)
+Optional<u32> user_atomic_fetch_or_relaxed(Userspace<u32 volatile*> var, u32 val)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return {}; // not aligned!
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return {};
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_fetch_or_relaxed(var, val);
+    return Kernel::safe_atomic_fetch_or_relaxed(var.unsafe_userspace_ptr(), val);
 }
 
-Optional<u32> user_atomic_fetch_xor_relaxed(u32 volatile* var, u32 val)
+Optional<u32> user_atomic_fetch_xor_relaxed(Userspace<u32 volatile*> var, u32 val)
 {
-    if (FlatPtr(var) & 3)
+    if (var.ptr() & 3)
         return {}; // not aligned!
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(FlatPtr(var)), sizeof(*var));
+    bool is_user = Kernel::Memory::is_user_range(var.vaddr(), sizeof(u32));
     if (!is_user)
         return {};
     Kernel::SmapDisabler disabler;
-    return Kernel::safe_atomic_fetch_xor_relaxed(var, val);
+    return Kernel::safe_atomic_fetch_xor_relaxed(var.unsafe_userspace_ptr(), val);
 }
 
 ErrorOr<void> copy_to_user(void* dest_ptr, void const* src_ptr, size_t n)

--- a/Kernel/Library/StdLib.h
+++ b/Kernel/Library/StdLib.h
@@ -43,15 +43,15 @@ ErrorOr<Duration> copy_time_from_user(timeval const*);
 template<typename T>
 ErrorOr<Duration> copy_time_from_user(Userspace<T*>);
 
-[[nodiscard]] Optional<u32> user_atomic_fetch_add_relaxed(u32 volatile* var, u32 val);
-[[nodiscard]] Optional<u32> user_atomic_exchange_relaxed(u32 volatile* var, u32 val);
-[[nodiscard]] Optional<u32> user_atomic_load_relaxed(u32 volatile* var);
-[[nodiscard]] bool user_atomic_store_relaxed(u32 volatile* var, u32 val);
-[[nodiscard]] Optional<bool> user_atomic_compare_exchange_relaxed(u32 volatile* var, u32& expected, u32 val);
-[[nodiscard]] Optional<u32> user_atomic_fetch_and_relaxed(u32 volatile* var, u32 val);
-[[nodiscard]] Optional<u32> user_atomic_fetch_and_not_relaxed(u32 volatile* var, u32 val);
-[[nodiscard]] Optional<u32> user_atomic_fetch_or_relaxed(u32 volatile* var, u32 val);
-[[nodiscard]] Optional<u32> user_atomic_fetch_xor_relaxed(u32 volatile* var, u32 val);
+[[nodiscard]] Optional<u32> user_atomic_fetch_add_relaxed(Userspace<u32 volatile*> var, u32 val);
+[[nodiscard]] Optional<u32> user_atomic_exchange_relaxed(Userspace<u32 volatile*> var, u32 val);
+[[nodiscard]] Optional<u32> user_atomic_load_relaxed(Userspace<u32 volatile*> var);
+[[nodiscard]] bool user_atomic_store_relaxed(Userspace<u32 volatile*> var, u32 val);
+[[nodiscard]] Optional<bool> user_atomic_compare_exchange_relaxed(Userspace<u32 volatile*> var, u32& expected, u32 val);
+[[nodiscard]] Optional<u32> user_atomic_fetch_and_relaxed(Userspace<u32 volatile*> var, u32 val);
+[[nodiscard]] Optional<u32> user_atomic_fetch_and_not_relaxed(Userspace<u32 volatile*> var, u32 val);
+[[nodiscard]] Optional<u32> user_atomic_fetch_or_relaxed(Userspace<u32 volatile*> var, u32 val);
+[[nodiscard]] Optional<u32> user_atomic_fetch_xor_relaxed(Userspace<u32 volatile*> var, u32 val);
 
 ErrorOr<void> copy_to_user(void*, void const*, size_t);
 ErrorOr<void> copy_from_user(void*, void const*, size_t);
@@ -149,7 +149,7 @@ template<typename T>
 }
 
 template<typename T>
-[[nodiscard]] inline ErrorOr<void> copy_n_from_user(T* dest, Userspace<T const*> src, size_t count)
+[[nodiscard]] inline ErrorOr<void> copy_n_from_user(T* dest, Userspace<IdentityType<T> const*> src, size_t count)
 {
     static_assert(IsTriviallyCopyable<T>);
     Checked<size_t> size = sizeof(T);
@@ -172,14 +172,6 @@ template<typename T>
 
 template<typename T>
 inline ErrorOr<T> copy_typed_from_user(Userspace<T const*> user_data)
-{
-    T data {};
-    TRY(copy_from_user(&data, user_data));
-    return data;
-}
-
-template<typename T>
-inline ErrorOr<T> copy_typed_from_user(Userspace<T*> user_data)
 {
     T data {};
     TRY(copy_from_user(&data, user_data));

--- a/Kernel/Net/IP/Socket.cpp
+++ b/Kernel/Net/IP/Socket.cpp
@@ -368,7 +368,7 @@ ErrorOr<size_t> IPv4Socket::receive_packet_buffered(OpenFileDescription& descrip
         memcpy(&out_addr.sin_addr, &packet->peer_address, sizeof(IPv4Address));
         out_addr.sin_port = htons(packet->peer_port);
         out_addr.sin_family = AF_INET;
-        Userspace<sockaddr_in*> dest_addr = addr.ptr();
+        Userspace<sockaddr_in*> dest_addr { addr.ptr() };
         SOCKET_TRY(copy_to_user(dest_addr, &out_addr));
 
         socklen_t out_length = sizeof(sockaddr_in);

--- a/Kernel/Syscalls/SyscallHandler.cpp
+++ b/Kernel/Syscalls/SyscallHandler.cpp
@@ -80,7 +80,7 @@ ErrorOr<FlatPtr> handle(RegisterState& regs, FlatPtr function, FlatPtr arg1, Fla
         case SC_exit:
             process.sys$exit(arg1);
         case SC_exit_thread:
-            process.sys$exit_thread(arg1, arg2, arg3);
+            process.sys$exit_thread(Userspace<void*> { arg1 }, Userspace<void*> { arg2 }, arg3);
         default:
             VERIFY_NOT_REACHED();
         }

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -8,6 +8,7 @@
 #include <AK/FixedArray.h>
 #include <AK/ScopeGuard.h>
 #include <AK/TemporaryChange.h>
+#include <Kernel/API/Syscall.h>
 #include <Kernel/Arch/CPU.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/Custody.h>
@@ -85,21 +86,21 @@ static ErrorOr<FlatPtr> make_userspace_context_for_main_thread([[maybe_unused]] 
 
     auto push_on_new_stack = [&new_sp](FlatPtr value) {
         new_sp -= sizeof(FlatPtr);
-        Userspace<FlatPtr*> stack_ptr = new_sp;
+        Userspace<FlatPtr*> stack_ptr { new_sp };
         auto result = copy_to_user(stack_ptr, &value);
         VERIFY(!result.is_error());
     };
 
     auto push_aux_value_on_new_stack = [&new_sp](auxv_t value) {
         new_sp -= sizeof(auxv_t);
-        Userspace<auxv_t*> stack_ptr = new_sp;
+        Userspace<auxv_t*> stack_ptr { new_sp };
         auto result = copy_to_user(stack_ptr, &value);
         VERIFY(!result.is_error());
     };
 
     auto push_string_on_new_stack = [&new_sp](StringView string) {
         new_sp -= round_up_to_power_of_two(string.length() + 1, sizeof(FlatPtr));
-        Userspace<FlatPtr*> stack_ptr = new_sp;
+        Userspace<FlatPtr*> stack_ptr { new_sp };
         auto result = copy_to_user(stack_ptr, string.characters_without_null_termination(), string.length() + 1);
         VERIFY(!result.is_error());
     };
@@ -992,13 +993,9 @@ ErrorOr<FlatPtr> Process::sys$execve(Userspace<Syscall::SC_execve_params const*>
         auto copy_user_strings = [](auto const& list, auto& output) -> ErrorOr<void> {
             if (!list.length)
                 return {};
-            Checked<size_t> size = sizeof(*list.strings);
-            size *= list.length;
-            if (size.has_overflow())
-                return EOVERFLOW;
             Vector<Syscall::StringArgument, 32> strings;
             TRY(strings.try_resize(list.length));
-            TRY(copy_from_user(strings.data(), list.strings, size.value()));
+            TRY(copy_n_from_user(strings.data(), list.strings, list.length));
             for (size_t i = 0; i < list.length; ++i) {
                 auto string = TRY(try_copy_kstring_from_user(strings[i]));
                 TRY(output.try_append(move(string)));

--- a/Kernel/Syscalls/futex.cpp
+++ b/Kernel/Syscalls/futex.cpp
@@ -167,8 +167,8 @@ ErrorOr<FlatPtr> Process::sys$futex(Userspace<Syscall::SC_futex_params const*> u
         return (int)woke_count;
     };
 
-    auto user_address = FlatPtr(params.userspace_address);
-    auto user_address2 = FlatPtr(params.userspace_address2);
+    auto user_address = params.userspace_address.ptr();
+    auto user_address2 = params.userspace_address2.ptr();
 
     auto do_wait = [&](u32 bitset) -> ErrorOr<FlatPtr> {
         bool did_create;
@@ -179,7 +179,7 @@ ErrorOr<FlatPtr> Process::sys$futex(Userspace<Syscall::SC_futex_params const*> u
             if (!user_value.has_value())
                 return EFAULT;
             if (user_value.value() != params.val) {
-                dbgln_if(FUTEX_DEBUG, "futex wait: EAGAIN. user value: {:p} @ {:p} != val: {}", user_value.value(), params.userspace_address, params.val);
+                dbgln_if(FUTEX_DEBUG, "futex wait: EAGAIN. user value: {:p} @ {:p} != val: {}", user_value.value(), params.userspace_address.ptr(), params.val);
                 return EAGAIN;
             }
             atomic_thread_fence(AK::MemoryOrder::memory_order_acquire);

--- a/Kernel/Syscalls/ioctl.cpp
+++ b/Kernel/Syscalls/ioctl.cpp
@@ -11,12 +11,12 @@
 
 namespace Kernel {
 
-ErrorOr<FlatPtr> Process::sys$ioctl(int fd, unsigned request, FlatPtr arg)
+ErrorOr<FlatPtr> Process::sys$ioctl(int fd, unsigned request, Userspace<void*> arg)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     auto description = TRY(open_file_description(fd));
     if (request == FIONBIO) {
-        description->set_blocking(TRY(copy_typed_from_user(Userspace<int const*>(arg))) == 0);
+        description->set_blocking(TRY(copy_typed_from_user(static_ptr_cast<int const*>(arg))) == 0);
         return 0;
     }
     if (request == FIOCLEX) {

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -67,7 +67,7 @@ ErrorOr<FlatPtr> Process::sys$mmap(Userspace<Syscall::SC_mmap_params const*> use
     TRY(require_promise(Pledge::stdio));
     auto params = TRY(copy_typed_from_user(user_params));
 
-    auto addr = (FlatPtr)params.addr;
+    auto addr = params.addr.ptr();
     auto size = params.size;
     auto alignment = params.alignment ? params.alignment : PAGE_SIZE;
     auto prot = params.prot;
@@ -393,7 +393,7 @@ ErrorOr<FlatPtr> Process::sys$set_mmap_name(Userspace<Syscall::SC_set_mmap_name_
         return ENAMETOOLONG;
 
     auto name = TRY(try_copy_kstring_from_user(params.name));
-    auto range = TRY(Memory::expand_range_to_page_boundaries((FlatPtr)params.addr, params.size));
+    auto range = TRY(Memory::expand_range_to_page_boundaries(params.addr.ptr(), params.size));
 
     return address_space().with([&](auto& space) -> ErrorOr<FlatPtr> {
         auto* region = space->find_region_from_range(range);
@@ -428,7 +428,7 @@ ErrorOr<FlatPtr> Process::sys$mremap(Userspace<Syscall::SC_mremap_params const*>
     TRY(require_promise(Pledge::stdio));
     auto params = TRY(copy_typed_from_user(user_params));
 
-    auto old_range = TRY(Memory::expand_range_to_page_boundaries((FlatPtr)params.old_address, params.old_size));
+    auto old_range = TRY(Memory::expand_range_to_page_boundaries(params.old_address.ptr(), params.old_size));
 
     return address_space().with([&](auto& space) -> ErrorOr<FlatPtr> {
         auto* old_region = space->find_region_from_range(old_range);

--- a/Kernel/Syscalls/poll.cpp
+++ b/Kernel/Syscalls/poll.cpp
@@ -37,12 +37,8 @@ ErrorOr<FlatPtr> Process::sys$poll(Userspace<Syscall::SC_poll_params const*> use
 
     Vector<pollfd, FD_SETSIZE> fds_copy;
     if (params.nfds > 0) {
-        Checked<size_t> nfds_checked = sizeof(pollfd);
-        nfds_checked *= params.nfds;
-        if (nfds_checked.has_overflow())
-            return EFAULT;
         TRY(fds_copy.try_resize(params.nfds));
-        TRY(copy_from_user(fds_copy.data(), &params.fds[0], nfds_checked.value()));
+        TRY(copy_n_from_user(fds_copy.data(), params.fds, params.nfds));
     }
 
     Thread::SelectBlocker::FDVector fds_info;
@@ -131,7 +127,7 @@ ErrorOr<FlatPtr> Process::sys$poll(Userspace<Syscall::SC_poll_params const*> use
     }
 
     if (params.nfds > 0)
-        TRY(copy_n_to_user(&params.fds[0], fds_copy.data(), params.nfds));
+        TRY(copy_n_to_user(params.fds, fds_copy.data(), params.nfds));
 
     return fds_with_revents;
 }

--- a/Kernel/Syscalls/posix_spawn.cpp
+++ b/Kernel/Syscalls/posix_spawn.cpp
@@ -42,13 +42,9 @@ ErrorOr<FlatPtr> Process::sys$posix_spawn(Userspace<Syscall::SC_posix_spawn_para
     auto copy_user_strings = [](auto const& list, auto& output) -> ErrorOr<void> {
         if (!list.length)
             return {};
-        Checked<size_t> size = sizeof(*list.strings);
-        size *= list.length;
-        if (size.has_overflow())
-            return EOVERFLOW;
         Vector<Syscall::StringArgument, 32> strings;
         TRY(strings.try_resize(list.length));
-        TRY(copy_from_user(strings.data(), list.strings, size.value()));
+        TRY(copy_n_from_user(strings.data(), list.strings, list.length));
         for (size_t i = 0; i < list.length; ++i) {
             auto string = TRY(try_copy_kstring_from_user(strings[i]));
             TRY(output.try_append(move(string)));

--- a/Kernel/Syscalls/prctl.cpp
+++ b/Kernel/Syscalls/prctl.cpp
@@ -38,7 +38,7 @@ ErrorOr<FlatPtr> Process::sys$prctl(int option, FlatPtr arg1, FlatPtr arg2, Flat
         return 0;
     }
     case PR_SET_COREDUMP_METADATA_VALUE: {
-        auto params = TRY(copy_typed_from_user<Syscall::SC_set_coredump_metadata_params>(arg1));
+        auto params = TRY(copy_typed_from_user(Userspace<Syscall::SC_set_coredump_metadata_params const*>(arg1)));
         if (params.key.length == 0 || params.key.length > 16 * KiB)
             return EINVAL;
         if (params.value.length > 16 * KiB)
@@ -50,7 +50,7 @@ ErrorOr<FlatPtr> Process::sys$prctl(int option, FlatPtr arg1, FlatPtr arg2, Flat
     }
     case PR_SET_PROCESS_NAME: {
         TRY(require_promise(Pledge::proc));
-        Userspace<char const*> buffer = arg1;
+        Userspace<char const*> buffer { arg1 };
         size_t buffer_size = static_cast<size_t>(arg2);
         Process::Name process_name {};
         TRY(try_copy_name_from_user_into_fixed_string_buffer(buffer, process_name, buffer_size));
@@ -62,7 +62,7 @@ ErrorOr<FlatPtr> Process::sys$prctl(int option, FlatPtr arg1, FlatPtr arg2, Flat
     }
     case PR_GET_PROCESS_NAME: {
         TRY(require_promise(Pledge::stdio));
-        Userspace<char*> buffer = arg1;
+        Userspace<char*> buffer { arg1 };
         size_t buffer_size = static_cast<size_t>(arg2);
         TRY(m_name.with([&buffer, buffer_size](auto& name) -> ErrorOr<void> {
             VERIFY(!name.representable_view().is_null());
@@ -73,7 +73,7 @@ ErrorOr<FlatPtr> Process::sys$prctl(int option, FlatPtr arg1, FlatPtr arg2, Flat
     case PR_SET_THREAD_NAME: {
         TRY(require_promise(Pledge::stdio));
         int thread_id = static_cast<int>(arg1);
-        Userspace<char const*> buffer = arg2;
+        Userspace<char const*> buffer { arg2 };
         size_t buffer_size = static_cast<size_t>(arg3);
 
         Thread::Name thread_name {};
@@ -85,7 +85,7 @@ ErrorOr<FlatPtr> Process::sys$prctl(int option, FlatPtr arg1, FlatPtr arg2, Flat
     case PR_GET_THREAD_NAME: {
         TRY(require_promise(Pledge::thread));
         int thread_id = static_cast<int>(arg1);
-        Userspace<char*> buffer = arg2;
+        Userspace<char*> buffer { arg2 };
         size_t buffer_size = static_cast<size_t>(arg3);
         auto thread = TRY(get_thread_from_thread_list(thread_id));
 

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/ScopeGuard.h>
+#include <AK/Userspace.h>
 #include <Kernel/Arch/aarch64/Registers.h>
 #include <Kernel/Memory/PrivateInodeVMObject.h>
 #include <Kernel/Memory/Region.h>
@@ -161,9 +162,9 @@ static ErrorOr<FlatPtr> handle_ptrace(Kernel::Syscall::SC_ptrace_params const& p
         while (buf_params.buf.size > 0) {
             size_t copy_this_iteration = min(buf.size(), buf_params.buf.size);
             TRY(peer->process().peek_user_data(buf.span().slice(0, copy_this_iteration), Userspace<u8 const*> { tracee_ptr }));
-            TRY(copy_to_user((void*)buf_params.buf.data, buf.data(), copy_this_iteration));
+            TRY(copy_to_user(buf_params.buf.data, buf.data(), copy_this_iteration));
             tracee_ptr += copy_this_iteration;
-            buf_params.buf.data += copy_this_iteration;
+            buf_params.buf.data = Userspace<u8*> { buf_params.buf.data.ptr() + copy_this_iteration };
             buf_params.buf.size -= copy_this_iteration;
         }
         break;

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -94,10 +94,10 @@ ErrorOr<FlatPtr> Process::sys$sigreturn(RegisterState& registers)
 
     stack_ptr += sizeof(siginfo); // We don't need this here.
 
-    auto ucontext = TRY(copy_typed_from_user<__ucontext>(stack_ptr));
+    auto ucontext = TRY(copy_typed_from_user(Userspace<__ucontext const*> { stack_ptr }));
     stack_ptr += sizeof(__ucontext);
 
-    auto saved_return_value = TRY(copy_typed_from_user<FlatPtr>(stack_ptr));
+    auto saved_return_value = TRY(copy_typed_from_user(Userspace<FlatPtr const*> { stack_ptr }));
 
     Thread::current()->m_signal_mask = ucontext.uc_sigmask;
     Thread::current()->m_currently_handled_signal = 0;

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -93,8 +93,8 @@ ErrorOr<FlatPtr> Process::sys$accept4(Userspace<Syscall::SC_accept4_params const
     auto params = TRY(copy_typed_from_user(user_params));
 
     int accepting_socket_fd = params.sockfd;
-    Userspace<sockaddr*> user_address((FlatPtr)params.addr);
-    Userspace<socklen_t*> user_address_size((FlatPtr)params.addrlen);
+    Userspace<sockaddr*> user_address = params.addr;
+    Userspace<socklen_t*> user_address_size = params.addrlen;
     int flags = params.flags;
 
     socklen_t address_size = 0;
@@ -337,7 +337,7 @@ template<Process::SockOrPeerName sock_or_peer_name, typename Params>
 ErrorOr<void> Process::get_sock_or_peer_name(Params const& params)
 {
     socklen_t addrlen_value;
-    TRY(copy_from_user(&addrlen_value, params.addrlen, sizeof(socklen_t)));
+    TRY(copy_from_user(&addrlen_value, params.addrlen));
 
     if (addrlen_value <= 0)
         return EINVAL;
@@ -383,18 +383,16 @@ ErrorOr<FlatPtr> Process::sys$getsockopt(Userspace<Syscall::SC_getsockopt_params
     int sockfd = params.sockfd;
     int level = params.level;
     int option = params.option;
-    Userspace<void*> user_value((FlatPtr)params.value);
-    Userspace<socklen_t*> user_value_size((FlatPtr)params.value_size);
 
     socklen_t value_size;
-    TRY(copy_from_user(&value_size, params.value_size, sizeof(socklen_t)));
+    TRY(copy_from_user(&value_size, params.value_size));
 
     auto description = TRY(open_file_description(sockfd));
     if (!description->is_socket())
         return ENOTSOCK;
     auto& socket = *description->socket();
     REQUIRE_PROMISE_FOR_SOCKET_DOMAIN(socket.domain());
-    TRY(socket.getsockopt(*description, level, option, user_value, user_value_size));
+    TRY(socket.getsockopt(*description, level, option, params.value, params.value_size));
     return 0;
 }
 

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -22,7 +22,7 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<Sys
     int schedule_priority = params.schedule_priority;
     unsigned stack_size = params.stack_size;
 
-    auto user_sp = Checked<FlatPtr>((FlatPtr)params.stack_location);
+    auto user_sp = make_checked(params.stack_location.ptr());
     user_sp += stack_size;
     if (user_sp.has_overflow())
         return EOVERFLOW;
@@ -62,9 +62,9 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<Sys
     regs.cr3 = address_space().with([](auto& space) { return space->page_directory().cr3(); });
 
     // Set up the argument registers expected by pthread_create_helper.
-    regs.rdi = (FlatPtr)params.entry;
-    regs.rsi = (FlatPtr)params.entry_argument;
-    regs.rdx = (FlatPtr)params.stack_location;
+    regs.rdi = params.entry.ptr();
+    regs.rsi = params.entry_argument.ptr();
+    regs.rdx = params.stack_location.ptr();
     regs.rcx = (FlatPtr)params.stack_size;
 
     thread->arch_specific_data().fs_base = bit_cast<FlatPtr>(params.tls_pointer);
@@ -72,9 +72,9 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<Sys
     regs.ttbr0_el1 = address_space().with([](auto& space) { return space->page_directory().ttbr0(); });
 
     // Set up the argument registers expected by pthread_create_helper.
-    regs.x[0] = (FlatPtr)params.entry;
-    regs.x[1] = (FlatPtr)params.entry_argument;
-    regs.x[2] = (FlatPtr)params.stack_location;
+    regs.x[0] = params.entry.ptr();
+    regs.x[1] = params.entry_argument.ptr();
+    regs.x[2] = params.stack_location.ptr();
     regs.x[3] = (FlatPtr)params.stack_size;
 
     regs.tpidr_el0 = bit_cast<FlatPtr>(params.tls_pointer);
@@ -82,9 +82,9 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<Sys
     regs.satp = address_space().with([](auto& space) { return space->page_directory().satp(); });
 
     // Set up the argument registers expected by pthread_create_helper.
-    regs.x[9] = (FlatPtr)params.entry;
-    regs.x[10] = (FlatPtr)params.entry_argument;
-    regs.x[11] = (FlatPtr)params.stack_location;
+    regs.x[9] = params.entry.ptr();
+    regs.x[10] = params.entry_argument.ptr();
+    regs.x[11] = params.stack_location.ptr();
     regs.x[12] = (FlatPtr)params.stack_size;
 
     regs.x[3] = bit_cast<FlatPtr>(params.tls_pointer);
@@ -127,7 +127,7 @@ void Process::sys$exit_thread(Userspace<void*> exit_value, Userspace<void*> stac
             dbgln("Failed to unmap thread stack, terminating thread anyway. Error code: {}", unmap_result.error());
     }
 
-    current_thread->exit(reinterpret_cast<void*>(exit_value.ptr()));
+    current_thread->exit(exit_value.unsafe_userspace_ptr());
     VERIFY_NOT_REACHED();
 }
 

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -814,8 +814,7 @@ ErrorOr<NonnullOwnPtr<KString>> Process::get_syscall_path_argument(Userspace<cha
 
 ErrorOr<NonnullOwnPtr<KString>> Process::get_syscall_path_argument(Syscall::StringArgument const& path)
 {
-    Userspace<char const*> path_characters((FlatPtr)path.characters);
-    return get_syscall_path_argument(path_characters, path.length);
+    return get_syscall_path_argument(path.characters, path.length);
 }
 
 ErrorOr<void> Process::dump_core()

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -437,7 +437,7 @@ public:
     ErrorOr<FlatPtr> sys$alarm(unsigned seconds);
     ErrorOr<FlatPtr> sys$faccessat(Userspace<Syscall::SC_faccessat_params const*>);
     ErrorOr<FlatPtr> sys$fcntl(int fd, int cmd, uintptr_t extra_arg);
-    ErrorOr<FlatPtr> sys$ioctl(int fd, unsigned request, FlatPtr arg);
+    ErrorOr<FlatPtr> sys$ioctl(int fd, unsigned request, Userspace<void*> arg);
     ErrorOr<FlatPtr> sys$mkdir(int dirfd, Userspace<char const*> pathname, size_t path_length, mode_t mode);
     ErrorOr<FlatPtr> sys$times(Userspace<tms*>);
     ErrorOr<FlatPtr> sys$utime(Userspace<char const*> pathname, size_t path_length, Userspace<const struct utimbuf*>);
@@ -666,7 +666,7 @@ public:
         // NOTE: If the string is too much big for the FixedStringBuffer,
         // we return E2BIG error here.
         FixedStringBuffer<Size> buffer;
-        TRY(try_copy_string_from_user_into_fixed_string_buffer<Size>(reinterpret_cast<FlatPtr>(argument.characters), buffer, argument.length));
+        TRY(try_copy_string_from_user_into_fixed_string_buffer<Size>(argument.characters, buffer, argument.length));
         return buffer;
     }
 
@@ -686,7 +686,7 @@ public:
         // NOTE: If the string is too much big for the FixedStringBuffer,
         // we return ENAMETOOLONG error here.
         FixedStringBuffer<Size> buffer;
-        TRY(try_copy_name_from_user_into_fixed_string_buffer<Size>(reinterpret_cast<FlatPtr>(argument.characters), buffer, argument.length));
+        TRY(try_copy_name_from_user_into_fixed_string_buffer<Size>(argument.characters, buffer, argument.length));
         return buffer;
     }
 
@@ -1197,8 +1197,7 @@ inline ProcessID Thread::pid() const
 
 inline ErrorOr<NonnullOwnPtr<KString>> try_copy_kstring_from_user(Kernel::Syscall::StringArgument const& string)
 {
-    Userspace<char const*> characters((FlatPtr)string.characters);
-    return try_copy_kstring_from_user(characters, string.length);
+    return try_copy_kstring_from_user(string.characters, string.length);
 }
 
 template<>

--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -81,7 +81,7 @@ static void* pthread_create_helper(void* (*routine)(void*), void* argument, void
 
 static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argument, PthreadAttrImpl* thread_params)
 {
-    void** stack = (void**)((uintptr_t)thread_params->stack_location + thread_params->stack_size);
+    void** stack = (void**)((uintptr_t)thread_params->stack_location.ptr() + thread_params->stack_size);
 
     auto push_on_stack = [&](void* data) {
         stack--;
@@ -158,7 +158,7 @@ int pthread_create(pthread_t* thread, pthread_attr_t const* attributes, void* (*
         used_attributes->schedule_priority,
         used_attributes->guard_page_size,
         used_attributes->stack_size,
-        used_attributes->stack_location);
+        used_attributes->stack_location.ptr());
 
     return create_thread(thread, start_routine, argument_to_start_routine, used_attributes);
 }
@@ -287,7 +287,7 @@ int pthread_attr_init(pthread_attr_t* attributes)
         impl->schedule_priority,
         impl->guard_page_size,
         impl->stack_size,
-        impl->stack_location);
+        impl->stack_location.ptr());
 
     return 0;
 }
@@ -331,7 +331,7 @@ int pthread_attr_setdetachstate(pthread_attr_t* attributes, int detach_state)
         attributes_impl->schedule_priority,
         attributes_impl->guard_page_size,
         attributes_impl->stack_size,
-        attributes_impl->stack_location);
+        attributes_impl->stack_location.ptr());
 
     return 0;
 }
@@ -375,7 +375,7 @@ int pthread_attr_setguardsize(pthread_attr_t* attributes, size_t guard_size)
         attributes_impl->schedule_priority,
         attributes_impl->guard_page_size,
         attributes_impl->stack_size,
-        attributes_impl->stack_location);
+        attributes_impl->stack_location.ptr());
 
     return 0;
 }
@@ -410,7 +410,7 @@ int pthread_attr_setschedparam(pthread_attr_t* attributes, const struct sched_pa
         attributes_impl->schedule_priority,
         attributes_impl->guard_page_size,
         attributes_impl->stack_size,
-        attributes_impl->stack_location);
+        attributes_impl->stack_location.ptr());
 
     return 0;
 }
@@ -423,7 +423,7 @@ int pthread_attr_getstack(pthread_attr_t const* attributes, void** p_stack_ptr, 
     if (!attributes_impl || !p_stack_ptr || !p_stack_size)
         return EINVAL;
 
-    *p_stack_ptr = attributes_impl->stack_location;
+    *p_stack_ptr = attributes_impl->stack_location.ptr();
     *p_stack_size = attributes_impl->stack_size;
 
     return 0;
@@ -455,7 +455,7 @@ int pthread_attr_setstack(pthread_attr_t* attributes, void* p_stack, size_t stac
         attributes_impl->schedule_priority,
         attributes_impl->guard_page_size,
         attributes_impl->stack_size,
-        attributes_impl->stack_location);
+        attributes_impl->stack_location.ptr());
 
     return 0;
 }
@@ -491,7 +491,7 @@ int pthread_attr_setstacksize(pthread_attr_t* attributes, size_t stack_size)
         attributes_impl->schedule_priority,
         attributes_impl->guard_page_size,
         attributes_impl->stack_size,
-        attributes_impl->stack_location);
+        attributes_impl->stack_location.ptr());
 
     return 0;
 }

--- a/Userland/Utilities/fusermount.cpp
+++ b/Userland/Utilities/fusermount.cpp
@@ -15,8 +15,8 @@
 static ErrorOr<void> set_mount_flag(ByteString key, u64 value, int mount_fd)
 {
     MountSpecificFlag flag;
-    flag.key_string_length = key.bytes().size();
-    flag.key_string_addr = key.bytes().data();
+    flag.key_string_length = key.length();
+    flag.key_string_addr = key.characters();
     flag.value_type = MountSpecificFlag::ValueType::UnsignedInteger;
     flag.value_length = 8;
     flag.value_addr = &value;

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -367,9 +367,9 @@ struct Formatter<StringArgument> : StandardFormatter {
         }
 
         // TODO: Avoid trying to copy excessively long strings.
-        auto string_buffer = copy_from_process(string_argument.argument.characters, string_argument.argument.length);
+        auto string_buffer = copy_from_process(string_argument.argument.characters.ptr(), string_argument.argument.length);
         if (string_buffer.is_error()) {
-            builder.appendff("{}{{{:p}, {}b}}", string_buffer.error(), (void const*)string_argument.argument.characters, string_argument.argument.length);
+            builder.appendff("{}{{{:p}, {}b}}", string_buffer.error(), string_argument.argument.characters.ptr(), string_argument.argument.length);
         } else {
             auto view = StringView(string_buffer.value());
             if (!string_argument.trim_by.is_empty())
@@ -664,7 +664,7 @@ static ErrorOr<void> format_poll(FormattedSyscallBuilder& builder, Syscall::SC_p
     auto params = TRY(copy_from_process(params_p));
     builder.add_arguments(
         params.nfds,
-        PointerArgument { params.fds },
+        PointerArgument { params.fds.ptr() },
         TRY(copy_from_process(params.timeout)),
         PointerArgument { params.sigmask });
     return {};
@@ -775,7 +775,7 @@ struct MemoryProtectionFlags : BitflagBase {
 static ErrorOr<void> format_mmap(FormattedSyscallBuilder& builder, Syscall::SC_mmap_params* params_p)
 {
     auto params = TRY(copy_from_process(params_p));
-    builder.add_arguments(params.addr, params.size, MemoryProtectionFlags { params.prot }, MmapFlags { params.flags }, params.fd, params.offset, params.alignment, StringArgument { params.name });
+    builder.add_arguments(params.addr.ptr(), params.size, MemoryProtectionFlags { params.prot }, MmapFlags { params.flags }, params.fd, params.offset, params.alignment, StringArgument { params.name });
     return {};
 }
 
@@ -792,7 +792,7 @@ static void format_mprotect(FormattedSyscallBuilder& builder, void* addr, size_t
 static ErrorOr<void> format_set_mmap_name(FormattedSyscallBuilder& builder, Syscall::SC_set_mmap_name_params* params_p)
 {
     auto params = TRY(copy_from_process(params_p));
-    builder.add_arguments(params.addr, params.size, StringArgument { params.name });
+    builder.add_arguments(params.addr.ptr(), params.size, StringArgument { params.name });
     return {};
 }
 


### PR DESCRIPTION
As the commit title suggests the main change is always passing the pointer arguments as Userspace<T*>.
This commit also makes creations of Userspace pointers more explicit on the kernel side and handles all the fallout from those changes.

These changes include:
* Adding dereferenceability on the Userland side of Userspace<T*>
* Adding const up conversion to Userspace<T*>
* changing kernel/user copies to use the correct overloads
* Adding/removing casts as necessary
* Changing signatures as necessary

And a bit more controversial:
* Changing futex params to contain volatile pointers
   This was the easiest way of getting the correct types for the atomic operations in sys$futex. The Kernel APIs should likely change signature instead, as volatility and atomicity are two very different concepts in modern c++.