### PR TITLE
LibC: Align PTHREAD_COND_INITIALIZER with pthread_cond_init

### DIFF
--- a/Userland/Libraries/LibC/pthread.h
+++ b/Userland/Libraries/LibC/pthread.h
@@ -76,9 +76,9 @@ int pthread_setschedparam(pthread_t thread, int policy, const struct sched_param
 #define PTHREAD_PROCESS_PRIVATE 1
 #define PTHREAD_PROCESS_SHARED 2
 
-#define PTHREAD_COND_INITIALIZER     \
-    {                                \
-        0, 0, CLOCK_MONOTONIC_COARSE \
+#define PTHREAD_COND_INITIALIZER    \
+    {                               \
+        0, 0, CLOCK_REALTIME_COARSE \
     }
 
 // FIXME: Actually implement this!


### PR DESCRIPTION
According to POSIX:
"In cases where default condition variable attributes are appropriate, the macro PTHREAD_COND_INITIALIZER can be used to initialise condition variables that are statically allocated. The effect is equivalent to dynamic initialisation by a call to pthread_cond_init() with parameter attr specified as NULL, except that no error checks are performed."

AFAICT, the clock choice is left as an implementation detail, but other systems seem to use CLOCK_REALTIME as the default:

https://sourceware.org/git/?p=glibc.git;a=blob;f=nptl/pthread_cond_init.c;h=688bcae5de5a6d0ecad2115ac486891961e2854a;hb=e474366724369f6371f32a4a05a1311d311ec2ae

https://github.com/openbsd/src/blob/7da33d17d09f1f2c0e27643875d90dc64f79173c/lib/libc/thread/rthread_cond.c#L30-L47

---

This fixes 25 libcxx tests:

std/thread/futures/futures.shared_future/wait_for.pass.cpp
std/thread/futures/futures.shared_future/wait_until.pass.cpp
std/thread/futures/futures.unique_future/wait_for.pass.cpp
std/thread/futures/futures.unique_future/wait_until.pass.cpp
std/thread/thread.condition/thread.condition.condvar/wait_for.pass.cpp
std/thread/thread.condition/thread.condition.condvar/wait_for_pred.pass.cpp
std/thread/thread.condition/thread.condition.condvar/wait_until.pass.cpp
std/thread/thread.condition/thread.condition.condvar/wait_until_pred.pass.cpp
std/thread/thread.condition/thread.condition.condvarany/wait_for.pass.cpp
std/thread/thread.condition/thread.condition.condvarany/wait_for_pred.pass.cpp
std/thread/thread.condition/thread.condition.condvarany/wait_for_token_pred.pass.cpp
std/thread/thread.condition/thread.condition.condvarany/wait_until.pass.cpp
std/thread/thread.condition/thread.condition.condvarany/wait_until_pred.pass.cpp
std/thread/thread.condition/thread.condition.condvarany/wait_until_token_pred.pass.cpp
std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_duration.pass.cpp
std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_time_point.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_for.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_shared_for.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_shared_until.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_until.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_until_deadlock_bug.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock_for.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock_until.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock_for.pass.cpp
std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock_until.pass.cpp
std/thread/thread.threads/thread.thread.this/sleep_until.pass.cpp