### PR TITLE
Ports+LibC: Make gnulib compile again

### DIFF
--- a/Ports/coreutils/patches/0001-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch
+++ b/Ports/coreutils/patches/0001-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch
@@ -1,0 +1,27 @@
+From d96a158fbd2beba379c8db4384febd3e2f1f3d80 Mon Sep 17 00:00:00 2001
+From: Eduardo Casadei <educasadei@gmail.com>
+Date: Thu, 10 Sep 2026 17:51:48 -0400
+Subject: [PATCH] gnulib: Port getlocalename_l_unsafe to SerenityOS
+
+---
+ lib/getlocalename_l-unsafe.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/getlocalename_l-unsafe.c b/lib/getlocalename_l-unsafe.c
+index e273882..5d10e59 100644
+--- a/lib/getlocalename_l-unsafe.c
++++ b/lib/getlocalename_l-unsafe.c
+@@ -668,6 +668,10 @@ getlocalename_l_unsafe (int category, locale_t locale)
+       };
+       const char *name = ((struct __locale_t *) locale)->mb_cur_max == 4 ? "C.UTF-8" : "C";
+       return (struct string_with_storage) { name, STORAGE_INDEFINITE };
++#elif defined __serenity__
++#   undef getlocalename_l
++      const char *name = getlocalename_l (category, locale);
++      return (struct string_with_storage) { name, STORAGE_OBJECT };
+ #else
+  #error "Please port gnulib getlocalename_l-unsafe.c to your platform! Report this to bug-gnulib."
+ #endif
+-- 
+2.53.0
+

--- a/Ports/coreutils/patches/ReadMe.md
+++ b/Ports/coreutils/patches/ReadMe.md
@@ -1,0 +1,7 @@
+# Patches for coreutils on SerenityOS
+
+## `0001-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch`
+
+gnulib: Port getlocalename_l_unsafe to SerenityOS
+
+

--- a/Ports/gettext/patches/0002-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch
+++ b/Ports/gettext/patches/0002-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch
@@ -1,0 +1,59 @@
+From b34c80eaff029051aef473c03ee2895b09a36d2c Mon Sep 17 00:00:00 2001
+From: Eduardo Casadei <educasadei@gmail.com>
+Date: Tue, 8 Sep 2026 09:57:02 -0400
+Subject: [PATCH] gnulib: Port getlocalename_l_unsafe to SerenityOS
+
+---
+ gettext-runtime/gnulib-lib/getlocalename_l-unsafe.c      | 4 ++++
+ gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c | 4 ++++
+ gettext-tools/gnulib-lib/getlocalename_l-unsafe.c        | 4 ++++
+ 3 files changed, 12 insertions(+)
+
+diff --git a/gettext-runtime/gnulib-lib/getlocalename_l-unsafe.c b/gettext-runtime/gnulib-lib/getlocalename_l-unsafe.c
+index db0a9c8..e1652c7 100644
+--- a/gettext-runtime/gnulib-lib/getlocalename_l-unsafe.c
++++ b/gettext-runtime/gnulib-lib/getlocalename_l-unsafe.c
+@@ -673,6 +673,10 @@ getlocalename_l_unsafe (int category, locale_t locale)
+       };
+       const char *name = ((struct __locale_t *) locale)->mb_cur_max == 4 ? "C.UTF-8" : "C";
+       return (struct string_with_storage) { name, STORAGE_INDEFINITE };
++#elif defined __serenity__
++#undef getlocalename_l
++      const char *name = getlocalename_l (category, locale);
++      return (struct string_with_storage) { name, STORAGE_OBJECT };
+ #else
+  #error "Please port gnulib getlocalename_l-unsafe.c to your platform! Report this to bug-gnulib."
+ #endif
+diff --git a/gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c b/gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c
+index db0a9c8..e1652c7 100644
+--- a/gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c
++++ b/gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c
+@@ -673,6 +673,10 @@ getlocalename_l_unsafe (int category, locale_t locale)
+       };
+       const char *name = ((struct __locale_t *) locale)->mb_cur_max == 4 ? "C.UTF-8" : "C";
+       return (struct string_with_storage) { name, STORAGE_INDEFINITE };
++#elif defined __serenity__
++#undef getlocalename_l
++      const char *name = getlocalename_l (category, locale);
++      return (struct string_with_storage) { name, STORAGE_OBJECT };
+ #else
+  #error "Please port gnulib getlocalename_l-unsafe.c to your platform! Report this to bug-gnulib."
+ #endif
+diff --git a/gettext-tools/gnulib-lib/getlocalename_l-unsafe.c b/gettext-tools/gnulib-lib/getlocalename_l-unsafe.c
+index db0a9c8..e1652c7 100644
+--- a/gettext-tools/gnulib-lib/getlocalename_l-unsafe.c
++++ b/gettext-tools/gnulib-lib/getlocalename_l-unsafe.c
+@@ -673,6 +673,10 @@ getlocalename_l_unsafe (int category, locale_t locale)
+       };
+       const char *name = ((struct __locale_t *) locale)->mb_cur_max == 4 ? "C.UTF-8" : "C";
+       return (struct string_with_storage) { name, STORAGE_INDEFINITE };
++#elif defined __serenity__
++#undef getlocalename_l
++      const char *name = getlocalename_l (category, locale);
++      return (struct string_with_storage) { name, STORAGE_OBJECT };
+ #else
+  #error "Please port gnulib getlocalename_l-unsafe.c to your platform! Report this to bug-gnulib."
+ #endif
+-- 
+2.53.0
+

