### PR TITLE
Ports/ncurses: Remove the --enable-term-driver build option

### DIFF
--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -5,7 +5,6 @@ useconfigure='true'
 configopts=(
     '--enable-pc-files'
     '--enable-sigwinch'
-    '--enable-term-driver'
     '--with-pkg-config=/usr/local/lib/pkgconfig'
     '--with-pkg-config-libdir=/usr/local/lib/pkgconfig'
     '--with-shared'


### PR DESCRIPTION
Fixes the issue with ncurses not properly resetting the background to the default color on programs that support default colored backgrounds, like cbonsai and cmatrix. 

The issue seems to have been introduced by 91ad7754fe156a6831eabdc49d1400e230b36b96. But although it seems the motivation for that commit was to make possible to build nano, with the current version of nano and ncurses without the `--enable-term-driver` option I'm still able to build nano without any problems.

Before:
<img width="589" height="405" alt="image" src="https://github.com/user-attachments/assets/3f24e0b9-3817-412f-b864-a676333f5659" />

After:
<img width="589" height="406" alt="image" src="https://github.com/user-attachments/assets/3aec2fcf-223c-4fc3-831e-144927fde050" />