### PR TITLE
Ports: Add mirror URL support for downloads

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -115,9 +115,13 @@ fi
 mkdir -p "${PORT_BUILD_DIR}"
 cd "${PORT_BUILD_DIR}"
 
-# 1 = url
+# 1 = source
 # 2 = sha256sum
-FILES_SIMPLE_PATTERN='^(https?:\/\/.+)#([0-9a-f]{64})$'
+FILES_SIMPLE_PATTERN='^(https?:\/\/.+|mirror://[^/]+/.+)#([0-9a-f]{64})$'
+
+# 1 = type
+# 2 = path
+MIRROR_URL_PATTERN="^mirror://([^/]+)/(.+)$"
 
 # 1 = repository
 # 2 = revision
@@ -301,23 +305,87 @@ func_defined post_fetch || post_fetch() {
     :
 }
 
+MIRROR_URLS_gnu="https://ftpmirror.gnu.org/gnu/ https://ftp.gnu.org/gnu/"
+
+resolve_mirror_urls() {
+    local type="${1}"
+    local path="${2}"
+
+    local mirror_urls_variable="MIRROR_URLS_${type}"
+    local mirrors_string="${!mirror_urls_variable:-}"
+
+    if [ -z "${mirrors_string}" ]; then
+        echo "error: Unknown mirror '${type}'" >&2
+        return 1
+    fi
+
+    local mirrors
+    read -ra mirrors <<< "${mirrors_string}"
+
+    local mirror
+    for mirror in "${mirrors[@]}"; do
+        printf '%s%s\n' "${mirror}" "${path}"
+    done
+}
+
 do_download_file() {
     local url="$1"
     local filename="$2"
     local accept_existing="${3:-true}"
+    local expected_checksum="${4:-}"
+
+    local urls=("${url}")
+    local resolved_urls
+
+    if [[ "${url}" =~ ${MIRROR_URL_PATTERN} ]]; then
+        local type="${BASH_REMATCH[1]}"
+        local path="${BASH_REMATCH[2]}"
+        if ! resolved_urls="$(resolve_mirror_urls "${type}" "${path}")"; then
+            return 1
+        fi
+
+        urls=()
+        local resolved_url
+        while IFS= read -r resolved_url; do
+            urls+=("${resolved_url}")
+        done <<< "${resolved_urls}"
+    fi
 
     if $accept_existing && [ -f "$filename" ]; then
         echo "$filename already exists"
         return
     fi
 
-    echo "Downloading URL: ${url}"
+    local download_status=1
 
-    if which curl; then
-        run_nocd curl ${curlopts:-} "$url" --fail -L -o "$filename"
-    else
-        run_nocd pro "$url" > "$filename"
-    fi
+    for candidate_url in "${urls[@]}"; do
+        echo "Downloading URL: ${candidate_url}"
+        if which curl; then
+            if run_nocd curl ${curlopts:-} "$candidate_url" --fail -L -o "$filename"; then
+                return 0
+            else
+                download_status="$?"
+                rm -f "${filename}"
+            fi
+        else
+            if run_nocd pro "$candidate_url" > "$filename"; then
+                if [ -n "${expected_checksum}" ]; then
+                    local actual_checksum="$(sha256sum "$filename" | cut -f1 -d' ')"
+
+                    if [ "${actual_checksum}" != "${expected_checksum}" ]; then
+                        rm -f "${filename}"
+                        continue
+                    fi
+                fi
+
+                return 0
+            else
+                download_status="$?"
+                rm -f "${filename}"
+            fi
+        fi
+    done
+    return "${download_status}"
 }
 
 fetch_simple() {
@@ -329,7 +397,7 @@ fetch_simple() {
     tried_download_again=0
 
     while true; do
-        do_download_file "${url}" "${PORT_META_DIR}/${filename}"
+        do_download_file "${url}" "${PORT_META_DIR}/${filename}" true "${checksum}"
 
         actual_checksum="$(sha256sum "${PORT_META_DIR}/${filename}" | cut -f1 -d' ')"
 

--- a/Ports/README.md
+++ b/Ports/README.md
@@ -197,11 +197,15 @@ An array of external files required by the port, one per line.
 The format of each entry is as follows:
 
 ```text
-URL#HASH
+SOURCE#HASH
 ```
 
-Where `URL` is the URL from where the file will be downloaded (using `curl`)
-and `HASH` is the SHA256 hash that will be used for verification.
+Where `SOURCE` is either a direct URL or a mirror source in the form
+`mirror://TYPE/PATH`, and `HASH` is the SHA256 hash that will be used for
+verification.
+
+For mirror sources, `TYPE` selects a configured list of mirror base URLs and
+`PATH` is appended to each of them. The resulting URLs are tried in order until a download succeeds.
 
 For example:
 
@@ -210,6 +214,17 @@ files=(
     "https://example.com/foo-${version}.tar.xz#9acd50f9a2af37e471f761c3fe7b8dea5617e51dac802fe6c177b74abf0abb5a"
 )
 ```
+
+Or using a mirror source:
+
+```bash
+files=(
+    "mirror://gnu/binutils/binutils-${version}.tar.xz#9acd50f9a2af37e471f761c3fe7b8dea5617e51dac802fe6c177b74abf0abb5a"
+)
+```
+
+Here, `gnu` is the mirror type and `binutils/binutils-${version}.tar.xz`
+is the path.
 
 If a file is a compressed tar archive, a gzip compressed file or a zip
 compressed file, it will be extracted.

--- a/Ports/bash/package.sh
+++ b/Ports/bash/package.sh
@@ -13,7 +13,7 @@ launcher_command='/usr/local/bin/bash'
 launcher_run_in_terminal='true'
 #icon_file=FIXME
 files=(
-    "https://ftpmirror.gnu.org/gnu/bash/bash-${version}.tar.gz#0d5cd86965f869a26cf64f4b71be7b96f90a3ba8b3d74e27e8e9d9d5550f31ba"
+    "mirror://gnu/bash/bash-${version}.tar.gz#0d5cd86965f869a26cf64f4b71be7b96f90a3ba8b3d74e27e8e9d9d5550f31ba"
 )
 depends=(
     'readline'

--- a/Ports/binutils/package.sh
+++ b/Ports/binutils/package.sh
@@ -13,7 +13,7 @@ configopts=(
     "--enable-libiberty"
 )
 files=(
-    "https://ftpmirror.gnu.org/gnu/binutils/binutils-${version}.tar.xz#d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2"
+    "mirror://gnu/binutils/binutils-${version}.tar.xz#d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2"
 )
 depends=(
     'zlib'

--- a/Ports/bison/package.sh
+++ b/Ports/bison/package.sh
@@ -6,5 +6,5 @@ configopts=(
     "--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
 )
 files=(
-    "https://ftpmirror.gnu.org/gnu/bison/bison-${version}.tar.gz#06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
+    "mirror://gnu/bison/bison-${version}.tar.gz#06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
 )

--- a/Ports/coreutils/package.sh
+++ b/Ports/coreutils/package.sh
@@ -3,7 +3,7 @@ port='coreutils'
 version='9.9'
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${version}.tar.gz#91a719fcf923de686016f2c8d084a8be1f793f34173861273c4668f7c65af94a"
+    "mirror://gnu/coreutils/coreutils-${version}.tar.gz#91a719fcf923de686016f2c8d084a8be1f793f34173861273c4668f7c65af94a"
 )
 
 # Exclude some non-working utilities:

--- a/Ports/cpio/package.sh
+++ b/Ports/cpio/package.sh
@@ -5,7 +5,7 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
 files=(
-    "https://ftpmirror.gnu.org/gnu/cpio/cpio-${version}.tar.gz#efa50ef983137eefc0a02fdb51509d624b5e3295c980aa127ceee4183455499e"
+    "mirror://gnu/cpio/cpio-${version}.tar.gz#efa50ef983137eefc0a02fdb51509d624b5e3295c980aa127ceee4183455499e"
 )
 configopts=(
     'CFLAGS=-std=c17'

--- a/Ports/diffutils/package.sh
+++ b/Ports/diffutils/package.sh
@@ -5,7 +5,7 @@ depends=(
     'libiconv'
 )
 files=(
-    "https://ftpmirror.gnu.org/gnu/diffutils/diffutils-${version}.tar.xz#7c8b7f9fc8609141fdea9cece85249d308624391ff61dedaf528fcb337727dfd"
+    "mirror://gnu/diffutils/diffutils-${version}.tar.xz#7c8b7f9fc8609141fdea9cece85249d308624391ff61dedaf528fcb337727dfd"
 )
 useconfigure='true'
 configopts=(

--- a/Ports/ed/package.sh
+++ b/Ports/ed/package.sh
@@ -2,7 +2,7 @@
 port='ed'
 version='1.22'
 files=(
-    "https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz#7eb22c30a99dcdb50a8630ef7ff3e4642491ac4f8cd1aa9f3182264df4f4ad08"
+    "mirror://gnu/ed/ed-${version}.tar.lz#7eb22c30a99dcdb50a8630ef7ff3e4642491ac4f8cd1aa9f3182264df4f4ad08"
 )
 useconfigure='true'
 depends=(

--- a/Ports/findutils/package.sh
+++ b/Ports/findutils/package.sh
@@ -5,5 +5,5 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
 files=(
-    "https://ftpmirror.gnu.org/gnu/findutils/findutils-${version}.tar.xz#1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5"
+    "mirror://gnu/findutils/findutils-${version}.tar.xz#1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5"
 )

--- a/Ports/freedink/package.sh
+++ b/Ports/freedink/package.sh
@@ -18,8 +18,8 @@ depends=(
 )
 freedink_data='freedink-data-1.08.20190120'
 files=(
-    "https://ftpmirror.gnu.org/gnu/freedink/freedink-${version}.tar.gz#5e0b35ac8f46d7bb87e656efd5f9c7c2ac1a6c519a908fc5b581e52657981002"
-    "https://ftpmirror.gnu.org/gnu/freedink/${freedink_data}.tar.gz#715f44773b05b73a9ec9b62b0e152f3f281be1a1512fbaaa386176da94cffb9d"
+    "mirror://gnu/freedink/freedink-${version}.tar.gz#5e0b35ac8f46d7bb87e656efd5f9c7c2ac1a6c519a908fc5b581e52657981002"
+    "mirror://gnu/freedink/${freedink_data}.tar.gz#715f44773b05b73a9ec9b62b0e152f3f281be1a1512fbaaa386176da94cffb9d"
 )
 configopts=(
     '--prefix=/usr/local'

--- a/Ports/gawk/package.sh
+++ b/Ports/gawk/package.sh
@@ -3,7 +3,7 @@ port='gawk'
 version='5.3.1'
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/gawk/gawk-${version}.tar.gz#fa41b3a85413af87fb5e3a7d9c8fa8d4a20728c67651185bb49c38a7f9382b1e"
+    "mirror://gnu/gawk/gawk-${version}.tar.gz#fa41b3a85413af87fb5e3a7d9c8fa8d4a20728c67651185bb49c38a7f9382b1e"
 )
 depends=(
     'gmp'

--- a/Ports/gcc/package.sh
+++ b/Ports/gcc/package.sh
@@ -4,7 +4,7 @@ version=16.2.0
 useconfigure=true
 configopts=("--target=${SERENITY_ARCH}-serenity" "--with-sysroot=/" "--with-build-sysroot=${SERENITY_INSTALL_ROOT}" "--enable-languages=c,c++" "--disable-lto" "--disable-nls" "--enable-shared" "--enable-default-pie" "--enable-host-shared" "--enable-threads=posix" "--enable-initfini-array" "--with-linker-hash-style=gnu")
 files=(
-    "https://ftpmirror.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.xz#e6738e29597f733270731aa90600f37ffdc045079dfc27ec7e8192cc81085c3e"
+    "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz#e6738e29597f733270731aa90600f37ffdc045079dfc27ec7e8192cc81085c3e"
 )
 makeopts=("all-gcc" "all-target-libgcc" "all-target-libstdc++-v3" "-j$(nproc)")
 installopts=("DESTDIR=${SERENITY_INSTALL_ROOT}" "install-gcc" "install-target-libgcc" "install-target-libstdc++-v3")

--- a/Ports/gdb/package.sh
+++ b/Ports/gdb/package.sh
@@ -4,7 +4,7 @@ version=11.2
 useconfigure=true
 configopts=("--target=${SERENITY_ARCH}-serenity" "--with-sysroot=/" "--with-build-sysroot=${SERENITY_INSTALL_ROOT}" "--with-newlib" "--enable-languages=c,c++" "--disable-lto" "--disable-nls" "--enable-shared" "--enable-default-pie" "--enable-host-shared" "--enable-threads=posix")
 files=(
-    "https://ftpmirror.gnu.org/gnu/gdb/gdb-${version}.tar.xz#1497c36a71881b8671a9a84a0ee40faab788ca30d7ba19d8463c3cc787152e32"
+    "mirror://gnu/gdb/gdb-${version}.tar.xz#1497c36a71881b8671a9a84a0ee40faab788ca30d7ba19d8463c3cc787152e32"
 )
 makeopts+=("all")
 installopts=("DESTDIR=${SERENITY_INSTALL_ROOT}")

--- a/Ports/gmp/package.sh
+++ b/Ports/gmp/package.sh
@@ -7,5 +7,5 @@ configopts=(
    "CFLAGS=-O2 -pedantic -std=c11"
 )
 files=(
-    "https://ftpmirror.gnu.org/gnu/gmp/gmp-${version}.tar.xz#a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
+    "mirror://gnu/gmp/gmp-${version}.tar.xz#a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
 )

--- a/Ports/gnuapl/package.sh
+++ b/Ports/gnuapl/package.sh
@@ -6,6 +6,6 @@ useconfigure="true"
 workdir="apl-${version}"
 configopts=("CXX_WERROR=no")
 files=(
-    "https://ftpmirror.gnu.org/gnu/apl/apl-${version}.tar.gz#144f4c858a0d430ce8f28be90a35920dd8e0951e56976cb80b55053fa0d8bbcb"
+    "mirror://gnu/apl/apl-${version}.tar.gz#144f4c858a0d430ce8f28be90a35920dd8e0951e56976cb80b55053fa0d8bbcb"
 )
 use_fresh_config_sub=true

--- a/Ports/gnucobol/package.sh
+++ b/Ports/gnucobol/package.sh
@@ -6,7 +6,7 @@ use_fresh_config_sub="true"
 config_sub_paths=("build_aux/config.sub")
 depends=("gmp" "gcc" "bash" "ncurses")
 files=(
-    "https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2#11181da708dbe65c7d047baadafb4bd49d5cde9b603bec0c842576a84e293fd5"
+    "mirror://gnu/gnucobol/gnucobol-${version}.tar.bz2#11181da708dbe65c7d047baadafb4bd49d5cde9b603bec0c842576a84e293fd5"
 )
 configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"

--- a/Ports/gperf/package.sh
+++ b/Ports/gperf/package.sh
@@ -3,6 +3,6 @@ port='gperf'
 version='3.3'
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/gperf/gperf-${version}.tar.gz#fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8"
+    "mirror://gnu/gperf/gperf-${version}.tar.gz#fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8"
 )
 configopts=("--prefix=/usr/local")

--- a/Ports/grep/package.sh
+++ b/Ports/grep/package.sh
@@ -2,7 +2,7 @@
 port='grep'
 version='3.12'
 files=(
-    "https://ftpmirror.gnu.org/gnu/grep/grep-${version}.tar.gz#badda546dfc4b9d97e992e2c35f3b5c7f20522ffcbe2f01ba1e9cdcbe7644cdc"
+    "mirror://gnu/grep/grep-${version}.tar.gz#badda546dfc4b9d97e992e2c35f3b5c7f20522ffcbe2f01ba1e9cdcbe7644cdc"
 )
 useconfigure='true'
 configopts=(

--- a/Ports/groff/package.sh
+++ b/Ports/groff/package.sh
@@ -5,7 +5,7 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
 files=(
-    "https://ftpmirror.gnu.org/gnu/groff/groff-${version}.tar.gz#e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293"
+    "mirror://gnu/groff/groff-${version}.tar.gz#e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293"
 )
 depends=(
     'libiconv'

--- a/Ports/gsl/package.sh
+++ b/Ports/gsl/package.sh
@@ -4,6 +4,6 @@ port=gsl
 version=2.7.1
 useconfigure=true
 files=(
-    "https://ftpmirror.gnu.org/gnu/gsl/gsl-${version}.tar.gz#dcb0fbd43048832b757ff9942691a8dd70026d5da0ff85601e52687f6deeb34b"
+    "mirror://gnu/gsl/gsl-${version}.tar.gz#dcb0fbd43048832b757ff9942691a8dd70026d5da0ff85601e52687f6deeb34b"
 )
 use_fresh_config_sub=true

--- a/Ports/guile/package.sh
+++ b/Ports/guile/package.sh
@@ -2,7 +2,7 @@
 port=guile
 version=3.0.8
 files=(
-    "https://ftpmirror.gnu.org/gnu/guile/guile-${version}.tar.gz#f25ae0c26e911af1b5005292d4f56621879f74d6958b30741cf67d8b6feb2016"
+    "mirror://gnu/guile/guile-${version}.tar.gz#f25ae0c26e911af1b5005292d4f56621879f74d6958b30741cf67d8b6feb2016"
 )
 depends=("gmp" "libunistring" "libffi" "bdwgc" "libiconv")
 

--- a/Ports/gzip/package.sh
+++ b/Ports/gzip/package.sh
@@ -3,5 +3,5 @@ port='gzip'
 version='1.14'
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/gzip/gzip-${version}.tar.gz#613d6ea44f1248d7370c7ccdeee0dd0017a09e6c39de894b3c6f03f981191c6b"
+    "mirror://gnu/gzip/gzip-${version}.tar.gz#613d6ea44f1248d7370c7ccdeee0dd0017a09e6c39de894b3c6f03f981191c6b"
 )

--- a/Ports/indent/package.sh
+++ b/Ports/indent/package.sh
@@ -2,7 +2,7 @@
 port='indent'
 version='2.2.13'
 files=(
-    "https://ftpmirror.gnu.org/gnu/indent/indent-${version}.tar.gz#9e64634fc4ce6797b204bcb8897ce14fdd0ab48ca57696f78767c59cae578095"
+    "mirror://gnu/indent/indent-${version}.tar.gz#9e64634fc4ce6797b204bcb8897ce14fdd0ab48ca57696f78767c59cae578095"
 )
 useconfigure='true'
 use_fresh_config_sub='true'

--- a/Ports/less/package.sh
+++ b/Ports/less/package.sh
@@ -3,7 +3,7 @@ port='less'
 version='704'
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/less/less-${version}.tar.gz#20a0b0a2bb2525fa53c7eee9beb854b4c9cf172eabb209af7020743547bfe9fb"
+    "mirror://gnu/less/less-${version}.tar.gz#20a0b0a2bb2525fa53c7eee9beb854b4c9cf172eabb209af7020743547bfe9fb"
 )
 depends=(
     'ncurses'

--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -2,7 +2,7 @@
 port='libiconv'
 version='1.19'
 files=(
-    "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-${version}.tar.gz#88dd96a8c0464eca144fc791ae60cd31cd8ee78321e67397e25fc095c4a19aa6"
+    "mirror://gnu/libiconv/libiconv-${version}.tar.gz#88dd96a8c0464eca144fc791ae60cd31cd8ee78321e67397e25fc095c4a19aa6"
 )
 useconfigure='true'
 configopts=("--enable-shared" "--disable-nls" "CFLAGS=-std=c17")

--- a/Ports/libtool/package.sh
+++ b/Ports/libtool/package.sh
@@ -7,7 +7,7 @@ depends=(
     'sed'
 )
 files=(
-    "https://ftpmirror.gnu.org/gnu/libtool/libtool-${version}.tar.xz#f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675"
+    "mirror://gnu/libtool/libtool-${version}.tar.xz#f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675"
 )
 configopts=("--prefix=/usr/local")
 

--- a/Ports/libunistring/package.sh
+++ b/Ports/libunistring/package.sh
@@ -2,7 +2,7 @@
 port='libunistring'
 version='1.4.1'
 files=(
-    "https://ftpmirror.gnu.org/gnu/libunistring/libunistring-${version}.tar.gz#12542ad7619470efd95a623174dcd4b364f2483caf708c6bee837cb53a54cb9d"
+    "mirror://gnu/libunistring/libunistring-${version}.tar.gz#12542ad7619470efd95a623174dcd4b364f2483caf708c6bee837cb53a54cb9d"
 )
 useconfigure='true'
 configopts=(

--- a/Ports/m4/package.sh
+++ b/Ports/m4/package.sh
@@ -2,7 +2,7 @@
 port='m4'
 version='1.4.20'
 files=(
-    "https://ftpmirror.gnu.org/gnu/m4/m4-${version}.tar.gz#6ac4fc31ce440debe63987c2ebbf9d7b6634e67a7c3279257dc7361de8bdb3ef"
+    "mirror://gnu/m4/m4-${version}.tar.gz#6ac4fc31ce440debe63987c2ebbf9d7b6634e67a7c3279257dc7361de8bdb3ef"
 )
 useconfigure='true'
 

--- a/Ports/make/package.sh
+++ b/Ports/make/package.sh
@@ -5,6 +5,6 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=("build-aux/config.sub")
 files=(
-    "https://ftpmirror.gnu.org/gnu/make/make-${version}.tar.gz#dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3"
+    "mirror://gnu/make/make-${version}.tar.gz#dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3"
 )
 configopts=("--without-guile" "CFLAGS=-std=c17")

--- a/Ports/mpc/package.sh
+++ b/Ports/mpc/package.sh
@@ -10,7 +10,7 @@ configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
 )
 files=(
-    "https://ftpmirror.gnu.org/gnu/mpc/mpc-${version}.tar.gz#ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
+    "mirror://gnu/mpc/mpc-${version}.tar.gz#ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
 )
 depends=(
     'gmp'

--- a/Ports/mpfr/package.sh
+++ b/Ports/mpfr/package.sh
@@ -7,7 +7,7 @@ configopts=(
     '--with-sysroot=/'
 )
 files=(
-    "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-${version}.tar.xz#277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2"
+    "mirror://gnu/mpfr/mpfr-${version}.tar.xz#277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2"
 )
 depends=(
     'gmp'

--- a/Ports/patch/package.sh
+++ b/Ports/patch/package.sh
@@ -3,5 +3,5 @@ port='patch'
 version='2.8'
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/patch/patch-${version}.tar.gz#308a4983ff324521b9b21310bfc2398ca861798f02307c79eb99bb0e0d2bf980"
+    "mirror://gnu/patch/patch-${version}.tar.gz#308a4983ff324521b9b21310bfc2398ca861798f02307c79eb99bb0e0d2bf980"
 )

--- a/Ports/readline/package.sh
+++ b/Ports/readline/package.sh
@@ -4,7 +4,7 @@ version='8.3'
 depends=('ncurses')
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/readline/readline-${version}.tar.gz#fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc"
+    "mirror://gnu/readline/readline-${version}.tar.gz#fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc"
 )
 configopts=(
     '--disable-static'

--- a/Ports/sed/package.sh
+++ b/Ports/sed/package.sh
@@ -5,5 +5,5 @@ useconfigure="true"
 use_fresh_config_sub="true"
 config_sub_paths=("build-aux/config.sub")
 files=(
-    "https://ftpmirror.gnu.org/gnu/sed/sed-${version}.tar.gz#d1478a18f033a73ac16822901f6533d30b6be561bcbce46ffd7abce93602282e"
+    "mirror://gnu/sed/sed-${version}.tar.gz#d1478a18f033a73ac16822901f6533d30b6be561bcbce46ffd7abce93602282e"
 )

--- a/Ports/tar/package.sh
+++ b/Ports/tar/package.sh
@@ -5,7 +5,7 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
 files=(
-    "https://ftpmirror.gnu.org/gnu/tar/tar-${version}.tar.gz#14d55e32063ea9526e057fbf35fcabd53378e769787eff7919c3755b02d2b57e"
+    "mirror://gnu/tar/tar-${version}.tar.gz#14d55e32063ea9526e057fbf35fcabd53378e769787eff7919c3755b02d2b57e"
 )
 depends=(
     'gettext'

--- a/Ports/wget/package.sh
+++ b/Ports/wget/package.sh
@@ -10,7 +10,7 @@ depends=(
     'openssl'
 )
 files=(
-    "https://ftpmirror.gnu.org/gnu/wget/wget-${version}.tar.gz#766e48423e79359ea31e41db9e5c289675947a7fcf2efdcedb726ac9d0da3784"
+    "mirror://gnu/wget/wget-${version}.tar.gz#766e48423e79359ea31e41db9e5c289675947a7fcf2efdcedb726ac9d0da3784"
 )
 configopts=(
     '--with-ssl=openssl'

--- a/Ports/which/package.sh
+++ b/Ports/which/package.sh
@@ -3,5 +3,5 @@ port='which'
 version='2.21'
 useconfigure='true'
 files=(
-    "https://ftpmirror.gnu.org/gnu/which/which-${version}.tar.gz#f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad"
+    "mirror://gnu/which/which-${version}.tar.gz#f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad"
 )


### PR DESCRIPTION
## Summary

Add support for mirror sources in simple port downloads.

The existing `URL#HASH` syntax remains unchanged. Ports may now also use:

`mirror://TYPE/PATH#HASH`

Mirror types resolve to a centrally configured list of base URLs. The
resulting URLs are tried in order until a download succeeds.

This adds the `gnu` mirror type using `ftpmirror.gnu.org` and `ftp.gnu.org`,
and migrates existing GNU ports using ftpmirror.gnu.org to use it.

## Testing

- Verified `grep` falls back from `ftpmirror.gnu.org` returning 502 to
  `ftp.gnu.org` successfully.
- Verified a regular non-mirror `curl` download still works.
- Verified `clean_dist` works with mirror sources.
- Ran `Meta/lint-ports.py`.
- Ran `Meta/lint-prettier.sh Ports/README.md`.
- Ran `git diff --check`.