--- a/Ports/gettext/patches/ReadMe.md
+++ b/Ports/gettext/patches/ReadMe.md
@@ -19,3 +19,8 @@ configure includes the code for detecting dynamic linker characteristics
 twice, and it also queries the C++ compiler for shared library support.
 
 
+## `0002-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch`
+
+gnulib: Port getlocalename_l_unsafe to SerenityOS
+
+

--- a/Ports/grep/patches/0001-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch
+++ b/Ports/grep/patches/0001-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch
@@ -1,0 +1,27 @@
+From 471d05eb3e09ea9fd68571dda4a479a1452dde48 Mon Sep 17 00:00:00 2001
+From: Eduardo Casadei <educasadei@gmail.com>
+Date: Thu, 10 Sep 2026 18:00:40 -0400
+Subject: [PATCH] gnulib: Port getlocalename_l_unsafe to SerenityOS
+
+---
+ gnulib-tests/getlocalename_l-unsafe.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gnulib-tests/getlocalename_l-unsafe.c b/gnulib-tests/getlocalename_l-unsafe.c
+index 6a72c81..b1e58ee 100644
+--- a/gnulib-tests/getlocalename_l-unsafe.c
++++ b/gnulib-tests/getlocalename_l-unsafe.c
+@@ -657,6 +657,10 @@ getlocalename_l_unsafe (int category, locale_t locale)
+       };
+       const char *name = ((struct __locale_t *) locale)->mb_cur_max == 4 ? "C.UTF-8" : "C";
+       return (struct string_with_storage) { name, STORAGE_INDEFINITE };
++#elif defined __serenity__
++#   undef getlocalename_l
++      const char *name = getlocalename_l (category, locale);
++      return (struct string_with_storage) { name, STORAGE_OBJECT };
+ #else
+  #error "Please port gnulib getlocalename_l-unsafe.c to your platform! Report this to bug-gnulib."
+ #endif
+-- 
+2.53.0
+

--- a/Ports/grep/patches/ReadMe.md
+++ b/Ports/grep/patches/ReadMe.md
@@ -1,0 +1,7 @@
+# Patches for grep on SerenityOS
+
+## `0001-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch`
+
+gnulib: Port getlocalename_l_unsafe to SerenityOS
+
+

