### PR TITLE
LibC: Stub the timespec_get function

### DIFF
--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -520,4 +520,12 @@ double difftime(time_t t1, time_t t0)
 {
     return (double)(t1 - t0);
 }
+
+int timespec_get(struct timespec* ts, int base)
+{
+    (void)ts;
+    (void)base;
+    dbgln("FIXME: Implement timespec_get");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/time.h
+++ b/Userland/Libraries/LibC/time.h
@@ -52,4 +52,7 @@ struct tm* localtime_r(time_t const* timep, struct tm* result);
 double difftime(time_t, time_t);
 size_t strftime(char* s, size_t max, char const* format, const struct tm*) __attribute__((format(strftime, 3, 0)));
 
+#define TIME_UTC 0
+int timespec_get(struct timespec*, int);
+
 __END_DECLS


### PR DESCRIPTION
And add the related TIME_UTC macro.

This makes us pass this libcxx test:
std/language.support/support.runtime/ctime.timespec.compile.pass.cpp