### PR TITLE
LibC: Respect FILE's direction in fread and fwrite

### DIFF
--- a/Tests/LibC/TestStdio.cpp
+++ b/Tests/LibC/TestStdio.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibFileSystem/TempFile.h>
 #include <LibTest/TestCase.h>
 #include <stdio.h>
 #include <sys/wait.h>
@@ -53,4 +54,28 @@ TEST_CASE(sprintf_sign)
 
     EXPECT_EQ(buf1, "+12"sv);
     EXPECT_EQ(buf2, "-12"sv);
+}
+
+TEST_CASE(cannot_write_to_read_only_file)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+
+    auto c_file = fopen(temp_file->path().characters(), "r");
+    EXPECT(c_file);
+
+    EXPECT_EQ(fputc('x', c_file), EOF);
+    EXPECT(ferror(c_file));
+    EXPECT(!fclose(c_file));
+}
+
+TEST_CASE(cannot_read_from_write_only_file)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+
+    auto c_file = fopen(temp_file->path().characters(), "w");
+    EXPECT(c_file);
+
+    EXPECT_EQ(fgetc(c_file), EOF);
+    EXPECT(ferror(c_file));
+    EXPECT(!fclose(c_file));
 }

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -169,6 +169,11 @@ bool FILE::write_from_buffer()
 
 size_t FILE::read(u8* data, size_t size)
 {
+    if (!(m_mode & O_RDONLY)) {
+        set_err();
+        return 0;
+    }
+
     size_t total_read = 0;
 
     m_flags |= Flags::LastRead;
@@ -211,6 +216,11 @@ size_t FILE::read(u8* data, size_t size)
 
 size_t FILE::write(u8 const* data, size_t size)
 {
+    if (!(m_mode & O_WRONLY)) {
+        set_err();
+        return 0;
+    }
+
     size_t total_written = 0;
 
     m_flags &= ~Flags::LastRead;

--- a/Userland/Libraries/LibFileSystem/TempFile.h
+++ b/Userland/Libraries/LibFileSystem/TempFile.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/String.h>
 
 namespace FileSystem {

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -519,6 +519,28 @@ static void format_exit(FormattedSyscallBuilder& builder, int status)
     builder.add_argument(status);
 }
 
+VALUES_TO_NAMES(fcntl_command)
+HANDLE(F_DUPFD)
+HANDLE(F_GETFD)
+HANDLE(F_SETFD)
+HANDLE(F_GETFL)
+HANDLE(F_SETFL)
+HANDLE(F_ISTTY)
+HANDLE(F_GETLK)
+HANDLE(F_SETLK)
+HANDLE(F_SETLKW)
+HANDLE(F_DUPFD_CLOEXEC)
+END_VALUES_TO_NAMES()
+
+static void format_fcntl(FormattedSyscallBuilder& builder, int fd, int cmd, int arg1, int arg2)
+{
+    builder.add_arguments(fd, fcntl_command(cmd));
+    // FIXME: Format command args.
+    (void)arg1;
+    (void)arg2;
+    builder.add_arguments("...");
+}
+
 static void format_ftruncate(FormattedSyscallBuilder& builder, int fd, off_t length)
 {
     builder.add_arguments(fd, length);
@@ -885,6 +907,9 @@ static ErrorOr<void> format_syscall_early(FormattedSyscallBuilder& builder, Sysc
         break;
     case SC_exit:
         format_exit(builder, (int)arg1);
+        break;
+    case SC_fcntl:
+        format_fcntl(builder, (int)arg1, (int)arg2, (int)arg3, (int)arg4);
         break;
     case SC_ftruncate:
         format_ftruncate(builder, (int)arg1, (off_t)arg2);


### PR DESCRIPTION
Don't allow writing to a read-only file or reading from a write-only file.

---

The PR also includes a strace commit that I wrote when I started to debug this.

This fixes libcxx's:
std/input.output/iostream.format/print.fun/print.file.pass.cpp
std/input.output/iostream.format/print.fun/println.file.pass.cpp
std/input.output/iostream.format/print.fun/vprint_nonunicode.file.pass.cpp
std/input.output/iostream.format/print.fun/vprint_unicode.file.pass.cpp