### PR TITLE
LibC: Improve lgamma coverage, performance and precision

### DIFF
--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -277,7 +277,9 @@ TEST_CASE(gamma)
     EXPECT(isnan(tgamma(-INFINITY)));
     EXPECT(isnan(tgamma(-5)));
 
-    // TODO: investigate Stirling approximation implementation of gamma function
+    // TODO: Stirling approximation is not precise for small values.
+    //       Eyeballed from the graph on https://en.wikipedia.org/wiki/Stirling%27s_approximation,
+    //       we should use another approximation for x < 2.
     // EXPECT_APPROXIMATE(tgamma(0.5), sqrt(M_PI));
     EXPECT_EQ(tgammal(21.0l), 2'432'902'008'176'640'000.0l);
     EXPECT_EQ(tgamma(19.0), 6'402'373'705'728'000.0);

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -286,6 +286,13 @@ TEST_CASE(gamma)
     EXPECT_EQ(tgammaf(11.0f), 3628800.0f);
     EXPECT_EQ(tgamma(4.0), 6);
 
+    // The stirling approximation for log(gamma(x)) is O(log(x)), so the error
+    // of 10 is well inside the range. That being said, we're off the expected
+    // results because our log(x) is not precise.
+    // Expected results are from WolframAlpha.
+    EXPECT_APPROXIMATE_WITH_ERROR(lgamma(128738941), 2275241556.917756, 10);
+    EXPECT_APPROXIMATE_WITH_ERROR(lgamma(128738943), 2275241594.264350, 10);
+
     EXPECT_EQ(lgamma(1.0), 0.0);
     EXPECT_EQ(lgamma(2.0), 0.0);
     EXPECT(isinf(lgamma(0.0)));

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -297,6 +297,18 @@ static FloatT internal_gamma(FloatT x) NOEXCEPT
     return sqrtl(2.0 * M_PIl / static_cast<long double>(x)) * powl(static_cast<long double>(x) / M_El, static_cast<long double>(x));
 }
 
+template<typename Float>
+Float internal_lgamma(Float value, int* sign)
+{
+    if (value == static_cast<Float>(1.0) || value == static_cast<Float>(2.0))
+        return 0.0;
+    if (isinf(value) || value == static_cast<Float>(0.0))
+        return INFINITY;
+    Float result = AK::log(internal_gamma(value));
+    *sign = signbit(result) ? -1 : 1;
+    return result;
+}
+
 extern "C" {
 
 float nanf(char const* s) NOEXCEPT
@@ -900,35 +912,17 @@ float lgammaf(float value) NOEXCEPT
 
 long double lgammal_r(long double value, int* sign) NOEXCEPT
 {
-    if (value == 1.0 || value == 2.0)
-        return 0.0;
-    if (isinf(value) || value == 0.0)
-        return INFINITY;
-    long double result = logl(internal_gamma(value));
-    *sign = signbit(result) ? -1 : 1;
-    return result;
+    return internal_lgamma(value, sign);
 }
 
 double lgamma_r(double value, int* sign) NOEXCEPT
 {
-    if (value == 1.0 || value == 2.0)
-        return 0.0;
-    if (isinf(value) || value == 0.0)
-        return INFINITY;
-    double result = log(internal_gamma(value));
-    *sign = signbit(result) ? -1 : 1;
-    return result;
+    return internal_lgamma(value, sign);
 }
 
 float lgammaf_r(float value, int* sign) NOEXCEPT
 {
-    if (value == 1.0f || value == 2.0f)
-        return 0.0;
-    if (isinf(value) || value == 0.0f)
-        return INFINITY;
-    float result = logf(internal_gamma(value));
-    *sign = signbit(result) ? -1 : 1;
-    return result;
+    return internal_lgamma(value, sign);
 }
 
 long double expm1l(long double x) NOEXCEPT

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -304,7 +304,11 @@ Float internal_lgamma(Float value, int* sign)
         return 0.0;
     if (isinf(value) || value == static_cast<Float>(0.0))
         return INFINITY;
-    Float result = AK::log(internal_gamma(value));
+
+    // Use the Stirling approximation for log(gamma(x)) directly.
+    // This allows us to support bigger values of x, where gamma(x) would have returned inf.
+    // https://en.wikipedia.org/wiki/Stirling%27s_approximation
+    Float result = value * AK::log(value) - value;
     *sign = signbit(result) ? -1 : 1;
     return result;
 }


### PR DESCRIPTION
(in theory)
This makes us use a direct approximation of `log(gamma(x))` instead of computing it literally. This is required to obtain results for large values of `x`. The Gamma function can produce extremely large values, causing `gamma(x)` to return `inf` even when `lgamma(x)` can still return a finite result. This explains the coverage part of the title. Performance and precision gains have not been measured, but the approximation is simpler so they should be there if we look.

---

Now it's time for a fun story. Libcxx uses the `lgamma` function to initialize the parameters of `std::binomial_distribution`, and then the `operator()` is implemented as an iterative algorithm from these parameters (see [here](https://github.com/llvm/llvm-project/blob/76111306082b5be7fcfcc34d181cef26326cd4f5/libcxx/include/__random/binomial_distribution.h#L113-L153)).
This iterative algorithm, when fed with proper values usually returns in less than three iterations, but when there is a `nan` in these parameters, it can take many more iterations... In fact, it's always the same number: 128738941 iterations. This is for every invocation of the `operator()`, you have guessed it, it is _substantially_ slower.

The issue made this test take forever:
[std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp](https://github.com/llvm/llvm-project/blob/main/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp)

This test invokes `std::binomial_distribution::operator()` `N` times. With `N` set to `10` it took ~5s, but the upstream value is `1000000`, so completing the test would have taken `~500000` seconds, just under 6 days...

With this PR, it completes (still doesn't pass though :cry:) in 200ms. That's around **2.5 millions** times faster.