### PR TITLE
LibGUI: Include limits.h in Window

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -29,6 +29,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Palette.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
1. Add an extra include to LibGUI/Window.cpp, since we were using INT_MAX without the proper header. This broke on Fedora 44 with gcc-16.

~~2. Reformat the default cursor png with ImageMagick to fix a premultiplied alpha problem. See commit for details.~~

Edit: png alphas handled in Loom code.