### PR TITLE
AK: Handle edge cases correctly in exp, cosh, sinh and tanh

### DIFF
--- a/AK/Math/Exponentials.h
+++ b/AK/Math/Exponentials.h
@@ -12,6 +12,7 @@
 #include <AK/Math/Constants.h>
 #include <AK/Math/Fabs.h>
 #include <AK/NumericLimits.h>
+#include <math.h>
 
 #include <AK/Math/Macros.h>
 
@@ -223,6 +224,19 @@ template<FloatingPoint T>
 constexpr T exp(T exponent)
 {
     CONSTEXPR_STATE(exp, exponent);
+
+    // "If x is NaN, a NaN shall be returned."
+    if (isnan(exponent))
+        return NaN<T>;
+    // "If x is ±0, 1 shall be returned."
+    if (exponent == 0)
+        return T(1);
+    // "If x is -Inf, +0 shall be returned."
+    if (isinf(exponent) && signbit(exponent))
+        return T(0);
+    // "If x is +Inf, x shall be returned."
+    if (isinf(exponent))
+        return exponent;
 
 #if ARCH(X86_64)
     T res;

--- a/AK/Math/Hyperbolic.h
+++ b/AK/Math/Hyperbolic.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <AK/Math/Copysign.h>
 #include <AK/Math/Sqrt.h>
+#include <math.h>
 
 #include <AK/Math/Macros.h>
 
@@ -37,6 +39,16 @@ constexpr T cosh(T x)
 template<FloatingPoint T>
 constexpr T tanh(T x)
 {
+    // "If x is NaN, a NaN shall be returned."
+    if (isnan(x))
+        return NaN<T>;
+    // "If x is ±0, x shall be returned."
+    if (x == 0)
+        return x;
+    // "If x is ±Inf, ±1 shall be returned."
+    if (isinf(x))
+        return AK::copysign(T(1), x);
+
     if (x > 0) {
         T exponentiated = exp<T>(2 * x);
         return (exponentiated - 1) / (exponentiated + 1);

--- a/AK/Math/Hyperbolic.h
+++ b/AK/Math/Hyperbolic.h
@@ -19,6 +19,13 @@ namespace Hyperbolic {
 template<FloatingPoint T>
 constexpr T sinh(T x)
 {
+    // "If x is NaN, a NaN shall be returned."
+    if (isnan(x))
+        return NaN<T>;
+    // "If x is ±0 or ±Inf, x shall be returned."
+    if (x == 0 || isinf(x))
+        return x;
+
     T exponentiated = exp<T>(x);
     if (x > 0)
         return (exponentiated * exponentiated - 1) / 2 / exponentiated;

--- a/AK/Math/Hyperbolic.h
+++ b/AK/Math/Hyperbolic.h
@@ -37,6 +37,16 @@ constexpr T cosh(T x)
 {
     CONSTEXPR_STATE(cosh, x);
 
+    // "If x is NaN, a NaN shall be returned."
+    if (isnan(x))
+        return NaN<T>;
+    // "If x is ±0, the value 1.0 shall be returned."
+    if (x == 0)
+        return T(1.0);
+    // "If x is ±Inf, +Inf shall be returned."
+    if (isinf(x))
+        return Infinity<T>;
+
     T exponentiated = exp(-x);
     if (x < 0)
         return (1 + exponentiated * exponentiated) / 2 / exponentiated;

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -428,3 +428,12 @@ TEST_CASE(tanh)
     EXPECT_EQ(tanh(AK::Infinity<double>), 1.0);
     EXPECT_EQ(tanh(-AK::Infinity<double>), -1.0);
 }
+
+TEST_CASE(sinh)
+{
+    EXPECT(isnan(sinh(AK::NaN<double>)));
+    EXPECT_EQ(sinh(0.0), 0.0);
+    EXPECT_EQ(sinh(-0.0), -0.0);
+    EXPECT_EQ(sinh(AK::Infinity<double>), AK::Infinity<double>);
+    EXPECT_EQ(sinh(-AK::Infinity<double>), -AK::Infinity<double>);
+}

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -449,3 +449,15 @@ TEST_CASE(cosh)
     EXPECT_EQ(cosh(AK::Infinity<double>), AK::Infinity<double>);
     EXPECT_EQ(cosh(-AK::Infinity<double>), AK::Infinity<double>);
 }
+
+TEST_CASE(exp)
+{
+    EXPECT(isnan(exp(AK::NaN<double>)));
+
+    EXPECT_EQ(exp(0.0), 1.0);
+    EXPECT_EQ(exp(-0.0), 1.0);
+
+    EXPECT_EQ(exp(-AK::Infinity<double>), 0.0);
+
+    EXPECT_EQ(exp(AK::Infinity<double>), AK::Infinity<double>);
+}

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -415,3 +415,16 @@ TEST_CASE(hypot)
     EXPECT(isnan(hypot(+NAN, 42)));
     EXPECT(isnan(hypot(42, -NAN)));
 }
+
+TEST_CASE(tanh)
+{
+    EXPECT(isnan(tanh(AK::NaN<double>)));
+
+    EXPECT_EQ(tanh(0.0), 0);
+    EXPECT_EQ(signbit(tanh(0.0)), 0);
+    EXPECT_EQ(tanh(-0.0), 0);
+    EXPECT_EQ(signbit(tanh(-0.0)), 1);
+
+    EXPECT_EQ(tanh(AK::Infinity<double>), 1.0);
+    EXPECT_EQ(tanh(-AK::Infinity<double>), -1.0);
+}

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -432,8 +432,20 @@ TEST_CASE(tanh)
 TEST_CASE(sinh)
 {
     EXPECT(isnan(sinh(AK::NaN<double>)));
+
     EXPECT_EQ(sinh(0.0), 0.0);
     EXPECT_EQ(sinh(-0.0), -0.0);
     EXPECT_EQ(sinh(AK::Infinity<double>), AK::Infinity<double>);
     EXPECT_EQ(sinh(-AK::Infinity<double>), -AK::Infinity<double>);
+}
+
+TEST_CASE(cosh)
+{
+    EXPECT(isnan(cosh(AK::NaN<double>)));
+
+    EXPECT_EQ(cosh(0.0), 1.0);
+    EXPECT_EQ(cosh(-0.0), 1.0);
+
+    EXPECT_EQ(cosh(AK::Infinity<double>), AK::Infinity<double>);
+    EXPECT_EQ(cosh(-AK::Infinity<double>), AK::Infinity<double>);
 }


### PR DESCRIPTION
This fixes these libcxx tests:

std/numerics/complex.number/complex.transcendentals/cosh.pass.cpp
/numerics/complex.number/complex.transcendentals/exp.pass.cpp
std/numerics/complex.number/complex.transcendentals/sinh.pass.cpp
std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp