### PR TITLE
AK: Handle edge cases correctly in hypot

### DIFF
--- a/AK/Math/Trigonometry.h
+++ b/AK/Math/Trigonometry.h
@@ -22,6 +22,13 @@ namespace Trigonometry {
 template<FloatingPoint T>
 constexpr T hypot(T x, T y)
 {
+    // "If x or y is ±Inf, +Inf shall be returned (even if one of x or y is NaN)."
+    if (isinf(x) || isinf(y))
+        return Infinity<T>;
+    // "If x or y is NaN, and the other is not ±Inf, a NaN shall be returned."
+    if (isnan(x) || isnan(y))
+        return NaN<T>;
+
     return sqrt(x * x + y * y);
 }
 

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -395,3 +395,23 @@ TEST_CASE(round)
     EXPECT_EQ(round(9999999999999.5), 10000000000000.0);
     EXPECT_EQ(round(-9999999999999.5), -10000000000000.0);
 }
+
+TEST_CASE(hypot)
+{
+    double r = hypot(INFINITY, INFINITY);
+    EXPECT(isinf(r));
+    EXPECT(!signbit(r));
+    r = hypot(INFINITY, NAN);
+    EXPECT(isinf(r));
+    EXPECT(!signbit(r));
+    r = hypot(+INFINITY, 42);
+    EXPECT(isinf(r));
+    EXPECT(!signbit(r));
+    r = hypot(42, -INFINITY);
+    EXPECT(isinf(r));
+    EXPECT(!signbit(r));
+
+    EXPECT(isnan(hypot(NAN, NAN)));
+    EXPECT(isnan(hypot(+NAN, 42)));
+    EXPECT(isnan(hypot(42, -NAN)));
+}


### PR DESCRIPTION
Fixes this libcxx test:
std/numerics/complex.number/complex.value.ops/abs.pass.cpp

(`abs` is implemented as `hypot(real, imag)`)