### PR TITLE
AK: Printf enhancement

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -12,6 +12,7 @@
 #include <stdarg.h>
 
 #ifndef KERNEL
+#    include <AK/FloatingPoint.h>
 #    include <math.h>
 #    include <wchar.h>
 #endif
@@ -248,6 +249,89 @@ ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number
 
     return length;
 }
+
+template<typename PutChFunc, typename CharType>
+ALWAYS_INLINE int print_double_as_hex(PutChFunc putch, CharType*& bufptr, double number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, u32 precision)
+{
+    int length = 0;
+
+    bool sign = signbit(number);
+
+    length = print_nan_and_inf(putch, bufptr, number, sign, always_sign, left_pad, field_width);
+    if (length > 0)
+        return length;
+
+    if (sign || always_sign) {
+        if (sign)
+            putch(bufptr, '-');
+        else
+            putch(bufptr, '+');
+        length++;
+    }
+
+    if (left_pad || zero_pad) {
+        dbgln("FIXME: Modifiers are unsupported with %a");
+        (void)zero_pad;
+        (void)precision;
+    }
+
+    auto extractor = FloatExtractor<f64>::from_float(number);
+
+    if (extractor.exponent == 0 && extractor.mantissa == 0) {
+        // FIXME: Maybe share the modifiers logic with print_nan_and_inf.
+        putch(bufptr, '0');
+        putch(bufptr, 'x');
+        putch(bufptr, '0');
+        putch(bufptr, 'p');
+        putch(bufptr, '+');
+        putch(bufptr, '0');
+        length += 6;
+
+        return length;
+    }
+
+    putch(bufptr, '0');
+    putch(bufptr, 'x');
+    putch(bufptr, '1');
+    length += 3;
+
+    if (extractor.mantissa != 0) {
+        putch(bufptr, '.');
+        length++;
+
+        bool has_seen_non_zero = false;
+        u32 first_trailing_zero = 0;
+        for (u32 i = FloatExtractor<f64>::mantissa_bits; i > 0; i -= 4) {
+            auto extracted = extractor.mantissa & (0xFul << (i - 4));
+
+            if (!has_seen_non_zero) {
+                if (extracted != 0)
+                    has_seen_non_zero = true;
+                continue;
+            }
+
+            if (extracted == 0) {
+                first_trailing_zero = i;
+                break;
+            }
+        }
+        u32 mantissa_precision = (FloatExtractor<f64>::mantissa_bits - first_trailing_zero) / 4;
+
+        auto without_right_zeroes = extractor.mantissa;
+        while ((without_right_zeroes & 0xFu) == 0)
+            without_right_zeroes >>= 4u;
+
+        length += print_hex(putch, bufptr, without_right_zeroes, false, false, false, true, mantissa_precision, false, 0);
+    }
+
+    putch(bufptr, 'p');
+    length++;
+
+    auto unbiased_exponent = static_cast<i32>(extractor.exponent) - FloatExtractor<f64>::exponent_bias;
+    length += print_decimal(putch, bufptr, abs(unbiased_exponent), unbiased_exponent < 0, true, false, false, 0, false, 0);
+
+    return length;
+}
 #endif
 template<typename PutChFunc, typename CharType>
 ALWAYS_INLINE int print_octal_number(PutChFunc putch, CharType*& bufptr, u64 number, bool alternate_form, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
@@ -436,6 +520,10 @@ struct PrintfImpl {
     {
         return print_double(m_putch, m_bufptr, NextArgument<double>()(ap), state.always_sign, state.left_pad, state.zero_pad, state.field_width, state.precision, true);
     }
+    ALWAYS_INLINE int format_a(ModifierState const& state, ArgumentListRefT ap) const
+    {
+        return print_double_as_hex(m_putch, m_bufptr, NextArgument<double>()(ap), state.always_sign, state.left_pad, state.zero_pad, state.field_width, state.precision);
+    }
 #endif
     ALWAYS_INLINE int format_o(ModifierState const& state, ArgumentListRefT ap) const
     {
@@ -623,6 +711,7 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, IdentityType<CharType>* buffe
 #ifndef KERNEL
                 PRINTF_IMPL_DELEGATE_TO_IMPL(f);
                 PRINTF_IMPL_DELEGATE_TO_IMPL(g);
+                PRINTF_IMPL_DELEGATE_TO_IMPL(a);
 #endif
                 PRINTF_IMPL_DELEGATE_TO_IMPL(i);
                 PRINTF_IMPL_DELEGATE_TO_IMPL(n);

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -164,13 +164,10 @@ ALWAYS_INLINE int print_decimal(PutChFunc putch, CharType*& bufptr, u64 number, 
 }
 #ifndef KERNEL
 template<typename PutChFunc, typename CharType>
-ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, u32 precision, bool trailing_zeros)
+ALWAYS_INLINE u32 print_nan_and_inf(PutChFunc putch, CharType*& bufptr, double number, bool sign, u32 field_width)
 {
-    int length = 0;
+    u32 length = 0;
 
-    u32 whole_width = (field_width >= precision + 1) ? field_width - precision - 1 : 0;
-
-    bool sign = signbit(number);
     bool nan = isnan(number);
     bool inf = isinf(number);
 
@@ -192,12 +189,26 @@ ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number
             putch(bufptr, 'n');
             putch(bufptr, 'f');
         }
-        return length + 3;
+        length += 3;
     }
+    return length;
+}
+
+template<typename PutChFunc, typename CharType>
+ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, u32 precision, bool trailing_zeros)
+{
+    int length = 0;
+
+    bool sign = signbit(number);
+
+    length = print_nan_and_inf(putch, bufptr, number, sign, field_width);
+    if (length > 0)
+        return length;
 
     if (sign)
         number = -number;
 
+    u32 whole_width = (field_width >= precision + 1) ? field_width - precision - 1 : 0;
     length = print_decimal(putch, bufptr, (i64)number, sign, always_sign, left_pad, zero_pad, whole_width, false, 1);
     if (precision > 0) {
         double fraction = number - (i64)number;

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -164,7 +164,7 @@ ALWAYS_INLINE int print_decimal(PutChFunc putch, CharType*& bufptr, u64 number, 
 }
 #ifndef KERNEL
 template<typename PutChFunc, typename CharType>
-ALWAYS_INLINE u32 print_nan_and_inf(PutChFunc putch, CharType*& bufptr, double number, bool sign, u32 field_width)
+ALWAYS_INLINE u32 print_nan_and_inf(PutChFunc putch, CharType*& bufptr, double number, bool sign, bool always_sign, bool left_pad, u32 field_width)
 {
     u32 length = 0;
 
@@ -172,12 +172,21 @@ ALWAYS_INLINE u32 print_nan_and_inf(PutChFunc putch, CharType*& bufptr, double n
     bool inf = isinf(number);
 
     if (nan || inf) {
-        for (unsigned i = 0; i < field_width - 3 - sign; i++) {
-            putch(bufptr, ' ');
-            length++;
+        bool include_sign = sign || always_sign;
+        u32 minimum_width = 3 + include_sign;
+        auto padding_width = field_width > minimum_width ? field_width - minimum_width : 0;
+
+        if (!left_pad) {
+            for (unsigned i = 0; i < padding_width; i++)
+                putch(bufptr, ' ');
+            length += padding_width;
         }
-        if (sign) {
-            putch(bufptr, '-');
+
+        if (include_sign) {
+            if (sign)
+                putch(bufptr, '-');
+            else
+                putch(bufptr, '+');
             length++;
         }
         if (nan) {
@@ -190,6 +199,12 @@ ALWAYS_INLINE u32 print_nan_and_inf(PutChFunc putch, CharType*& bufptr, double n
             putch(bufptr, 'f');
         }
         length += 3;
+
+        if (left_pad) {
+            for (unsigned i = 0; i < padding_width; i++)
+                putch(bufptr, ' ');
+            length += padding_width;
+        }
     }
     return length;
 }
@@ -201,7 +216,7 @@ ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number
 
     bool sign = signbit(number);
 
-    length = print_nan_and_inf(putch, bufptr, number, sign, field_width);
+    length = print_nan_and_inf(putch, bufptr, number, sign, always_sign, left_pad, field_width);
     if (length > 0)
         return length;
 

--- a/Tests/LibC/TestSnprintf.cpp
+++ b/Tests/LibC/TestSnprintf.cpp
@@ -386,3 +386,19 @@ TEST_CASE(g_format)
     EXPECT(test_single<double>({ LITERAL("xxxxx"), "|%g|", 10.0000001, 4, LITERAL("|10|\0") }));
     EXPECT(test_single<double>({ LITERAL("xxxxx"), "|%g|", 10.0000000001, 4, LITERAL("|10|\0") }));
 }
+
+TEST_CASE(a_format)
+{
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxx"), "|%a|", 0.0, 8, LITERAL("|0x0p+0|\0") }));
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxxx"), "|%a|", -0.0, 9, LITERAL("|-0x0p+0|\0") }));
+
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxx"), "|%a|", 1.0, 8, LITERAL("|0x1p+0|\0") }));
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxxxxxxxxxxxxxxxxx"), "|%+a|", 1.1, 23, LITERAL("|+0x1.199999999999ap+0|\0") }));
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxxxxxxxxxxxxxxxxx"), "|%a|", -1.12, 23, LITERAL("|-0x1.1eb851eb851ecp+0|\0") }));
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxxxxxxxxxxxxxxxx"), "|%a|", 10.0000001, 22, LITERAL("|0x1.40000035afe53p+3|\0") }));
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxxxxxxxxxxxxxxxx"), "|%a|", 10.0000000001, 22, LITERAL("|0x1.400000000dbe7p+3|\0") }));
+
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxxxx"), "|%a|", 42, 10, LITERAL("|0x1.5p+5|\0") }));
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxxxxx"), "|%a|", 420, 11, LITERAL("|0x1.a4p+8|\0") }));
+    EXPECT(test_single<double>({ LITERAL("xxxxxxxxxxxxxx"), "|%a|", 4200, 13, LITERAL("|0x1.068p+12|\0") }));
+}

--- a/Tests/LibC/TestSnprintf.cpp
+++ b/Tests/LibC/TestSnprintf.cpp
@@ -12,6 +12,7 @@
 #include <ctype.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -304,6 +305,28 @@ TEST_CASE(float_value_special)
     v.i = 0x7ff0000000000000;
     EXPECT(test_single<double>({ LITERAL("xxxxxxx"), "|%4f|", v.f, 6, LITERAL("| inf|\0") }));
     EXPECT(test_single<double>({ LITERAL("xxxxxxx"), "|%4f|", -v.f, 6, LITERAL("|-inf|\0") }));
+}
+
+TEST_CASE(float_nan_and_inf)
+{
+    EXPECT(test_single<float>({ LITERAL("xxxxxx"), "|%f|", NAN, 5, LITERAL("|nan|\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxx"), "|%+f|", NAN, 6, LITERAL("|+nan|\0") }));
+
+    EXPECT(test_single<float>({ LITERAL("xxxxxxx"), "|%f|", -INFINITY, 6, LITERAL("|-inf|\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxx"), "|%+f|", -INFINITY, 6, LITERAL("|-inf|\0") }));
+
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%08f|", NAN, 10, LITERAL("|     nan|\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%+08f|", NAN, 10, LITERAL("|    +nan|\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%08f|", -INFINITY, 10, LITERAL("|    -inf|\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%+08f|", -INFINITY, 10, LITERAL("|    -inf|\0") }));
+
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%8f|", NAN, 10, LITERAL("|     nan|\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%+8f|", NAN, 10, LITERAL("|    +nan|\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%8f|", -INFINITY, 10, LITERAL("|    -inf|\0") }));
+
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%-8f|", NAN, 10, LITERAL("|nan     |\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%-+8f|", NAN, 10, LITERAL("|+nan    |\0") }));
+    EXPECT(test_single<float>({ LITERAL("xxxxxxxxxxx"), "|%-8f|", -INFINITY, 10, LITERAL("|-inf    |\0") }));
 }
 
 TEST_CASE(string_precision)


### PR DESCRIPTION
The %a implementation is quite limited, but at least it comes with decent test coverage so hopefully it won't be a pain to modify in the future.

This makes us pass these 19 libcxx tests:

<details>
<summary>Details</summary>

std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bernoulli/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.geo/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.negbin/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.cauchy/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.chisq/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.f/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.lognormal/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.normal/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.t/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.exp/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.extreme/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.gamma/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.poisson/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.weibull/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.samp/rand.dist.samp.discrete/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.samp/rand.dist.samp.pconst/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.samp/rand.dist.samp.plinear/io.pass.cpp
std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/io.pass.cpp
</details>

These tests are mainly about the serialization of distributions, and they use the `%a` formatter to save the distribution's parameters.