### PR TITLE
Toolchain: Use the mirror syntax to download the GNU toolchain

### DIFF
--- a/Meta/download_file.sh
+++ b/Meta/download_file.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# This will be overridden in .port_include.sh
+run_nocd() {
+  ("$@")
+}
+
+# 1 = type
+# 2 = path
+MIRROR_URL_PATTERN="^mirror://([^/]+)/(.+)$"
+
+# shellcheck disable=SC2034
+MIRROR_URLS_gnu="https://ftpmirror.gnu.org/gnu/ https://ftp.gnu.org/gnu/"
+
+resolve_mirror_urls() {
+    local type="${1}"
+    local path="${2}"
+
+    local mirror_urls_variable="MIRROR_URLS_${type}"
+    local mirrors_string="${!mirror_urls_variable:-}"
+
+    if [ -z "${mirrors_string}" ]; then
+        echo "error: Unknown mirror '${type}'" >&2
+        return 1
+    fi
+
+    local mirrors
+    read -ra mirrors <<< "${mirrors_string}"
+
+    local mirror
+    for mirror in "${mirrors[@]}"; do
+        printf '%s%s\n' "${mirror}" "${path}"
+    done
+}
+
+# FIXME: Migrate users of do_download_file to download_file and remove
+#        redundant work from this function.
+do_download_file() {
+    local url="$1"
+    local filename="$2"
+    local accept_existing="${3:-true}"
+    local expected_checksum="${4:-}"
+
+    local urls=("${url}")
+    local resolved_urls
+
+    if [[ "${url}" =~ ${MIRROR_URL_PATTERN} ]]; then
+        local type="${BASH_REMATCH[1]}"
+        local path="${BASH_REMATCH[2]}"
+        if ! resolved_urls="$(resolve_mirror_urls "${type}" "${path}")"; then
+            return 1
+        fi
+
+        urls=()
+        local resolved_url
+        while IFS= read -r resolved_url; do
+            urls+=("${resolved_url}")
+        done <<< "${resolved_urls}"
+    fi
+
+    if $accept_existing && [ -f "$filename" ]; then
+        echo "$filename already exists"
+        return
+    fi
+
+    local download_status=1
+
+    for candidate_url in "${urls[@]}"; do
+        echo "Downloading URL: ${candidate_url}"
+        if which curl; then
+            # shellcheck disable=SC2086
+            if run_nocd curl ${curlopts:-} "$candidate_url" --fail -L -o "$filename"; then
+                return 0
+            else
+                download_status="$?"
+                rm -f "${filename}"
+            fi
+        else
+            if run_nocd pro "$candidate_url" > "$filename"; then
+                if [ -n "${expected_checksum}" ]; then
+                    actual_checksum="$(sha256sum "$filename" | cut -f1 -d' ')"
+                    local actual_checksum
+
+                    if [ "${actual_checksum}" != "${expected_checksum}" ]; then
+                        rm -f "${filename}"
+                        continue
+                    fi
+                fi
+
+                return 0
+            else
+                download_status="$?"
+                rm -f "${filename}"
+            fi
+        fi
+    done
+    return "${download_status}"
+}
+
+download_file() {
+    local url="${1}"
+    local destination="${2}"
+    local checksum="${3}"
+
+    local filename
+    filename="$(basename "${url}")"
+
+    local tried_download_again=0
+
+    while true; do
+        do_download_file "${url}" "${destination}" true "${checksum}"
+
+        actual_checksum="$(sha256sum "${destination}" | cut -f1 -d' ')"
+
+        if [ "${actual_checksum}" = "${checksum}" ]; then
+            break
+        fi
+
+        echo "SHA256 checksum of downloaded file '${filename}' does not match!"
+        echo "Expected: ${checksum}"
+        echo "Actual:   ${actual_checksum}"
+        rm -f "${destination}"
+        echo "Removed erroneous download."
+        if [ "${tried_download_again}" -eq 1 ]; then
+            echo "Please run script again."
+            exit 1
+        fi
+        echo "Trying to download the file again."
+        tried_download_again=1
+    done
+}

--- a/Meta/install-ports-tree.sh
+++ b/Meta/install-ports-tree.sh
@@ -3,7 +3,7 @@
 DESTDIR="${SERENITY_SOURCE_DIR}/Build/${SERENITY_ARCH}/Root/usr"
 
 git ls-files --full-name "${SERENITY_SOURCE_DIR}/Ports" | \
-  rsync -aHL \
+  rsync -raHL \
     --chown=0:0 --inplace --update \
     --files-from=- \
     --exclude="Ports/.hosted_defs.sh" \

--- a/Meta/install-ports-tree.sh
+++ b/Meta/install-ports-tree.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-SERENITY_PORTS_DIR="${SERENITY_SOURCE_DIR}/Build/${SERENITY_ARCH}/Root/usr/Ports"
+DESTDIR="${SERENITY_SOURCE_DIR}/Build/${SERENITY_ARCH}/Root/usr"
 
