### PR TITLE
LibC: Make the NULL macro available in locale.h

### DIFF
--- a/Userland/Libraries/LibC/locale.h
+++ b/Userland/Libraries/LibC/locale.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS


### PR DESCRIPTION
From POSIX:
"The <locale.h> header shall define NULL (as defined in <stddef.h>)"


---

Fixes these libcxx tests:
std/depr/depr.c.headers/locale_h.compile.pass.cpp
std/localization/c.locales/clocale.pass.cpp