--- a/Ports/m4/patches/0002-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch
+++ b/Ports/m4/patches/0002-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch
@@ -1,0 +1,27 @@
+From d96a158fbd2beba379c8db4384febd3e2f1f3d80 Mon Sep 17 00:00:00 2001
+From: Eduardo Casadei <educasadei@gmail.com>
+Date: Thu, 10 Sep 2026 17:51:48 -0400
+Subject: [PATCH] gnulib: Port getlocalename_l_unsafe to SerenityOS
+
+---
+ lib/getlocalename_l-unsafe.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/getlocalename_l-unsafe.c b/lib/getlocalename_l-unsafe.c
+index e273882..5d10e59 100644
+--- a/lib/getlocalename_l-unsafe.c
++++ b/lib/getlocalename_l-unsafe.c
+@@ -668,6 +668,10 @@ getlocalename_l_unsafe (int category, locale_t locale)
+       };
+       const char *name = ((struct __locale_t *) locale)->mb_cur_max == 4 ? "C.UTF-8" : "C";
+       return (struct string_with_storage) { name, STORAGE_INDEFINITE };
++#elif defined __serenity__
++#   undef getlocalename_l
++      const char *name = getlocalename_l (category, locale);
++      return (struct string_with_storage) { name, STORAGE_OBJECT };
+ #else
+  #error "Please port gnulib getlocalename_l-unsafe.c to your platform! Report this to bug-gnulib."
+ #endif
+-- 
+2.53.0
+

--- a/Ports/m4/patches/ReadMe.md
+++ b/Ports/m4/patches/ReadMe.md
@@ -6,3 +6,8 @@ Don't build misc stuff
 
 Skip building the examples, docs and avoid the checks.
 
+## `0002-gnulib-Port-getlocalename_l_unsafe-to-SerenityOS.patch`
+
+gnulib: Port getlocalename_l_unsafe to SerenityOS
+
+

--- a/Userland/Libraries/LibC/locale.cpp
+++ b/Userland/Libraries/LibC/locale.cpp
@@ -70,6 +70,12 @@ void freelocale(locale_t)
     // FIXME: Implement this.
 }
 
+char const* getlocalename_l(int, locale_t)
+{
+    // FIXME: Implement this.
+    return "C";
+}
+
 locale_t newlocale(int, char const*, locale_t)
 {
     // FIXME: Implement this.

--- a/Userland/Libraries/LibC/locale.h
+++ b/Userland/Libraries/LibC/locale.h
@@ -67,6 +67,7 @@ typedef struct __locale_t_impl* locale_t;
 
 struct lconv* localeconv(void);
 void freelocale(locale_t);
+char const* getlocalename_l(int, locale_t);
 locale_t newlocale(int, char const*, locale_t);
 char* setlocale(int category, char const* locale);
 locale_t uselocale(locale_t);

--- a/Userland/Libraries/LibC/locale.h
+++ b/Userland/Libraries/LibC/locale.h
@@ -35,6 +35,8 @@ enum {
 #define LC_MESSAGES_MASK (1 << LC_MESSAGES)
 #define LC_ALL_MASK (LC_NUMERIC_MASK | LC_CTYPE_MASK | LC_COLLATE_MASK | LC_TIME_MASK | LC_MONETARY_MASK | LC_MESSAGES_MASK)
 
+#define LC_GLOBAL_LOCALE ((locale_t) - 1)
+
 struct lconv {
     char* decimal_point;
     char* thousands_sep;


### PR DESCRIPTION
The port of gettext stopped compiling duo to it's gnulib not having a proper port of `getlocalename_l_unsafe` to SerenityOS.

I am not entirely sure why it stopped compiling recently, but I believe it was duo to recent additions to `locale.h` that made some of the configure tests pass and it enabled the `getlocalename_l_unsafe` compile path.