### PR TITLE
Kernel: Return ENOENT on empty paths

### DIFF
--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -806,7 +806,7 @@ NonnullRefPtr<Custody> Process::current_directory()
 ErrorOr<NonnullOwnPtr<KString>> Process::get_syscall_path_argument(Userspace<char const*> user_path, size_t path_length)
 {
     if (path_length == 0)
-        return EINVAL;
+        return ENOENT;
     if (path_length > PATH_MAX)
         return ENAMETOOLONG;
     return try_copy_kstring_from_user(user_path, path_length);

--- a/Tests/Kernel/POSIX/TestFIFO.cpp
+++ b/Tests/Kernel/POSIX/TestFIFO.cpp
@@ -21,6 +21,13 @@ ErrorOr<ByteString> make_fifo()
 
 }
 
+TEST_CASE(empty_path)
+{
+    auto error = Core::System::mkfifo(""sv, 0600);
+    EXPECT(error.is_error());
+    EXPECT_EQ(error.error().code(), ENOENT);
+}
+
 TEST_CASE(read_nonblock)
 {
     auto path = TRY_OR_FAIL(make_fifo());

--- a/Tests/Kernel/TestKernelUnveil.cpp
+++ b/Tests/Kernel/TestKernelUnveil.cpp
@@ -28,7 +28,7 @@ TEST_CASE(test_argument_validation)
 
     res = unveil("", "r");
     EXPECT_EQ(res, -1);
-    EXPECT_EQ(errno, EINVAL);
+    EXPECT_EQ(errno, ENOENT);
 
     res = unveil("test", "r");
     EXPECT_EQ(res, -1);


### PR DESCRIPTION
AFAICT, this is what most syscalls specify:

[ENOENT]
    A component of the path prefix specified by path does not name an
    existing directory or path is an empty string.

This fixes the following libcxx tests:
std/input.output/filesystems/class.directory_entry/directory_entry.mods/refresh.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.file_size/file_size.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.remove/remove.pass.cpp
std/input.output/filesystems/fs.op.funcs/fs.op.remove_all/remove_all.pass.cpp