### PR TITLE
LibVT: Correct SGR conflict with hyperlinks

### DIFF
--- a/Kernel/Devices/TTY/VirtualConsole.h
+++ b/Kernel/Devices/TTY/VirtualConsole.h
@@ -59,7 +59,7 @@ public:
         void clear()
         {
             ch = ' ';
-            attribute.reset();
+            attribute = VT::Attribute();
         }
         char ch;
         VT::Attribute attribute;

--- a/Userland/Libraries/LibVT/Attribute.h
+++ b/Userland/Libraries/LibVT/Attribute.h
@@ -22,15 +22,11 @@ struct Attribute {
     static constexpr Color default_foreground_color = Color::named(Color::ANSIColor::DefaultForeground);
     static constexpr Color default_background_color = Color::named(Color::ANSIColor::DefaultBackground);
 
-    void reset()
+    void reset_style()
     {
         foreground_color = default_foreground_color;
         background_color = default_background_color;
         flags = Flags::NoAttributes;
-#ifndef KERNEL
-        href = {};
-        href_id = {};
-#endif
     }
 
     Color foreground_color { default_foreground_color };
@@ -39,6 +35,12 @@ struct Attribute {
 #ifndef KERNEL
     ByteString href;
     Optional<ByteString> href_id;
+
+    void reset_hyperlink()
+    {
+        href = {};
+        href_id = {};
+    }
 #endif
 
     enum class Flags : u8 {

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -236,7 +236,7 @@ void Terminal::DECSET(Parameters params)
 void Terminal::SGR(Parameters params)
 {
     if (params.is_empty()) {
-        m_current_state.attribute.reset();
+        m_current_state.attribute.reset_style();
         return;
     }
     auto parse_color = [&]() -> Optional<Color> {
@@ -282,7 +282,7 @@ void Terminal::SGR(Parameters params)
             switch (param) {
             case 0:
                 // Reset
-                m_current_state.attribute.reset();
+                m_current_state.attribute.reset_style();
                 break;
             case 1:
                 m_current_state.attribute.flags |= Attribute::Flags::Bold;
@@ -1348,8 +1348,7 @@ void Terminal::execute_osc_sequence(OscParameters parameters, u8 last_byte)
             dbgln("Attempted to set href but gave too few parameters");
         } else if (parameters[1].is_empty() && parameters[2].is_empty()) {
             // Clear hyperlink
-            m_current_state.attribute.href = {};
-            m_current_state.attribute.href_id = {};
+            m_current_state.attribute.reset_hyperlink();
         } else {
             m_current_state.attribute.href = stringview_ify(2);
             // FIXME: Respect the provided ID


### PR DESCRIPTION
While in the middle of an hyperlink sequence if you emitted a SGR reset code it would cause the hyperlink chain to end before the hyperlink closing sequence.

Caused by the `VT::Attribute::reset` function clearing both the styling and hyperlink information when called from the SGR handler.