### PR TITLE
LibGUI: Validate shortcuts before finding the corresponding Action

### DIFF
--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -67,6 +67,9 @@ NonnullRefPtr<Action> Action::create_checkable(ByteString text, Shortcut const& 
 
 RefPtr<Action> Action::find_action_for_shortcut(Core::EventReceiver& object, Shortcut const& shortcut)
 {
+    if (!shortcut.is_valid())
+        return nullptr;
+
     RefPtr<Action> found_action = nullptr;
     object.for_each_child_of_type<Action>([&](auto& action) {
         if (action.shortcut() == shortcut || action.alternate_shortcut() == shortcut) {

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -134,8 +134,10 @@ void Application::quit(int exit_code)
 
 void Application::register_global_shortcut_action(Badge<Action>, Action& action)
 {
-    m_global_shortcut_actions.set(action.shortcut(), &action);
-    m_global_shortcut_actions.set(action.alternate_shortcut(), &action);
+    if (action.shortcut().is_valid())
+        m_global_shortcut_actions.set(action.shortcut(), &action);
+    if (action.alternate_shortcut().is_valid())
+        m_global_shortcut_actions.set(action.alternate_shortcut(), &action);
 }
 
 void Application::unregister_global_shortcut_action(Badge<Action>, Action& action)


### PR DESCRIPTION
Properly checks if a shortcut is valid before trying to find the corresponding Action for that shortcut.

Fixes the issue of having the About window of an application being opened when you pressed a key that didn't have a proper keyboard mapping and generated a Key_Invalid keycode. In my case the ABNT2 /+? key also known as the International1 key.

Being caused by the fact that the Shortcut class defaults its keyboard shortcut to the Key_Invalid keycode which caused actions without a keyboard shortcut, such as the About window action, to be found and opened when the Shortcut to be searched for contained a Key_Invalid keycode.