### PR TITLE
LibC: Make strchr and friends compatible with the C++ standard

### DIFF
--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -409,7 +409,7 @@ char* getenv(char const* name)
 {
     size_t vl = strlen(name);
     for (size_t i = 0; environ[i]; ++i) {
-        char const* decl = environ[i];
+        char* decl = environ[i];
         char* eq = strchr(decl, '=');
         if (!eq)
             continue;

--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#define __STRING_FORCE_C_DECLARATION
+#include <string.h>
+
 #include <AK/Format.h>
 #include <AK/MemMem.h>
 #include <AK/Memory.h>
@@ -17,7 +20,6 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 extern "C" {
 

--- a/Userland/Libraries/LibC/string.h
+++ b/Userland/Libraries/LibC/string.h
@@ -16,6 +16,9 @@
 
 __BEGIN_DECLS
 
+// Let libcxx and libstdc++ know that we provide the C++ version of strchr and friends.
+// Note that libcxx is not consistent between string.h and wchar.h, and it does not
+// require us to define _LIBCPP_STRING_H_HAS_CONST_OVERLOADS here.
 #ifdef __cplusplus
 #    define __CORRECT_ISO_CPP_STRING_H_PROTO
 #endif
@@ -24,6 +27,15 @@ __BEGIN_DECLS
 // `strcasecmp` etcetera to be available as part of a <string.h> include, so let's
 // do the same here to maintain compatibility
 #include <strings.h>
+
+#if defined(__cplusplus) && !defined(__STRING_FORCE_C_DECLARATION)
+#    define __MAKE_C_OR_CPP_DECLARATION(type, name, ...)                    \
+        extern "C++" type const* name(type const*, __VA_ARGS__) asm(#name); \
+        extern "C++" type* name(type*, __VA_ARGS__) asm(#name)
+#else
+#    define __MAKE_C_OR_CPP_DECLARATION(type, name, ...) \
+        type* name(type const*, __VA_ARGS__)
+#endif
 
 size_t strlen(char const*);
 size_t strnlen(char const*, size_t maxlen);
@@ -36,7 +48,7 @@ int timingsafe_memcmp(void const*, void const*, size_t);
 void* memcpy(void*, void const*, size_t);
 void* memccpy(void*, void const*, int, size_t);
 void* memmove(void*, void const*, size_t);
-void* memchr(void const*, int c, size_t);
+__MAKE_C_OR_CPP_DECLARATION(void, memchr, int c, size_t n);
 void* memmem(void const* haystack, size_t, void const* needle, size_t);
 
 void* memset(void*, int, size_t);
@@ -50,11 +62,11 @@ char* stpcpy(char* dest, char const* src);
 char* strncpy(char* dest, char const* src, size_t);
 __attribute__((warn_unused_result)) size_t strlcpy(char* dest, char const* src, size_t);
 
-char* strchr(char const*, int c);
+__MAKE_C_OR_CPP_DECLARATION(char, strchr, int c);
 char* strchrnul(char const*, int c);
-char* strstr(char const* haystack, char const* needle);
+__MAKE_C_OR_CPP_DECLARATION(char, strstr, char const* needle);
 char* strcasestr(char const* haystack, char const* needle);
-char* strrchr(char const*, int c);
+__MAKE_C_OR_CPP_DECLARATION(char, strrchr, int c);
 
 char* index(char const* str, int ch);
 char* rindex(char const* str, int ch);
@@ -67,7 +79,7 @@ size_t strcspn(char const*, char const* reject);
 int strerror_r(int, char*, size_t);
 char* strerror(int errnum);
 char* strsignal(int signum);
-char* strpbrk(char const*, char const* accept);
+__MAKE_C_OR_CPP_DECLARATION(char, strpbrk, char const* accept);
 char* strtok_r(char* str, char const* delim, char** saved_str);
 char* strtok(char* str, char const* delim);
 int strcoll(char const* s1, char const* s2);
@@ -75,3 +87,5 @@ size_t strxfrm(char* dest, char const* src, size_t n);
 char* strsep(char** str, char const* delim);
 
 __END_DECLS
+
+#undef __MAKE_C_OR_CPP_DECLARATION


### PR DESCRIPTION
The C++ standard defines strchr, strrchr, strpbrk, strstr and memchr differently than POSIX. To be conformant, we need to provide a different signature when __cplusplus is defined.

This is the same logic as 73d178af, but applied to string.h.

---

This fixes libcxx's:
std/depr/depr.c.headers/string_h.pass.cpp
std/strings/c.strings/cstring.pass.cpp