-for file in $(git ls-files "${SERENITY_SOURCE_DIR}/Ports"); do
-    if [ "$(basename "$file")" != ".hosted_defs.sh" ]; then
-        target=${SERENITY_PORTS_DIR}/$(realpath --relative-to="${SERENITY_SOURCE_DIR}/Ports" "$file")
-        mkdir -p "$(dirname "$target")" && cp "$file" "$target"
-    fi
-done
+git ls-files --full-name "${SERENITY_SOURCE_DIR}/Ports" | \
+  rsync -aHL \
+    --chown=0:0 --inplace --update \
+    --files-from=- \
+    --exclude="Ports/.hosted_defs.sh" \
+    "${SERENITY_SOURCE_DIR}" "${DESTDIR}"

--- a/Meta/lint-ports.py
+++ b/Meta/lint-ports.py
@@ -21,6 +21,7 @@ GIT_HASH_REGEX = re.compile(r'^[0-9a-f]{40}$')
 PORT_TABLE_FILE = 'AvailablePorts.md'
 IGNORE_FILES = {
     '.gitignore',
+    '.download_file.sh',
     '.port_include.sh',
     '.strip_env.sh',
     PORT_TABLE_FILE,

--- a/Ports/.download_file.sh
+++ b/Ports/.download_file.sh
@@ -1,0 +1,1 @@
+../Meta/download_file.sh

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -8,6 +8,8 @@ if [ -z "${SERENITY_STRIPPED_ENV:-}" ]; then
 fi
 unset SERENITY_STRIPPED_ENV
 
+source "${SCRIPT}/.download_file.sh"
+
 export MAKEJOBS="${MAKEJOBS:-$(nproc)}"
 export CMAKE_BUILD_PARALLEL_LEVEL="$MAKEJOBS"
 
@@ -118,10 +120,6 @@ cd "${PORT_BUILD_DIR}"
 # 1 = source
 # 2 = sha256sum
 FILES_SIMPLE_PATTERN='^(https?:\/\/.+|mirror://[^/]+/.+)#([0-9a-f]{64})$'
-
-# 1 = type
-# 2 = path
-MIRROR_URL_PATTERN="^mirror://([^/]+)/(.+)$"
 
 # 1 = repository
 # 2 = revision
@@ -305,118 +303,13 @@ func_defined post_fetch || post_fetch() {
     :
 }
 
-MIRROR_URLS_gnu="https://ftpmirror.gnu.org/gnu/ https://ftp.gnu.org/gnu/"
-
-resolve_mirror_urls() {
-    local type="${1}"
-    local path="${2}"
-
-    local mirror_urls_variable="MIRROR_URLS_${type}"
-    local mirrors_string="${!mirror_urls_variable:-}"
-
-    if [ -z "${mirrors_string}" ]; then
-        echo "error: Unknown mirror '${type}'" >&2
-        return 1
-    fi
-
-    local mirrors
-    read -ra mirrors <<< "${mirrors_string}"
-
-    local mirror
-    for mirror in "${mirrors[@]}"; do
-        printf '%s%s\n' "${mirror}" "${path}"
-    done
-}
-
-do_download_file() {
-    local url="$1"
-    local filename="$2"
-    local accept_existing="${3:-true}"
-    local expected_checksum="${4:-}"
-
-    local urls=("${url}")
-    local resolved_urls
-
-    if [[ "${url}" =~ ${MIRROR_URL_PATTERN} ]]; then
-        local type="${BASH_REMATCH[1]}"
-        local path="${BASH_REMATCH[2]}"
-        if ! resolved_urls="$(resolve_mirror_urls "${type}" "${path}")"; then
-            return 1
-        fi
-
-        urls=()
-        local resolved_url
-        while IFS= read -r resolved_url; do
-            urls+=("${resolved_url}")
-        done <<< "${resolved_urls}"
-    fi
-
-    if $accept_existing && [ -f "$filename" ]; then
-        echo "$filename already exists"
-        return
-    fi
-
-    local download_status=1
-
-    for candidate_url in "${urls[@]}"; do
-        echo "Downloading URL: ${candidate_url}"
-        if which curl; then
-            if run_nocd curl ${curlopts:-} "$candidate_url" --fail -L -o "$filename"; then
-                return 0
-            else
-                download_status="$?"
-                rm -f "${filename}"
-            fi
-        else
-            if run_nocd pro "$candidate_url" > "$filename"; then
-                if [ -n "${expected_checksum}" ]; then
-                    local actual_checksum="$(sha256sum "$filename" | cut -f1 -d' ')"
-
-                    if [ "${actual_checksum}" != "${expected_checksum}" ]; then
-                        rm -f "${filename}"
-                        continue
-                    fi
-                fi
-
-                return 0
-            else
-                download_status="$?"
-                rm -f "${filename}"
-            fi
-        fi
-    done
-    return "${download_status}"
-}
-
 fetch_simple() {
     url="${1}"
     checksum="${2}"
 
     filename="$(basename "${url}")"
 
-    tried_download_again=0
-
-    while true; do
-        do_download_file "${url}" "${PORT_META_DIR}/${filename}" true "${checksum}"
-
-        actual_checksum="$(sha256sum "${PORT_META_DIR}/${filename}" | cut -f1 -d' ')"
-
-        if [ "${actual_checksum}" = "${checksum}" ]; then
-            break
-        fi
-
-        echo "SHA256 checksum of downloaded file '${filename}' does not match!"
-        echo "Expected: ${checksum}"
-        echo "Actual:   ${actual_checksum}"
-        rm -f "${PORT_META_DIR}/${filename}"
-        echo "Removed erroneous download."
-        if [ "${tried_download_again}" -eq 1 ]; then
-            echo "Please run script again."
-            exit 1
-        fi
-        echo "Trying to download the file again."
-        tried_download_again=1
-    done
+    download_file "${url}" "${PORT_META_DIR}/${filename}" "${checksum}"
 
     if [ ! -f "$workdir"/.${filename}_extracted ]; then
         case "$filename" in

--- a/Toolchain/BuildGNU.sh
+++ b/Toolchain/BuildGNU.sh
@@ -7,6 +7,7 @@ set -eo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . "${DIR}/../Meta/shell_include.sh"
+. "${DIR}/../Meta/download_file.sh"
 
 exit_if_running_as_root "Do not run BuildGNU.sh as root, your Build directory will become root-owned"
 
@@ -69,18 +70,18 @@ mkdir -p "$DIR/Tarballs"
 
 # FIXME: When updating this version to the next release, remove the 'development=false' workaround patch.
 BINUTILS_VERSION="2.46.0"
-BINUTILS_MD5SUM="81bb6810bcd1119819dc0804956e1c92"
+BINUTILS_SHA256="d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2"
 BINUTILS_NAME="binutils-$BINUTILS_VERSION"
 BINUTILS_PKG="${BINUTILS_NAME}.tar.xz"
-BINUTILS_BASE_URL="https://ftpmirror.gnu.org/gnu/binutils"
+BINUTILS_BASE_URL="mirror://gnu/binutils"
 
 # Note: If you bump the gcc version, you also have to update the matching
 #       GCC_VERSION variable in the project's root CMakeLists.txt
 GCC_VERSION="16.2.0"
-GCC_MD5SUM="19b777fb19ea4982731392481306f0d3"
+GCC_SHA256="e6738e29597f733270731aa90600f37ffdc045079dfc27ec7e8192cc81085c3e"
 GCC_NAME="gcc-$GCC_VERSION"
 GCC_PKG="${GCC_NAME}.tar.xz"
-GCC_BASE_URL="https://ftpmirror.gnu.org/gnu/gcc"
+GCC_BASE_URL="mirror://gnu/gcc"
 
 buildstep() {
     NAME=$1
@@ -126,29 +127,8 @@ fi
 
 # === DOWNLOAD AND PATCH ===
 pushd "$DIR/Tarballs"
-    md5=""
-    if [ -e "$BINUTILS_PKG" ]; then
-        md5="$($MD5SUM $BINUTILS_PKG | cut -f1 -d' ')"
-        echo "binutils md5='$md5'"
-    fi
-    if [ "$md5" != ${BINUTILS_MD5SUM} ] ; then
-        rm -f $BINUTILS_PKG
-        curl -LO "$BINUTILS_BASE_URL/$BINUTILS_PKG"
-    else
-        echo "Skipped downloading binutils"
-    fi
-
-    md5=""
-    if [ -e "$GCC_PKG" ]; then
-        md5="$($MD5SUM ${GCC_PKG} | cut -f1 -d' ')"
-        echo "gcc md5='$md5'"
-    fi
-    if [ "$md5" != ${GCC_MD5SUM} ] ; then
-        rm -f $GCC_PKG
-        curl -LO "$GCC_BASE_URL/$GCC_NAME/$GCC_PKG"
-    else
-        echo "Skipped downloading gcc"
-    fi
+    download_file "${BINUTILS_BASE_URL}/${BINUTILS_PKG}" "${BINUTILS_PKG}" "${BINUTILS_SHA256}"
+    download_file "${GCC_BASE_URL}/${GCC_NAME}/${GCC_PKG}" "${GCC_PKG}" "${GCC_SHA256}"
 
     patch_md5="$(${MD5SUM} "${DIR}"/Patches/binutils/*.patch)"
 


### PR DESCRIPTION
First extract the download code from `.port_include.sh` and put it in `Meta`. And then use it inside `BuildGNU.sh`.

This supersedes #27015 by accomplishing the exact same thing but without adding more code.